### PR TITLE
Debug fixes: Support 1× scale, and avoid Daycare tab crashing on reset

### DIFF
--- a/modules/Daycare.py
+++ b/modules/Daycare.py
@@ -123,8 +123,10 @@ class DaycareData:
     compatibility: tuple[DaycareCompatibility, str]
 
 
-def GetDaycareData():
+def GetDaycareData() -> Union[DaycareData, None]:
     data = GetSaveBlock(1, 0x3030, 0x120)
+    if data is None:
+        return None
 
     pokemon1 = ParsePokemon(data[0x00:0x50])
     pokemon2 = ParsePokemon(data[0x8C:0xDC])

--- a/modules/Gui.py
+++ b/modules/Gui.py
@@ -739,7 +739,8 @@ class PokebotGui:
 
     def UpdateWindow(self):
         from modules.Stats import GetEncounterRate
-        self.controls.OnFrameRender()
+        if self.scale > 1:
+            self.controls.OnFrameRender()
 
         current_fps = emulator.GetCurrentFPS()
         current_load = emulator.GetCurrentTimeSpentInBotFraction()

--- a/modules/GuiDebug.py
+++ b/modules/GuiDebug.py
@@ -416,6 +416,8 @@ class DaycareTab(DebugTab):
 
     def _GetData(self):
         data = GetDaycareData()
+        if data is None:
+            return {}
 
         pokemon1 = 'n/a'
         if data.pokemon1 is not None:


### PR DESCRIPTION
When scaling to 1× (original GBA resolution), I am disabling all emulator controls as there's simply not enough space. This crashed the debug views though because they still tried to update.

Also, when you had the Daycare tab open and reset the emulator, that would crash because no trainer data was available.