### PR TITLE
Debian Bookworm support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,8 +33,7 @@ The bot can run on Windows, Ubuntu 23.04, and Debian 12 (support for Mac and oth
 ### Requirements
 - [Python 3.11](https://www.python.org/downloads/release/python-3110/)
 - Double click `requirements.py` or run `python requirements.py` in a terminal to install Python modules and [libmgba](https://github.com/hanzi/libmgba-py)
-  - (**Ubuntu Linux 23.04** only) `sudo apt install libmgba portaudio19-dev`
-  - (**Debian 12** only) `sudo apt install libmgba0.10 portaudio19-dev`
+  - (**Ubuntu Linux 23.04** and **Debian 12** only) `sudo apt install libmgba portaudio19-dev`
 - Place some Pokémon .gba ROMs into the `roms/` folder
 
 ### Optional

--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ The bot can run on Windows, Ubuntu 23.04, and Debian 12 (support for Mac and oth
 ### Requirements
 - [Python 3.11](https://www.python.org/downloads/release/python-3110/)
 - Double click `requirements.py` or run `python requirements.py` in a terminal to install Python modules and [libmgba](https://github.com/hanzi/libmgba-py)
-  - (**Ubuntu Linux 23.04** and **Debian 12** only) `sudo apt install libmgba portaudio19-dev`
+  - (**Ubuntu Linux 23.04** and **Debian 12** only) `sudo apt install libmgba0.10 portaudio19-dev`
 - Place some Pokémon .gba ROMs into the `roms/` folder
 
 ### Optional

--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ The bot can run on Windows, Ubuntu 23.04, and Debian 12 (support for Mac and oth
 ### Requirements
 - [Python 3.11](https://www.python.org/downloads/release/python-3110/)
 - Double click `requirements.py` or run `python requirements.py` in a terminal to install Python modules and [libmgba](https://github.com/hanzi/libmgba-py)
-  - (**Ubuntu Linux 23.04** and **Debian 12** only) `sudo apt install libmgba0.10 portaudio19-dev`
+  - **Ubuntu Linux 23.04** and **Debian 12** only: Install the following packages: `sudo apt install python3-tk libmgba0.10 portaudio19-dev`
 - Place some Pokémon .gba ROMs into the `roms/` folder
 
 ### Optional

--- a/Readme.md
+++ b/Readme.md
@@ -28,12 +28,13 @@ The bot is frame perfect and can cheat by reading data from any point in memory.
 ***
 
 # 🔒 Prerequisites
-The bot can run on Windows or Ubuntu Linux 23.04 (support for Mac and other Linux distributions **_may_** be added later.)
+The bot can run on Windows, Ubuntu 23.04, and Debian 12 (support for Mac and other Linux distributions **_may_** be added later).
 
 ### Requirements
 - [Python 3.11](https://www.python.org/downloads/release/python-3110/)
 - Double click `requirements.py` or run `python requirements.py` in a terminal to install Python modules and [libmgba](https://github.com/hanzi/libmgba-py)
-  - **(Ubuntu Linux 23.04** only) `sudo apt install libmgba portaudio19-dev`
+  - (**Ubuntu Linux 23.04** only) `sudo apt install libmgba portaudio19-dev`
+  - (**Debian 12** only) `sudo apt install libmgba0.10 portaudio19-dev`
 - Place some Pokémon .gba ROMs into the `roms/` folder
 
 ### Optional
@@ -100,7 +101,7 @@ The bot will mash random directions to spin on a single tile.
 <details>
 <summary>✅🟨❌ Click here for support information</summary>
 
-|          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen | 
+|          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:----:|:--------:|:-------:|:-------:|:---------:|
 | English  |  ✅   |    ✅     |    ✅    |    ✅    |     ✅     |
 | Japanese |  -   |    -     |    -    |    -    |     -     |
@@ -141,7 +142,7 @@ For modes that use soft resets such as starters, the bot attempts to hit a uniqu
 <details>
 <summary>✅🟨❌ Click here for support information</summary>
 
-|          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen | 
+|          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ✅    |      ✅      |     ✅      |     ✅      |      ✅       |
 | Japanese |    -    |      -      |     -      |     -      |      -       |
@@ -308,17 +309,17 @@ Each webhook type also supports pinging @users or @roles.
 `ping_mode` - set to `user` or `role`
 - Leave blank to disable pings
 
-`ping_id` - set to user/role ID 
+`ping_id` - set to user/role ID
 - **Settings** > **Advanced** > Enable **Developer Mode** to enable Discord developer mode
 - Right click **user/role** > **Copy ID**
 
 #### Webhook types
 `shiny_pokemon_encounter` - Shiny Pokémon encounters
- 
+
 ![Discord_c0jrjiKGRE](https://github.com/40Cakes/pokebot-gen3/assets/16377135/e1706b41-5f89-40b4-918d-30d6e8fa92c2)
 
 `pokemon_encounter_milestones` - Pokémon encounter milestones messages every `interval` encounters
- 
+
 ![Discord_ObO28tVrPk](https://github.com/40Cakes/pokebot-gen3/assets/16377135/5c4698f0-07cf-4289-aa4e-6398f56422e0)
 
 `shiny_pokemon_encounter_milestones` - Shiny Pokémon encounter milestones every `interval` encounters
@@ -386,7 +387,7 @@ RNG manipulation options may be added to the bot in the future, all cheats are d
 
 ### OBS
 #### OBS WebSocket Server Settings
-The `obs_websocket` config will allow the bot to send commands to OBS via WebSockets, 
+The `obs_websocket` config will allow the bot to send commands to OBS via WebSockets,
 see [here](https://github.com/obsproject/obs-websocket) for more information on OBS WebSockets.
 
 Enable WebSockets in **OBS** > **Tools** > **Websocket Server Settings** > **Enable WebSocket Server**
@@ -404,12 +405,12 @@ Enable WebSockets in **OBS** > **Tools** > **Websocket Server Settings** > **Ena
 
 `screenshot` - take OBS screenshot of shiny encounter
 - **Note**: **OBS** > **Settings** > **Hotkeys** > **Screenshot Output** must be set to **Ctrl + F11**
-- The bot does **not** emulate keystrokes, it simply sends a `TriggerHotkeyByKeySequence` (**Ctrl + F11**) WebSocket command 
+- The bot does **not** emulate keystrokes, it simply sends a `TriggerHotkeyByKeySequence` (**Ctrl + F11**) WebSocket command
 - Screenshot is taken after `shiny_delay` to allow stream overlays to update
 
 `replay_buffer` - save OBS replay buffer after `replay_buffer_delay`
 - **Note**: **OBS** > **Settings** > **Hotkeys** > **Replay Buffer** > **Save Replay** must set to **Ctrl + F12**
-- The bot does **not** emulate keystrokes, it simply sends a `TriggerHotkeyByKeySequence` (**Ctrl + F12**) WebSocket command 
+- The bot does **not** emulate keystrokes, it simply sends a `TriggerHotkeyByKeySequence` (**Ctrl + F12**) WebSocket command
 
 `replay_buffer_delay` - delay saving OBS replay buffer by `n` frames
 - Runs in a separate thread and will not pause main bot thread

--- a/Readme.md
+++ b/Readme.md
@@ -28,12 +28,16 @@ The bot is frame perfect and can cheat by reading data from any point in memory.
 ***
 
 # 🔒 Prerequisites
-The bot can run on Windows, Ubuntu 23.04, and Debian 12 (support for Mac and other Linux distributions **_may_** be added later).
+### Operating Systems
+
+- Windows (**64-bit**)
+- Linux (**64-bit**)
+  - Note: only tested and confirmed working on **Ubuntu 23.04** and **Debian 12**
 
 ### Requirements
 - [Python 3.11](https://www.python.org/downloads/release/python-3110/)
 - Double click `requirements.py` or run `python requirements.py` in a terminal to install Python modules and [libmgba](https://github.com/hanzi/libmgba-py)
-  - **Ubuntu Linux 23.04** and **Debian 12** only: Install the following packages: `sudo apt install python3-tk libmgba0.10 portaudio19-dev`
+  - **Linux** only: Install the following packages with `apt` or appropriate package manager: `sudo apt install python3-tk libmgba0.10 portaudio19-dev`
 - Place some Pokémon .gba ROMs into the `roms/` folder
 
 ### Optional

--- a/requirements.py
+++ b/requirements.py
@@ -23,15 +23,19 @@ try:
 
         case 'Linux':
             linux_release = platform.freedesktop_os_release()
-            if linux_release['ID'] != 'ubuntu' or linux_release['VERSION_ID'] != '23.04':
-                raise Exception('Currently, only Ubuntu 23.04 is supported by this bot. '
-                                f'You are running {linux_release["PRETTY_NAME"]}...')
+            if linux_release['ID'] == 'ubuntu' and linux_release['VERSION_ID'] == '23.04':
+                print("You are running Ubuntu 23.04.")
+            elif linux_release['ID'] == 'debian' and linux_release['VERSION_ID'] == '12':
+                print("You are running Debian 12.")
+            else:
+                raise Exception('Currently, only Ubuntu 23.04 and Debian 12 are supported by this bot. '
+                                f'You are running {linux_release["PRETTY_NAME"]}.')
 
             libmgba_url = f'https://github.com/hanzi/libmgba-py/releases/download/{libmgba_tag}/'\
                           f'libmgba-py_{libmgba_ver}_ubuntu-lunar.zip'
 
         case _:
-            raise Exception(f'Currently, only Windows and Ubuntu 23.04 are supported by this bot. '
+            raise Exception(f'Currently, only Windows, Ubuntu 23.04, and Debian 12 are supported by this bot. '
                             'You are running {platform.system()}!')
 
     if platform.architecture()[0] != '64bit':

--- a/requirements.py
+++ b/requirements.py
@@ -5,50 +5,57 @@ import subprocess
 import sys
 import zipfile
 
-libmgba_tag = '0.2.0-2'
-libmgba_ver = '0.2.0'
+libmgba_tag = "0.2.0-2"
+libmgba_ver = "0.2.0"
 
 try:
-    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-r', './requirements.txt'])
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "./requirements.txt"])
 
     match platform.system():
-        case 'Windows':
+        case "Windows":
             import os
             import atexit
             import psutil
 
-            atexit.register(lambda: psutil.Process(os.getppid()).name() == 'py.exe' and input('Press enter to exit...'))
-            libmgba_url = f'https://github.com/hanzi/libmgba-py/releases/download/{libmgba_tag}/'\
-                          f'libmgba-py_{libmgba_ver}_win64.zip'
+            atexit.register(lambda: psutil.Process(os.getppid()).name() == "py.exe" and input("Press enter to exit..."))
+            libmgba_url = (
+                f"https://github.com/hanzi/libmgba-py/releases/download/{libmgba_tag}/"
+                f"libmgba-py_{libmgba_ver}_win64.zip"
+            )
 
-        case 'Linux':
+        case "Linux":
             linux_release = platform.freedesktop_os_release()
-            if linux_release['ID'] == 'ubuntu' and linux_release['VERSION_ID'] == '23.04':
-                print("You are running Ubuntu 23.04.")
-            elif linux_release['ID'] == 'debian' and linux_release['VERSION_ID'] == '12':
-                print("You are running Debian 12.")
-            else:
-                raise Exception('Currently, only Ubuntu 23.04 and Debian 12 are supported by this bot. '
-                                f'You are running {linux_release["PRETTY_NAME"]}.')
-
-            libmgba_url = f'https://github.com/hanzi/libmgba-py/releases/download/{libmgba_tag}/'\
-                          f'libmgba-py_{libmgba_ver}_ubuntu-lunar.zip'
+            if not (linux_release["ID"] == "ubuntu" and linux_release["VERSION_ID"] == "23.04") or not (
+                linux_release["ID"] == "debian" and linux_release["VERSION_ID"] == "12"
+            ):
+                print(
+                    f'You are running an untested version of Linux ({linux_release["PRETTY_NAME"]}). '
+                    "Currently, only Ubuntu 23.04 and Debian 12 have been tested and confirmed working."
+                )
+                input("Press enter to install libmgba anyway...")
+            libmgba_url = (
+                f"https://github.com/hanzi/libmgba-py/releases/download/{libmgba_tag}/"
+                f"libmgba-py_{libmgba_ver}_ubuntu-lunar.zip"
+            )
 
         case _:
-            raise Exception(f'Currently, only Windows, Ubuntu 23.04, and Debian 12 are supported by this bot. '
-                            'You are running {platform.system()}!')
+            raise Exception(f"{platform.system()} is unsupported, currently, only Windows and Linux are supported.")
 
-    if platform.architecture()[0] != '64bit':
-        raise Exception('Only 64-bit systems are supported by this bot!')
+    if platform.architecture()[0] != "64bit":
+        raise Exception(
+            f"{platform.architecture()[0]} architecture is currently unsupported, "
+            "only 64-bit architecture is supported by this bot!"
+        )
 
     this_directory = pathlib.Path(__file__).parent
-    libmgba_directory = this_directory / 'mgba'
+    libmgba_directory = this_directory / "mgba"
     if not libmgba_directory.exists():
-        print(f'Downloading libmgba from `{libmgba_url}`...')
+        print(f"Downloading libmgba from `{libmgba_url}`...")
         import requests
+
         response = requests.get(libmgba_url)
         if response.status_code == 200:
-            print('Unzipping libmgba into `./mgba`...')
+            print("Unzipping libmgba into `./mgba`...")
             with zipfile.ZipFile(io.BytesIO(response.content)) as zip_handle:
                 zip_handle.extractall(this_directory)
 


### PR DESCRIPTION
This PR adds preliminary support for Debian 12, as the bot otherwise has no issues running on it. It can probably also run well on Debian 11, and perhaps earlier versions, but I haven't tested this, and I didn't want to tamper with the current hardcoded approach.

It also updates Readme.md to add information on this support, as well as add a package requirement (`python3-tk`). I squeezed some grammar fixes in that area of the readme as well.