### PR TITLE
force profile yml to UTF-8

### DIFF
--- a/modules/Profiles.py
+++ b/modules/Profiles.py
@@ -123,7 +123,9 @@ def CreateProfile(name: str, rom: ROM) -> Profile:
         raise RuntimeError(f'There already is a profile called "{name}", cannot create a new one with that name.')
 
     profile_directory.mkdir()
-    YAML().dump({
+    yaml = YAML()
+    yaml.allow_unicode = False
+    yaml.dump({
         'version': 1,
         'rom': {
             'file_name': rom.file.name,


### PR DESCRIPTION
this forces the creation of the Profile .yml to not switch the file format to ANSI when encountering a unicode character.
because apparently it can write them but cant read them.

Steps to verify:
1. have only one rom and name it "Pokémon Emerald Version.gba"
2. Create a profile with that rom
3. try to start the bot again

Without this the resulting metadata.yml will be ANSI Encoded and the profile selection wont open.

With this the rom name will be escaped as "Pok\xE9mon Emerald Version.gba" in the metadata.yml, the file will still be UTF-8 Encoded and the bot will start up to the Profile selection.

