### PR TITLE
Support creating a screenshot when video is disabled, and simplify save state API a bit

### DIFF
--- a/modules/Gui.py
+++ b/modules/Gui.py
@@ -497,7 +497,7 @@ class PokebotGui:
                     case 'reset':
                         emulator.Reset()
                     case 'save_state':
-                        emulator.CreateSaveState()
+                        emulator.CreateSaveState('manual')
                     case 'toggle_stepping_mode':
                         self.ToggleSteppingMode()
                     case 'zoom_in':

--- a/modules/Stats.py
+++ b/modules/Stats.py
@@ -650,8 +650,8 @@ def EncounterPokemon(pokemon: dict) -> NoReturn:
         if not custom_found and pokemon['name'] in block_list:
             console.print('[bold yellow]' + pokemon['name'] + ' is on the catch block list, skipping encounter...')
         else:
-            state_filename = f"{time.strftime('%Y-%m-%d_%H-%M-%S')}_{state_tag}_{pokemon['name']}"
-            state_filename = ''.join(c for c in state_filename if c in dirsafe_chars)
-            emulator.CreateSaveState(state_filename)
+            filename_suffix = f"{state_tag}_{pokemon['name']}"
+            filename_suffix = ''.join(c for c in filename_suffix if c in dirsafe_chars)
+            emulator.CreateSaveState(suffix=filename_suffix)
 
             ForceManualMode()

--- a/modules/Stats.py
+++ b/modules/Stats.py
@@ -16,7 +16,7 @@ from modules.Colours import IVColour, IVSumColour, SVColour
 from modules.Config import config, ForceManualMode
 from modules.Console import console
 from modules.Files import BackupFolder, ReadFile, WriteFile
-from modules.Gui import SetMessage, emulator
+from modules.Gui import SetMessage, GetEmulator
 from modules.Inputs import PressButton, WaitFrames
 from modules.Memory import GetGameState, GameState
 from modules.Profiles import Profile
@@ -652,6 +652,6 @@ def EncounterPokemon(pokemon: dict) -> NoReturn:
         else:
             filename_suffix = f"{state_tag}_{pokemon['name']}"
             filename_suffix = ''.join(c for c in filename_suffix if c in dirsafe_chars)
-            emulator.CreateSaveState(suffix=filename_suffix)
+            GetEmulator().CreateSaveState(suffix=filename_suffix)
 
             ForceManualMode()


### PR DESCRIPTION
Until now, creating a screenshot was only possible when video was on.

While this is not a problem right now (nothing is using that function anyway), it might become limiting in the future.   
For example, mGBA supports save states to contain screenshots/thumbnails for easier selection, which I'd like to support eventually.

Hence this workaround. I've also updated the `CreateSaveState()` function to accept a suffix instead of the entire filename, to match the screenshot function.