### PR TITLE
Fix debug tabs in non-Emerald games

### DIFF
--- a/modules/Daycare.py
+++ b/modules/Daycare.py
@@ -1,4 +1,3 @@
-import struct
 from dataclasses import dataclass
 from enum import IntEnum
 from typing import Union
@@ -131,17 +130,24 @@ def GetDaycareData() -> Union[DaycareData, None]:
     pokemon1 = ParsePokemon(data[0x00:0x50])
     pokemon2 = ParsePokemon(data[0x8C:0xDC])
 
-    egg_groups1 = pokemon_list[pokemon1['name']]['egg_groups']
-    egg_groups2 = pokemon_list[pokemon2['name']]['egg_groups']
+    if pokemon1 is None:
+        egg_groups1 = []
+    else:
+        egg_groups1 = pokemon_list[pokemon1['name']]['egg_groups']
+
+    if pokemon2 is None:
+        egg_groups2 = []
+    else:
+        egg_groups2 = pokemon_list[pokemon2['name']]['egg_groups']
 
     return DaycareData(
         pokemon1=pokemon1,
         pokemon1_egg_groups=egg_groups1,
-        pokemon1_steps=struct.unpack('<I', data[0x88:0x8C])[0],
+        pokemon1_steps=int.from_bytes(data[0x88:0x8C], byteorder='little'),
         pokemon2=pokemon2,
         pokemon2_egg_groups=egg_groups2,
-        pokemon2_steps=struct.unpack('<I', data[0x114:0x118])[0],
-        offspring_personality=struct.unpack('<I', data[0x118:0x11C])[0],
+        pokemon2_steps=int.from_bytes(data[0x114:0x118], byteorder='little'),
+        offspring_personality=int.from_bytes(data[0x118:0x11C], byteorder='little'),
         step_counter=int(data[0x11C]),
         compatibility=DaycareCompatibility.CalculateFor(pokemon1, pokemon2)
     )

--- a/modules/GuiDebug.py
+++ b/modules/GuiDebug.py
@@ -324,9 +324,19 @@ class SymbolsTab(DebugTab):
         data = {}
 
         for symbol in self.SYMBOLS_TO_DISPLAY:
-            value = ReadSymbol(symbol.upper())
+            try:
+                address, length = GetSymbol(symbol.upper())
+            except RuntimeError:
+                self.SYMBOLS_TO_DISPLAY.remove(symbol)
+                self.DISPLAY_AS_STRING.remove(symbol)
+                break
+
+            value = emulator.ReadBytes(address, length)
             if symbol in self.DISPLAY_AS_STRING:
                 data[symbol] = DecodeString(value)
+            elif length == 4 or length == 2:
+                n = int.from_bytes(value, byteorder='little')
+                data[symbol] = f"{value.hex(' ', 1)} ({n})"
             else:
                 data[symbol] = value.hex(' ', 1)
 
@@ -425,7 +435,7 @@ class DaycareTab(DebugTab):
                 gender = ''
 
             pokemon1 = {
-                '__value': f"{data.pokemon2['name']}{gender}; {data.pokemon1_steps:,} steps",
+                '__value': f"{data.pokemon1['name']}{gender}; {data.pokemon1_steps:,} steps",
                 'pokemon': data.pokemon1,
                 'steps': data.pokemon1_steps,
                 'egg_groups': ', '.join(set(data.pokemon1_egg_groups))


### PR DESCRIPTION
The Symbols tab was crashing on (at least) Ruby/Sapphire because one of the default symbols (`sChat`) does not exist in their symbols table.

I fixed that by automatically removing any symbol that could not be found, rather than throwing an Exception.

Also, the Daycare tab broke on Ruby because the case where `ParsePokemon()` returns `None` was not handled correctly.