### PR TITLE
import_pk3 : added the possibilty to import saved pokemon into PC storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__
 .venv
 .idea
 .vs
+.vscode
 
 *.gba
 .last-requirements-check

--- a/Readme.md
+++ b/Readme.md
@@ -320,7 +320,7 @@ The following `console` options will control how much data is displayed in the P
 - `encounter_moves`
 - `statistics`
 
-### Save raw Pokémon data
+### Save raw Pokémon data (.pk3)
 The bot can dump individual Pokémon files (.pk3 format) to be managed/transferred in the [PKHeX save editor](https://github.com/kwsch/PKHeX).
 
 The Pokémon are dumped to the `pokemon/` folder in your profile, in the following format:
@@ -333,6 +333,15 @@ The Pokémon are dumped to the `pokemon/` folder in your profile, in the followi
 - `custom` - dump custom catch filter encounters
 
 Feel free to share any rare/interesting .pk3 files in [#pkhexchange💱](https://discord.com/channels/1057088810950860850/1123523909745135616)!
+
+### Import raw Pokémon data (.pk3)
+While auto-catch is currently still a work in progress, the following option automatically import encountered Pokémon into your PC storage.
+
+Imported Pokémon will be placed into the first available PC slot, in a regular PokéBall.
+
+If space is available in the PC, and the Pokémon was successfully imported, the bot will run from the encounter and continue to hunt.
+
+`import_pk3` - enable automatic .pk3 import to PC storage
 
 </details>
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -69,6 +69,8 @@ logging_schema = """
                 type: boolean
             custom:
                 type: boolean
+    import_pk3:
+        type: boolean
 """
 
 discord_schema = """

--- a/modules/files.py
+++ b/modules/files.py
@@ -51,7 +51,7 @@ def write_pk(file: str, data: bytes) -> bool:
     to write byte arrays out directly into a file
 
     :param file: File to write to
-    :param date: Pokemon data to be written
+    :param data: Pokemon data to be written
     :return: True if file was written to successfully, otherwise False (bool)
     """
     try:

--- a/modules/pc_storage.py
+++ b/modules/pc_storage.py
@@ -39,8 +39,7 @@ def import_pk3_into_storage(path: str) -> bool:
         data = bytes(handle.read(80))
         pokemon = Pokemon(data)
         if pokemon.is_valid:
-            addr = _find_pokemon_storage_offset()[0]
-            get_emulator().write_bytes(addr + available_offset, data)
+            get_emulator().write_bytes(g_pokemon_storage + available_offset, data)
         else:
             return False
 

--- a/modules/pc_storage.py
+++ b/modules/pc_storage.py
@@ -1,6 +1,8 @@
+import math
+
 from modules.console import console
 from modules.game import get_symbol
-from modules.gui import get_emulator, get_rom
+from modules.gui import get_emulator, get_rom, set_message
 from modules.memory import read_symbol, unpack_uint32
 from modules.pokemon import Pokemon
 
@@ -10,37 +12,43 @@ IN_BOX_ROWS = 5
 IN_BOX_COLUMNS = 6
 IN_BOX_COUNT = IN_BOX_ROWS * IN_BOX_COLUMNS
 
+
 def _find_pokemon_storage_offset() -> tuple[int, int]:
-    if get_rom().game_title in ['POKEMON EMER', 'POKEMON FIRE', 'POKEMON LEAF']:
-        offset = unpack_uint32(read_symbol('gPokemonStoragePtr'))
-        length = get_symbol('gPokemonStorage')[1]
+    if get_rom().game_title in ["POKEMON EMER", "POKEMON FIRE", "POKEMON LEAF"]:
+        offset = unpack_uint32(read_symbol("gPokemonStoragePtr"))
+        length = get_symbol("gPokemonStorage")[1]
     else:
-        offset, length = get_symbol('gPokemonStorage')
+        offset, length = get_symbol("gPokemonStorage")
     return offset, length
 
-def import_pk3_into_storage(path: str) -> bool:
+
+def import_into_storage(data: bytes) -> bool:
+    data = data[:80]
+
     # find first available spot offset
-    available = False
+    space_available = False
     g_pokemon_storage = _find_pokemon_storage_offset()[0]
     for i in range(IN_BOX_COUNT * TOTAL_BOXES_COUNT):
         # the first 4 bytes are the current box
         # first mon is stored at offset gPokemonStorage + 4
         offset_to_check = 4 + i * 80
-        # if a spot is available, it is all 0
-        available = unpack_uint32(get_emulator().read_bytes(g_pokemon_storage + offset_to_check, 4)) == 0
-        if available: 
+        # if a spot is space_available, it is all 0
+        space_available = unpack_uint32(get_emulator().read_bytes(g_pokemon_storage + offset_to_check, 4)) == 0
+        if space_available:
             available_offset = offset_to_check
             break
-    # no available offset, can not continue
-    if not available:
-        return False
-    
-    with open(path, 'rb') as handle:
-        data = bytes(handle.read(80))
-        pokemon = Pokemon(data)
-        if pokemon.is_valid:
-            get_emulator().write_bytes(g_pokemon_storage + available_offset, data)
-        else:
-            return False
 
+    pokemon = Pokemon(data)
+    if pokemon.is_valid and space_available:
+        box = math.floor((available_offset/80) / IN_BOX_COUNT)
+        message = f"Saved {pokemon.species.name} to PC box {box}!"
+
+        get_emulator().write_bytes(g_pokemon_storage + available_offset, data)
+        set_message(message)
+        console.print(message)
+    else:
+        message = f"Not enough room in PC to automatically import {pokemon.species.name}!"
+        set_message(message)
+        console.print(message)
+        return False
     return True

--- a/modules/pc_storage.py
+++ b/modules/pc_storage.py
@@ -1,0 +1,47 @@
+from modules.console import console
+from modules.game import get_symbol
+from modules.gui import get_emulator, get_rom
+from modules.memory import read_symbol, unpack_uint32
+from modules.pokemon import Pokemon
+
+# see pret/pokeemerald:include/pokemon_storage_system.h
+TOTAL_BOXES_COUNT = 14
+IN_BOX_ROWS = 5
+IN_BOX_COLUMNS = 6
+IN_BOX_COUNT = IN_BOX_ROWS * IN_BOX_COLUMNS
+
+def _find_pokemon_storage_offset() -> tuple[int, int]:
+    if get_rom().game_title in ['POKEMON EMER', 'POKEMON FIRE', 'POKEMON LEAF']:
+        offset = unpack_uint32(read_symbol('gPokemonStoragePtr'))
+        length = get_symbol('gPokemonStorage')[1]
+    else:
+        offset, length = get_symbol('gPokemonStorage')
+    return offset, length
+
+def import_pk3_into_storage(path: str) -> bool:
+    # find first available spot offset
+    available = False
+    g_pokemon_storage = _find_pokemon_storage_offset()[0]
+    for i in range(IN_BOX_COUNT * TOTAL_BOXES_COUNT):
+        # the first 4 bytes are the current box
+        # first mon is stored at offset gPokemonStorage + 4
+        offset_to_check = 4 + i * 80
+        # if a spot is available, it is all 0
+        available = unpack_uint32(get_emulator().read_bytes(g_pokemon_storage + offset_to_check, 4)) == 0
+        if available: 
+            available_offset = offset_to_check
+            break
+    # no available offset, can not continue
+    if not available:
+        return False
+    
+    with open(path, 'rb') as handle:
+        data = bytes(handle.read(80))
+        pokemon = Pokemon(data)
+        if pokemon.is_valid:
+            addr = _find_pokemon_storage_offset()[0]
+            get_emulator().write_bytes(addr + available_offset, data)
+        else:
+            return False
+
+    return True

--- a/modules/pc_storage.py
+++ b/modules/pc_storage.py
@@ -40,9 +40,8 @@ def import_into_storage(data: bytes) -> bool:
 
     pokemon = Pokemon(data)
     if pokemon.is_valid and space_available:
-        box = math.floor((available_offset/80) / IN_BOX_COUNT)
+        box = math.floor(((available_offset / 80) / IN_BOX_COUNT) + 1)
         message = f"Saved {pokemon.species.name} to PC box {box}!"
-
         get_emulator().write_bytes(g_pokemon_storage + available_offset, data)
         set_message(message)
         console.print(message)

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -19,6 +19,7 @@ from modules.memory import get_game_state, GameState
 from modules.pokemon import Pokemon
 from modules.profiles import Profile
 from modules.files import write_pk
+from modules.pc_storage import import_pk3_into_storage
 
 custom_catch_filters = None
 custom_hooks = None
@@ -619,9 +620,14 @@ def encounter_pokemon(pokemon: Pokemon) -> None:
     """
 
     global block_list
+    mon_is_saved = False
+    mon_is_imported = False
 
     if config["logging"]["save_pk3"]["all"]:
-        save_pk3(pokemon)
+        path = save_pk3(pokemon)
+        mon_is_saved = True
+        if config["logging"]["import_pk3"]:
+            mon_is_imported = import_pk3_into_storage(path)
 
     if pokemon.is_shiny or block_list == []:
         # Load catch block config file - allows for editing while bot is running
@@ -638,14 +644,20 @@ def encounter_pokemon(pokemon: Pokemon) -> None:
     if pokemon.is_shiny or custom_found:
         if pokemon.is_shiny:
             if not config["logging"]["save_pk3"]["all"] and config["logging"]["save_pk3"]["shiny"]:
-                save_pk3(pokemon)
+                path = save_pk3(pokemon)
+                mon_is_saved = True
+                if config["logging"]["import_pk3"]:
+                    mon_is_imported = import_pk3_into_storage(path)
             state_tag = "shiny"
             console.print("[bold yellow]Shiny found!")
             set_message("Shiny found! Bot has been switched to manual mode so you can catch it.")
 
         elif custom_found:
             if not config["logging"]["save_pk3"]["all"] and config["logging"]["save_pk3"]["custom"]:
-                save_pk3(pokemon)
+                path = save_pk3(pokemon)
+                mon_is_saved = True
+                if config["logging"]["import_pk3"]:
+                    mon_is_imported = import_pk3_into_storage(path)
             state_tag = "customfilter"
             console.print("[bold green]Custom filter Pokemon found!")
             set_message("Custom filter triggered! Bot has been switched to manual mode so you can catch it.")
@@ -657,16 +669,22 @@ def encounter_pokemon(pokemon: Pokemon) -> None:
         else:
             filename_suffix = f"{state_tag}_{pokemon.species.safe_name}"
             get_emulator().create_save_state(suffix=filename_suffix)
+            # TEMPORARY until auto-battle/auto-catch is done
+            # if the mon is saved and imported, no need to catch it by hand
+            if mon_is_saved and config["logging"]["import_pk3"] and mon_is_imported:
+                pass
+            else:
+                force_manual_mode()
+                get_emulator().set_speed_factor(1)
+                get_emulator().set_throttle(True)
+                get_emulator().set_video_enabled(True)
 
-            force_manual_mode()
-            get_emulator().set_speed_factor(1)
-            get_emulator().set_throttle(True)
-            get_emulator().set_video_enabled(True)
 
-
-def save_pk3(pokemon: Pokemon) -> None:
+def save_pk3(pokemon: Pokemon) -> str:
     """
     Takes the byte data of [obj]Pokémon.data and outputs it in a pkX format in the /profiles/[PROFILE]/pokemon dir.
+    
+    :return: the path the pokemon was saved to
     """
 
     pk3_filename = f"{pokemon.species.national_dex_number}"
@@ -677,5 +695,6 @@ def save_pk3(pokemon: Pokemon) -> None:
         f"{pk3_filename} - {pokemon.name} - {pokemon.nature} "
         f"[{pokemon.ivs.sum()}] - {hex(pokemon.personality_value)[2:].upper()}.pk3"
     )
-
-    write_pk(f"{pokemon_dir}/{pk3_filename}", pokemon.data)
+    path = f"{pokemon_dir}/{pk3_filename}"
+    write_pk(path, pokemon.data)
+    return path

--- a/profiles/logging.yml
+++ b/profiles/logging.yml
@@ -21,4 +21,4 @@ save_pk3:
 
 # Import pokemon from pk3 file into pc storage right after saving them
 # `true`, `false`
-import_pk3: true
+import_pk3: false

--- a/profiles/logging.yml
+++ b/profiles/logging.yml
@@ -19,6 +19,6 @@ save_pk3:
   shiny: true
   custom: true
 
-# Import pokemon from pk3 file into pc storage right after saving them
+# Automatically load .pk3 file into PC storage
 # `true`, `false`
 import_pk3: false

--- a/profiles/logging.yml
+++ b/profiles/logging.yml
@@ -18,3 +18,7 @@ save_pk3:
   all: false
   shiny: true
   custom: true
+
+# Import pokemon from pk3 file into pc storage right after saving them
+# `true`, `false`
+import_pk3: true


### PR DESCRIPTION
This PR allows the pokemon that was saved to a .pk3 file to be imported into the PC storage, thus temporarily working around the auto-catch feature