### PR TITLE
Fix Linux distro detection logic

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -55,7 +55,7 @@ try:
 
         case "Linux":
             linux_release = platform.freedesktop_os_release()
-            if not (linux_release["ID"] == "ubuntu" and linux_release["VERSION_ID"] == "23.04") or not (
+            if not (linux_release["ID"] == "ubuntu" and linux_release["VERSION_ID"] == "23.04") and not (
                 linux_release["ID"] == "debian" and linux_release["VERSION_ID"] == "12"
             ):
                 print(

--- a/requirements.py
+++ b/requirements.py
@@ -55,12 +55,11 @@ try:
 
         case "Linux":
             linux_release = platform.freedesktop_os_release()
-            if not (linux_release["ID"] == "ubuntu" and linux_release["VERSION_ID"] == "23.04") and not (
-                linux_release["ID"] == "debian" and linux_release["VERSION_ID"] == "12"
-            ):
+            supported_linux_releases = [("ubuntu", "23.04"), ("debian", "12")]
+            if (linux_release["ID"], linux_release["VERSION_ID"]) not in supported_linux_releases:
                 print(
                     f'You are running an untested version of Linux ({linux_release["PRETTY_NAME"]}). '
-                    "Currently, only Ubuntu 23.04 and Debian 12 have been tested and confirmed working."
+                    f"Currently, only {supported_linux_releases} have been tested and confirmed working."
                 )
                 input("Press enter to install libmgba anyway...")
             libmgba_url = (


### PR DESCRIPTION
With the previous logic, if the user was not running Ubuntu 23.04, `requirements.py` would complain, regardless of whether the user was running Debian 12 or not.

Now, using an `and` instead of an `or`, it checks properly for both cases and alerts if neither are true.