### PR TITLE
Make the 'first run' screen fit by shortening text

### DIFF
--- a/modules/Gui.py
+++ b/modules/Gui.py
@@ -700,9 +700,10 @@ class PokebotGui:
             welcome_message = f'Hey! This seems to be your first launch of {pokebot_name}, ' \
                               'to get started you first need to create a profile.\n\n' \
                               'A profile stores your save game, save states, bot config, ' \
-                              'bot statistics, screenshots etc. Profiles are stored in the "profiles/" folder.\n\n' \
-                              'You can create and run as many profiles as your PC can handle, ' \
-                              'simply launch another instance of the bot with a different profile.\n'
+                              'bot statistics, screenshots etc. Profiles are stored in the "profiles/" folder.\n'
+            # To be re-added at a later date...
+            # 'You can create and run as many profiles as your PC can handle, ' \
+            # 'simply launch another instance of the bot with a different profile.\n'
             ttk.Label(frame, text=welcome_message, wraplength=450, justify='left').grid(column=0, row=0, columnspan=2)
 
         group = ttk.LabelFrame(frame, text='Create a new profile', padding=10)


### PR DESCRIPTION
This is a (hopefully temporary) fix for #65 that was caused by text overflow in the 'first run' screen.

Making the window fit the text would be preferrable, but is a bit more tedious and left for a later GUI update.

fixes #65 