### PR TITLE
change init_stats() to correctly load custom customcatchfilters.py

### DIFF
--- a/modules/stats.py
+++ b/modules/stats.py
@@ -37,7 +37,7 @@ files = None
 def init_stats(profile: Profile):
     global custom_catch_filters, custom_hooks, stats, encounter_log, shiny_log, stats_dir, files
 
-    config_dir_path = profile.path / "profiles"
+    config_dir_path = profile.path
     stats_dir_path = profile.path / "stats"
     if not stats_dir_path.exists():
         stats_dir_path.mkdir()
@@ -48,8 +48,8 @@ def init_stats(profile: Profile):
     try:
         if (config_dir_path / "customcatchfilters.py").is_file():
             custom_catch_filters = importlib.import_module(
-                ".custom_catch_filters", f"profiles.{profile.path.name}.config"
-            ).customcatchfilters
+                ".customcatchfilters", f"profiles.{profile.path.name}"
+            ).custom_catch_filters
         else:
             from profiles.customcatchfilters import custom_catch_filters
 

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -54,7 +54,7 @@ def init_stats(profile: Profile):
             from profiles.customcatchfilters import custom_catch_filters
 
         if (config_dir_path / "customhooks.py").is_file():
-            custom_hooks = importlib.import_module(".custom_hooks", f"profiles.{profile.path.name}.config").customhooks
+            custom_hooks = importlib.import_module(".customhooks", f"profiles.{profile.path.name}").custom_hooks
         else:
             from profiles.customhooks import custom_hooks
 


### PR DESCRIPTION
When creating a custom customcatchfilters.py in a profiles/<profile_name>, it was not read because it was looking the profiles/<profile_name>/profiles directory and importing customcatchfilters() from the custom_catch_filters.py file