### PR TITLE
Recreate Placeholder on resizing

### DIFF
--- a/modules/Gui.py
+++ b/modules/Gui.py
@@ -435,22 +435,25 @@ class PokebotGui:
         emulator.SetVideoEnabled(not emulator.GetVideoEnabled())
         self.controls.Update()
         if not emulator.GetVideoEnabled():
-            # Create a fancy placeholder image.
-            placeholder = PIL.Image.new(mode='RGBA', size=(self.width * self.scale, self.height * self.scale))
-            draw = PIL.ImageDraw.Draw(placeholder)
+            self.SetPlaceholderImage()
 
-            # Black background
-            draw.rectangle(xy=[(0, 0), (placeholder.width, placeholder.height)], fill='#000000FF')
+    def SetPlaceholderImage(self) -> None:
+        # Create a fancy placeholder image.
+        placeholder = PIL.Image.new(mode='RGBA', size=(self.width * self.scale, self.height * self.scale))
+        draw = PIL.ImageDraw.Draw(placeholder)
 
-            # Paste a random sprite on top
-            sprite = PIL.Image.open(self.ChooseRandomSprite())
-            if sprite.mode != 'RGBA':
-                sprite = sprite.convert('RGBA')
-            sprite_position = (placeholder.width // 2 - sprite.width // 2, placeholder.height // 2 - sprite.height // 2)
-            placeholder.paste(sprite, sprite_position, sprite)
+        # Black background
+        draw.rectangle(xy=[(0, 0), (placeholder.width, placeholder.height)], fill='#000000FF')
 
-            self.canvas_current_image = PIL.ImageTk.PhotoImage(placeholder)
-            self.canvas.create_image(self.center_of_canvas, image=self.canvas_current_image, state='normal')
+        # Paste a random sprite on top
+        sprite = PIL.Image.open(self.ChooseRandomSprite())
+        if sprite.mode != 'RGBA':
+            sprite = sprite.convert('RGBA')
+        sprite_position = (placeholder.width // 2 - sprite.width // 2, placeholder.height // 2 - sprite.height // 2)
+        placeholder.paste(sprite, sprite_position, sprite)
+
+        self.canvas_current_image = PIL.ImageTk.PhotoImage(placeholder)
+        self.canvas.create_image(self.center_of_canvas, image=self.canvas_current_image, state='normal')
 
     def SetBotMode(self, new_bot_mode: str) -> None:
         SetBotMode(new_bot_mode)
@@ -494,8 +497,10 @@ class PokebotGui:
                         self.ToggleSteppingMode()
                     case 'zoom_in':
                         self.SetScale(min(5, self.scale + 1))
+                        self.SetPlaceholderImage()
                     case 'zoom_out':
                         self.SetScale(max(1, self.scale - 1))
+                        self.SetPlaceholderImage()
                     case 'toggle_manual':
                         ToggleManualMode()
                         console.print(f'Now in [cyan]{config["general"]["bot_mode"]}[/] mode')


### PR DESCRIPTION
Recreates the placeholder image when Resizing the window via the assigned shortcuts.

Currently behaviour:

https://github.com/40Cakes/pokebot-gen3/assets/35451366/ebd325e3-3b8a-4434-ad47-a15b38e41baf

New Behaviour:

https://github.com/40Cakes/pokebot-gen3/assets/35451366/7734731a-006f-4813-adb6-23905831f549

