### PR TITLE
Add support for Python 3.12

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ Alternatively, if you'd like to be able to easily pull the latest updates withou
 - Any time there's a new update, you can pull the latest changes by clicking **Fetch origin**, then **Pull origin**
 
 ### Requirements
-- [Python 3.11](https://www.python.org/downloads/release/python-3110/) (**64-bit**)
+- [Python 3.12](https://www.python.org/downloads/release/python-3120/) (**64-bit**)
 - **Linux** only: Install the following packages with `apt` or appropriate package manager: `sudo apt install python3-tk libmgba0.10 portaudio19-dev`
 - **Note**: running the bot will **automatically** install required Python packages and download + extract [libmgba](https://github.com/hanzi/libmgba-py) - if you're using Python for any other projects, consider using a [venv](https://docs.python.org/3/library/venv.html) to isolate these packages from your base environment
 

--- a/pokebot.py
+++ b/pokebot.py
@@ -5,24 +5,24 @@ from pathlib import Path
 
 from modules.version import pokebot_name, pokebot_version
 
-recommended_python_version = "3.11"
-supported_python_versions = [(3, 10), (3, 11)]
+recommended_python_version = "3.12"
+supported_python_versions = [(3, 10), (3, 11), (3, 12)]
 
 libmgba_tag = "0.2.0-2"
 libmgba_ver = "0.2.0"
 
 required_modules = [
-    "numpy~=1.25.2",
+    "numpy~=1.26.1",
     "Flask~=2.3.2",
     "Flask-Cors~=4.0.0",
-    "ruamel.yaml~=0.17.32",
+    "ruamel.yaml~=0.18.2",
     "pypresence~=4.3.0",
     "obsws-python~=1.6.0",
-    "pandas~=2.0.3",
+    "pandas~=2.1.1",
     "discord-webhook~=1.2.1",
     "jsonschema~=4.17.3",
     "rich~=13.5.2",
-    "cffi~=1.15.1",
+    "cffi~=1.16.0",
     "Pillow~=10.0.1",
     "sounddevice~=0.4.6",
     "requests~=2.31.0",
@@ -108,9 +108,11 @@ def check_requirements() -> None:
         # Run `pip install` on all required modules.
         import subprocess
 
+        pip_flags = ["--disable-pip-version-check", "--no-python-version-warning"]
         for module in required_modules:
             subprocess.check_call(
-                [sys.executable, "-m", "pip", "install", module], stderr=sys.stderr, stdout=sys.stdout
+                [sys.executable, "-m", "pip", "install", *pip_flags, module],
+                stderr=sys.stderr, stdout=sys.stdout
             )
 
         # Make sure that `libmgba-py` is installed.

--- a/pokebot.py
+++ b/pokebot.py
@@ -66,10 +66,11 @@ def check_requirements() -> None:
     # As a quick sanity check, we store the current bot version in `.last-requirements-check`.
     # If that file is present and contains the current bot version, we skip the check.
     requirements_file = this_directory / ".last-requirements-check"
+    requirements_version_hash = pokebot_version + '/' + platform.python_version()
     need_to_fetch_requirements = True
     if requirements_file.is_file():
         with open(requirements_file, "r") as file:
-            if file.read() == pokebot_version:
+            if file.read() == requirements_version_hash:
                 need_to_fetch_requirements = False
             else:
                 print(
@@ -157,7 +158,7 @@ def check_requirements() -> None:
         # Mark the requirements for the current bot version as checked, so we do not
         # have to run all of this again until the next update.
         with open(requirements_file, "w") as file:
-            file.write(pokebot_version)
+            file.write(requirements_version_hash)
 
     print("")
 


### PR DESCRIPTION
Now that the `ruamel.yaml` library has updated wheels on PyPI, there is nothing blocking support for Python 3.12 anymore.

This change updates a few requirements to versions that support Python 3.12, and adds Python 3.12 as a supported (and recommended) version of Python to the requirements list and to the Readme.

**Edit:** It also adds the Python version to the `.last-requirements-check` file, so that requirements are re-checked whenever the Python version changes.