### PR TITLE
Fix to be able to Parse BoxMons and Fix for metLocation if Pokémon obtained in a Trade

### DIFF
--- a/modules/Memory.py
+++ b/modules/Memory.py
@@ -449,7 +449,7 @@ def ParsePokemon(b_Pokemon: bytes) -> dict:
             'isBadEgg': flags & 0x1,
             'hasSpecies': (flags >> 0x1) & 0x1,
             'isEgg': (flags >> 0x2) & 0x1,
-            'level': int(b_Pokemon[84]) if len(b_Pokemon) > 80 else False,
+            'level': int(b_Pokemon[84]) if len(b_Pokemon) > 80 else 0,
             'expGroup': exp_groups_list[id - 1],
             'item': {
                 'id': item_id,
@@ -470,7 +470,7 @@ def ParsePokemon(b_Pokemon: bytes) -> dict:
                 'freeze': True if int(struct.unpack('<I', b_Pokemon[80:84])[0]) & (1 << 5) else False,
                 'paralysis': True if int(struct.unpack('<I', b_Pokemon[80:84])[0]) & (1 << 6) else False,
                 'badPoison': True if int(struct.unpack('<I', b_Pokemon[80:84])[0]) & (1 << 7) else False
-            } if len(b_Pokemon) > 80 else False,
+            } if len(b_Pokemon) > 80 else None,
             'stats': {
                 'hp': int(b_Pokemon[86]),
                 'maxHP': int(b_Pokemon[88]),
@@ -479,7 +479,7 @@ def ParsePokemon(b_Pokemon: bytes) -> dict:
                 'speed': int(b_Pokemon[94]),
                 'spAttack': int(b_Pokemon[96]),
                 'spDefense': int(b_Pokemon[98])
-            } if len(b_Pokemon) > 80 else False,
+            } if len(b_Pokemon) > 80 else None,
 
             # Substruct G - Growth
             'experience': int(struct.unpack('<I', sections['G'][4:8])[0]),
@@ -517,7 +517,7 @@ def ParsePokemon(b_Pokemon: bytes) -> dict:
                 'days': int(sections['M'][0]) & 0xF,
                 'strain': int(sections['M'][0]) >> 0x4,
             },
-            'metLocation': location_list[met_location] if met_location < len(location_list) else "obtained in a trade",
+            'metLocation': location_list[met_location] if met_location < len(location_list) else 'Traded',
             'origins': {
                 'metLevel': int(struct.unpack('<H', sections['M'][2:4])[0]) & 0x7F,
                 'hatched': False if int(struct.unpack('<H', sections['M'][2:4])[0]) & 0x7F else True,

--- a/modules/Memory.py
+++ b/modules/Memory.py
@@ -430,6 +430,7 @@ def ParsePokemon(b_Pokemon: bytes) -> dict:
         item_id = int(struct.unpack('<H', sections['G'][2:4])[0])
         shiny_value = int(tid ^ sid ^ struct.unpack('<H', b_Pokemon[0:2])[0] ^ struct.unpack('<H', b_Pokemon[2:4])[0])
         shiny = True if shiny_value < 8 else False
+        met_location = int(sections['M'][1])
 
         pokemon = {
             'name': name,
@@ -448,7 +449,7 @@ def ParsePokemon(b_Pokemon: bytes) -> dict:
             'isBadEgg': flags & 0x1,
             'hasSpecies': (flags >> 0x1) & 0x1,
             'isEgg': (flags >> 0x2) & 0x1,
-            'level': int(b_Pokemon[84]),
+            'level': int(b_Pokemon[84]) if len(b_Pokemon) > 80 else False,
             'expGroup': exp_groups_list[id - 1],
             'item': {
                 'id': item_id,
@@ -469,7 +470,7 @@ def ParsePokemon(b_Pokemon: bytes) -> dict:
                 'freeze': True if int(struct.unpack('<I', b_Pokemon[80:84])[0]) & (1 << 5) else False,
                 'paralysis': True if int(struct.unpack('<I', b_Pokemon[80:84])[0]) & (1 << 6) else False,
                 'badPoison': True if int(struct.unpack('<I', b_Pokemon[80:84])[0]) & (1 << 7) else False
-            },
+            } if len(b_Pokemon) > 80 else False,
             'stats': {
                 'hp': int(b_Pokemon[86]),
                 'maxHP': int(b_Pokemon[88]),
@@ -478,7 +479,7 @@ def ParsePokemon(b_Pokemon: bytes) -> dict:
                 'speed': int(b_Pokemon[94]),
                 'spAttack': int(b_Pokemon[96]),
                 'spDefense': int(b_Pokemon[98])
-            },
+            } if len(b_Pokemon) > 80 else False,
 
             # Substruct G - Growth
             'experience': int(struct.unpack('<I', sections['G'][4:8])[0]),
@@ -516,7 +517,7 @@ def ParsePokemon(b_Pokemon: bytes) -> dict:
                 'days': int(sections['M'][0]) & 0xF,
                 'strain': int(sections['M'][0]) >> 0x4,
             },
-            'metLocation': location_list[int(sections['M'][1])],
+            'metLocation': location_list[met_location] if met_location < len(location_list) else "obtained in a trade",
             'origins': {
                 'metLevel': int(struct.unpack('<H', sections['M'][2:4])[0]) & 0x7F,
                 'hatched': False if int(struct.unpack('<H', sections['M'][2:4])[0]) & 0x7F else True,

--- a/modules/Memory.py
+++ b/modules/Memory.py
@@ -429,7 +429,6 @@ def ParsePokemon(b_Pokemon: bytes) -> dict:
         }
         item_id = int(struct.unpack('<H', sections['G'][2:4])[0])
         shiny_value = int(tid ^ sid ^ struct.unpack('<H', b_Pokemon[0:2])[0] ^ struct.unpack('<H', b_Pokemon[2:4])[0])
-        shiny = True if shiny_value < 8 else False
         met_location = int(sections['M'][1])
 
         pokemon = {
@@ -441,7 +440,7 @@ def ParsePokemon(b_Pokemon: bytes) -> dict:
             'nature': natures_list[pid % 0x19],
             'language': Language(int(b_Pokemon[18])),
             'shinyValue': shiny_value,
-            'shiny': shiny,
+            'shiny': True if shiny_value < 8 else False,
             'ot': {
                 'tid': tid,
                 'sid': sid


### PR DESCRIPTION
Box mons are 20 bytes shorter then Full Pokémon
these get recalculated when pulled out of the PC

for now the values are just set to `False` 

commit also fixes `metLocation` for Pokémon obtained in a Trade. These on my save had a `sections['M'][1]` = 254

missing stats are:
- u32 status;
- u8 level;
- u8 mail;
- u16 hp;
- u16 maxHP;
- u16 attack;
- u16 defense;
- u16 speed;
- u16 spAttack;
- u16 spDefense;