### PR TITLE
Update Reverse lookup with language patches

### DIFF
--- a/modules/Game.py
+++ b/modules/Game.py
@@ -37,6 +37,10 @@ def _LoadSymbols(symbols_file: str, language: ROMLanguage) -> None:
                     int(language_patches[item][language_code], 16),
                     _symbols[item.upper()][1]
                 )
+                _reverse_symbols[int(language_patches[item][language_code], 16)] = (
+                    item.upper(),
+                    _symbols[item.upper()][1]
+                )
 
 
 def _LoadCharmap(charmap_index: str) -> None:


### PR DESCRIPTION
Add the language patches on top of the reverse lookup table.

this should bring back all the previous working languages for Emerald