### PR TITLE
Do not advance a frame if GetParty ran into an error

### DIFF
--- a/modules/LibmgbaEmulator.py
+++ b/modules/LibmgbaEmulator.py
@@ -431,6 +431,25 @@ class LibmgbaEmulator:
         with open(png_path, 'wb') as file:
             self.GetScreenshot().save(file, format='PNG')
 
+    def PeekFrame(self, callback: callable, frames_to_advance: int = 1) -> any:
+        """
+        Runs the emulation for a number of frames and then runs {callback()}, after which it restores
+        the original emulator state.
+
+        This can be used to check the emulator state in a given number of frames without actually
+        advancing the emulation.
+
+        :param callback: A function to run after the emulation has progressed
+        :param frames_to_advance: Optional number of frames to advance (defaults to 1)
+        :return: The return value of the callback function
+        """
+        original_emulator_state = self.GetSaveState()
+        for i in range(frames_to_advance):
+            self._core.run_frame()
+        result = callback()
+        self.LoadSaveState(original_emulator_state)
+        return result
+
     def RunSingleFrame(self) -> None:
         """
         Runs the emulation for a single frame, and then waits if necessary to hit the target FPS rate.

--- a/modules/Pokemon.py
+++ b/modules/Pokemon.py
@@ -276,19 +276,15 @@ def GetOpponent() -> dict:
 
     :return: opponent (dict)
     """
-    try:
-        while True:
-            mon = ParsePokemon(ReadSymbol('gEnemyParty')[:100])
-            if not mon:
-                console.print('[red]Pokémon has invalid checksum! Waiting 1 frame and checking again...')
-                WaitFrames(1)
-                continue
-            else:
-                return mon
-    except SystemExit:
-        raise
-    except:
-        console.print_exception(show_locals=True)
+    mon = ParsePokemon(ReadSymbol('gEnemyParty')[:100])
+
+    # See comment in `GetParty()`
+    if mon is None:
+        mon = GetEmulator().PeekFrame(lambda: ParsePokemon(ReadSymbol('gEnemyParty')[:100]))
+        if mon is None:
+            raise RuntimeError(f'Opponent Pokemon was invalid for two frames in a row.')
+
+    return mon
 
 
 last_opid = b'\x00\x00\x00\x00' # ReadSymbol('gEnemyParty', size=4)

--- a/modules/modes/frlg/Starters.py
+++ b/modules/modes/frlg/Starters.py
@@ -47,7 +47,7 @@ def Starters() -> NoReturn:
             PressButton(['B'])
 
         if config['cheats']['starters']:
-            while GetParty() == {}:
+            while not GetParty():
                 PressButton(['B'])
         else:
             while GetTrainer()['facing'] != 'Down':

--- a/modules/modes/rse/Starters.py
+++ b/modules/modes/rse/Starters.py
@@ -59,7 +59,7 @@ def Starters() -> NoReturn:
                     rng = int(struct.unpack('<I', ReadSymbol('gRngValue', size=4))[0])
 
             if config['cheats']['starters']:
-                while GetParty() == {}:
+                while not GetParty():
                     PressButton(['A'])
             else:
                 while GetGameState() != GameState.BATTLE:


### PR DESCRIPTION
This introduces the `PeekFrame()` method for the emulator, which allows accessing a future frame's memory without actually progressing the emulation.

The `GetParty()` function sometimes gets corrupt memory, presumably because on occasion the `gPlayerParty` memory is being written to while we are trying to read it -- after all, the game is not obligated to idle at the exact moment a frame is completed.

Currently, the solution for that is to just advance a frame and try again, which seems to work in all cases. Unfortunately that also means that the code that calls `GetParty()` sort of misses a frame. (In theory it could miss up to 6 frames, once per party Pokemon, but I've never seen more than 1 frame skip.)

Which is why I've implemented aforementioned method. It works by progressing the emulation, reading the memory, and then reloading a save state taken at the start.

---

The previous implementation also did not actually _return_ the invalid Pokemon after retrying. It would just include a `None` in the results. I'm not sure if that was intentional, but it seemed counterintuitive so I changed it here as well.

Also, I changed the return type to be a `list` rather than a numerically indexed `dict`. I don't think there's any downside to this as there is no valid in-game reason why a party slot somewhere in between should be empty.