### PR TITLE
Set video output to true and speed to 1

### DIFF
--- a/modules/stats.py
+++ b/modules/stats.py
@@ -646,3 +646,5 @@ def encounter_pokemon(pokemon: Pokemon) -> None:
             get_emulator().create_save_state(suffix=filename_suffix)
 
             force_manual_mode()
+            get_emulator().set_speed_factor(1)
+            get_emulator().set_video_enabled(True)

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -647,4 +647,5 @@ def encounter_pokemon(pokemon: Pokemon) -> None:
 
             force_manual_mode()
             get_emulator().set_speed_factor(1)
+            get_emulator().set_throttle(True)
             get_emulator().set_video_enabled(True)


### PR DESCRIPTION
When playing a bit around with this bot, I used max speed. On max speed, time is moving forward very fast. Doing so, missing a shiny by just two minutes could be 30 minutes playtime. To reduce this, the speed factor should be reduced back to normal. 
Additionally, I found out that turning of video doubled the hunting speed. Turning it on when something was found, is good for that, too. If you don't have any notifications for shinies, you wouldn't even notice that you got one. 