### PR TITLE
Add a basic GitHub Actions workflow for releases

### DIFF
--- a/.github/workflows/release-when-tag-pushed.yml
+++ b/.github/workflows/release-when-tag-pushed.yml
@@ -1,0 +1,34 @@
+name: Creates a new release when a tag is pushed
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  create-release-for-tag:
+    name: "Create a release for the tag"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update version.py and remove unnecessary files
+        run: |
+          echo "pokebot_name = \"PokéBot\"" > modules/version.py
+          echo "pokebot_version = \"${{ github.ref_name }}\"" >> modules/version.py
+          rm -rf .git .github .gitattributes .gitignore pokebot.spec
+          mv LICENSE LICENSE.txt
+
+      - name: Create a ZIP file
+        run: |
+          zip -qq -r /tmp/pokebot-${{ github.ref_name }}.zip .
+
+      - name: Creates the GitHub release
+        uses: marvinpinto/action-automatic-releases@v1.2.1
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: false
+          automatic_release_tag: ${{ github.ref_name }}
+          files: |
+            /tmp/pokebot-${{ github.ref_name }}.zip

--- a/.github/workflows/release-when-tag-pushed.yml
+++ b/.github/workflows/release-when-tag-pushed.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   create-release-for-tag:
+    # This release action only really makes sense in the main repository and not in
+    # a fork, hence this condition.
+    if: github.repository == '40Cakes/pokebot-gen3'
+
     name: "Create a release for the tag"
     runs-on: ubuntu-latest
 

--- a/modules/debug.py
+++ b/modules/debug.py
@@ -153,9 +153,9 @@ class FancyTreeview:
         if len(selection) < 1:
             return
 
-        import pyperclip
+        import pyperclip3
 
-        pyperclip.copy(self._tv.item(selection[0])["values"][0])
+        pyperclip3.copy(str(self._tv.item(selection[0])["values"][0]))
 
     def _handle_action(self, callback: callable) -> None:
         selection = self._tv.selection()

--- a/modules/runtime.py
+++ b/modules/runtime.py
@@ -9,6 +9,13 @@ def is_bundled_app() -> bool:
     return getattr(sys, "frozen", False)
 
 
+def is_virtualenv() -> bool:
+    """
+    :return: Whether we are running in a virtualenv (True) or in the global Python environment (False)
+    """
+    return sys.prefix != sys.base_prefix
+
+
 def get_base_path() -> Path:
     """
     :return: A `Path` object to the base directory of the bot (where `pokebot.py` or `pokebot.exe`

--- a/modules/version.py
+++ b/modules/version.py
@@ -1,2 +1,33 @@
+# Note: This file will get replaced when run in GitHub actions.
+# In that case, the tagged version will be placed in here instead.
+#
+# So this file is only for development, or when someone just fetches
+# the Git repository.
+#
+# It will try to get the current commit hash and use it as the
+# version number, prefixed by `dev-` (e.g. `dev-a1b2c3d`.)
+
+import os
+from modules.runtime import get_base_path
+
 pokebot_name = "PokéBot"
-pokebot_version = "v0.0.3a"  # TODO automatically append latest commit hash to version e.g. v0.0.1-e3fa5f5
+pokebot_version = "dev"
+
+try:
+    # If someone managed to get a copy of the repository without actually having
+    # Git installed, this should still be able to get the commit hash of the current
+    # HEAD.
+    # It's probably not the _best_ way to do this... but it works.
+    git_dir = get_base_path() / ".git"
+    if git_dir.is_dir():
+        with open(git_dir / "HEAD", "r") as head_file:
+            head = head_file.read().strip()
+            if head.startswith("ref: "):
+                full_path = git_dir.as_posix() + "/" + head[5:]
+                with open(full_path, "r") as ref_file:
+                    ref = ref_file.read().strip()
+                    pokebot_version = f"dev-{ref[0:7]}"
+except:
+    # If any issue occurred while trying to figure out the current commit hash,
+    # just default to showing 'dev' for the version.
+    pass

--- a/pokebot.py
+++ b/pokebot.py
@@ -3,44 +3,11 @@
 import argparse
 import atexit
 import platform
-import sys
-import json
 
 from modules.runtime import is_bundled_app, get_base_path
 from modules.version import pokebot_name, pokebot_version
 
 OS_NAME = platform.system()
-
-recommended_python_version = "3.12"
-supported_python_versions = [(3, 10), (3, 11), (3, 12)]
-
-libmgba_tag = "0.2.0-2"
-libmgba_ver = "0.2.0"
-
-required_modules = [
-    "numpy~=1.26.1",
-    "Flask~=2.3.2",
-    "Flask-Cors~=4.0.0",
-    "ruamel.yaml~=0.18.2",
-    "pypresence~=4.3.0",
-    "obsws-python~=1.6.0",
-    "pandas~=2.1.1",
-    "discord-webhook~=1.2.1",
-    "jsonschema~=4.17.3",
-    "rich~=13.5.2",
-    "cffi~=1.16.0",
-    "Pillow~=10.0.1",
-    "sounddevice~=0.4.6",
-    "requests~=2.31.0",
-    "pyperclip~=1.8.2",
-]
-
-if OS_NAME == "Windows":
-    required_modules.extend([
-        "pywin32>=306",
-        "psutil~=5.9.5"
-    ])
-
 gui = None
 
 
@@ -50,132 +17,23 @@ gui = None
 # For those cases, we register an `atexit` handler that will wait for user input before closing
 # the terminal window.
 def on_exit() -> None:
-    """Windows-specific handler to prevent the terminal from being terminated until user input."""
-    import psutil
-    import os
-    parent_process_name = psutil.Process(os.getppid()).name()
-    if parent_process_name == "py.exe" or is_bundled_app():
-        if gui is not None and gui.window is not None:
-            gui.window.withdraw()
+    if OS_NAME == "Windows":
+        import psutil
+        import os
+        parent_process_name = psutil.Process(os.getppid()).name()
+        if parent_process_name == "py.exe" or is_bundled_app():
+            if gui is not None and gui.window is not None:
+                gui.window.withdraw()
 
-        print("")
-        input("Press Enter to close...")
-
-
-if OS_NAME == "Windows":
-    atexit.register(on_exit)
-
-
-def check_requirements() -> None:
-    # We do not want to do downlaod requirements every single time the bot is started.
-    # As a quick sanity check, we store the current bot version in `.last-requirements-check`.
-    # If that file is present and contains the current bot version, we skip the check.
-    requirements_file = get_base_path() / ".last-requirements-check"
-    requirements_version_hash = pokebot_version + '/' + platform.python_version()
-    need_to_fetch_requirements = True
-    if requirements_file.is_file():
-        with open(requirements_file, "r") as file:
-            if file.read() == requirements_version_hash:
-                need_to_fetch_requirements = False
-            else:
-                print(
-                    f"This is a newer version of {pokebot_name} than you have run before. "
-                    f"Checking if requirements are met..."
-                )
-                print("")
-    else:
-        print(
-            f"Seems like this is the first time you are running {pokebot_name}!\n"
-            "Checking if requirements are met..."
-        )
-        print("")
-
-    if need_to_fetch_requirements:
-        print(f"The following Python modules need to be installed:\n\n{json.dumps(required_modules, indent=2)}\n\n")
-        response = input("Install modules? [y/n] ")
-        if response.lower() == "y":
-            python_version = platform.python_version_tuple()
-            version_matched = False
-            for supported_version in supported_python_versions:
-                if int(python_version[0]) == supported_version[0] and int(python_version[1]) == supported_version[1]:
-                    version_matched = True
-                    break
-            if not version_matched:
-                supported_versions_list = ", ".join(map(lambda t: f"{str(t[0])}.{str(t[1])}", supported_python_versions))
-                print(f"ERROR: The Python version you are using (Python {platform.python_version()}) is not supported.\n")
-                print(f"Supported versions are: {supported_versions_list}")
-                print(f"It is recommended that you install Python {recommended_python_version}.")
-                sys.exit(1)
-
-            # Some dependencies only work with 64-bit Python. Since this isn't the 90s anymore,
-            # we'll just require that.
-            if platform.architecture()[0] != "64bit":
-                print(f"ERROR: A 64-bit version of Python is required in order to run {pokebot_name} {pokebot_version}.\n")
-                print(f"You are currently running a {platform.architecture()[0]} version.")
-                sys.exit(1)
-
-            # Run `pip install` on all required modules.
-            import subprocess
-
-            pip_flags = ["--disable-pip-version-check", "--no-python-version-warning"]
-            for module in required_modules:
-                subprocess.check_call(
-                    [sys.executable, "-m", "pip", "install", *pip_flags, module],
-                    stderr=sys.stderr, stdout=sys.stdout
-                )
-
-            # Make sure that `libmgba-py` is installed.
             print("")
-            libmgba_directory = get_base_path() / "mgba"
-            if not libmgba_directory.is_dir():
-                match platform.system():
-                    case "Windows":
-                        libmgba_url = (
-                            f"https://github.com/hanzi/libmgba-py/releases/download/{libmgba_tag}/"
-                            f"libmgba-py_{libmgba_ver}_win64.zip"
-                        )
+            input("Press Enter to close...")
 
-                    case "Linux":
-                        linux_release = platform.freedesktop_os_release()
-                        supported_linux_releases = [("ubuntu", "23.04"), ("debian", "12")]
-                        if (linux_release["ID"], linux_release["VERSION_ID"]) not in supported_linux_releases:
-                            print(
-                                f'You are running an untested version of Linux ({linux_release["PRETTY_NAME"]}). '
-                                f"Currently, only {supported_linux_releases} have been tested and confirmed working."
-                            )
-                            input("Press enter to install libmgba-py anyway...")
-                        libmgba_url = (
-                            f"https://github.com/hanzi/libmgba-py/releases/download/{libmgba_tag}/"
-                            f"libmgba-py_{libmgba_ver}_ubuntu-lunar.zip"
-                        )
 
-                    case _:
-                        print(f"ERROR: {platform.system()} is unsupported. Only Windows and Linux are currently supported.")
-                        sys.exit(1)
+atexit.register(on_exit)
 
-                import io
-                import requests
-                import zipfile
-
-                response = requests.get(libmgba_url)
-                if response.status_code == 200:
-                    print("Unzipping libmgba into `./mgba`...")
-                    with zipfile.ZipFile(io.BytesIO(response.content)) as zip_handle:
-                        zip_handle.extractall(get_base_path())
-
-            # Mark the requirements for the current bot version as checked, so we do not
-            # have to run all of this again until the next update.
-            with open(requirements_file, "w") as file:
-                file.write(requirements_version_hash)
-
-        else:
-            print("Exiting!")
-            sys.exit(1)
-
-    print("")
 
 def parse_arguments() -> argparse.Namespace:
-    """Parses program arguments."""
+    """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description=f'{pokebot_name} {pokebot_version}')
     parser.add_argument(
         'profile',
@@ -185,8 +43,10 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument('-d', '--debug', action='store_true', help='Enable extra debug options and a debug menu.')
     return parser.parse_args()
 
+
 if __name__ == "__main__":
     if not is_bundled_app():
+        from requirements import check_requirements
         check_requirements()
 
     from modules.config import load_config_from_directory
@@ -203,11 +63,13 @@ if __name__ == "__main__":
     if OS_NAME == "Windows":
         import win32api
 
+
         def win32_signal_handler(signal_type):
             if signal_type == 2:
                 emulator = get_emulator()
                 if emulator is not None:
                     emulator.shutdown()
+
 
         win32api.SetConsoleCtrlHandler(win32_signal_handler, True)
 

--- a/pokebot.spec
+++ b/pokebot.spec
@@ -1,56 +1,47 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-app_name='pokebot'
-
-a = Analysis(
-    ['pokebot.py'],
-    pathex=[],
-    binaries=[],
-    datas=[('sprites', 'sprites'), ('modules/data', 'modules/data')],
-    hiddenimports=[],
-    hookspath=[],
-    hooksconfig={},
-    runtime_hooks=[],
-    excludes=[],
-    noarchive=False,
-)
-pyz = PYZ(a.pure)
-
-exe = EXE(
-    pyz,
-    a.scripts,
-    [],
-    exclude_binaries=True,
-    name=app_name,
-    debug=False,
-    bootloader_ignore_signals=False,
-    strip=False,
-    upx=True,
-    console=True,
-    disable_windowed_traceback=False,
-    argv_emulation=False,
-    target_arch=None,
-    codesign_identity=None,
-    entitlements_file=None,
-)
-coll = COLLECT(
-    exe,
-    a.binaries,
-    a.datas,
-    strip=False,
-    upx=True,
-    upx_exclude=[],
-    name=app_name,
-)
-
 import os
 import pathlib
 import shutil
+import sys
+
+sys.path.append(os.getcwd())
+from requirements import update_requirements
+
+update_requirements(ask_for_confirmation=False)
+
+app_name = 'pokebot'
+
+# Build pokebot.exe
+pokebot_analysis = Analysis(['pokebot.py'], pathex=[], binaries=[],
+                            datas=[('sprites', 'sprites'), ('modules/data', 'modules/data')],
+                            hiddenimports=[], hookspath=[], hooksconfig={}, runtime_hooks=[], excludes=[],
+                            noarchive=False)
+pokebot_pyz = PYZ(pokebot_analysis.pure)
+pokebot_exe = EXE(pokebot_pyz, pokebot_analysis.scripts, [], exclude_binaries=True, name=app_name, debug=False,
+                  bootloader_ignore_signals=False, strip=False, upx=True, console=True,
+                  disable_windowed_traceback=False,
+                  argv_emulation=False, target_arch=None, codesign_identity=None, entitlements_file=None)
+
+# Build import.exe
+import_analysis = Analysis(['import.py'], pathex=[], binaries=[], datas=[], hiddenimports=[], hookspath=[],
+                           hooksconfig={},
+                           runtime_hooks=[], excludes=[], noarchive=False)
+import_pyz = PYZ(import_analysis.pure)
+import_exe = EXE(import_pyz, import_analysis.scripts, [], exclude_binaries=True, name='import', debug=False,
+                 bootloader_ignore_signals=False, strip=False, upx=True, console=False,
+                 disable_windowed_traceback=False, argv_emulation=False, target_arch=None, codesign_identity=None,
+                 entitlements_file=None)
+
+# Put everything in the dist directory
+coll = COLLECT(pokebot_exe, pokebot_analysis.binaries, pokebot_analysis.datas,
+               import_exe, import_analysis.binaries, import_analysis.datas,
+               strip=False, upx=True, upx_exclude=[], name=app_name)
 
 current_dir = pathlib.Path(os.getcwd())
 output_dir = pathlib.Path(DISTPATH) / app_name
 
-shutil.copyfile(current_dir / 'LICENSE', output_dir / 'LICENSE')
+shutil.copyfile(current_dir / 'LICENSE', output_dir / 'LICENSE.txt')
 shutil.copyfile(current_dir / 'Readme.md', output_dir / 'Readme.md')
 
 os.mkdir(output_dir / 'profiles')

--- a/requirements.py
+++ b/requirements.py
@@ -1,0 +1,197 @@
+import platform
+import sys
+
+from modules.runtime import is_bundled_app, is_virtualenv, get_base_path
+from modules.version import pokebot_name, pokebot_version
+
+recommended_python_version = "3.12"
+supported_python_versions = ["3.10", "3.11", "3.12"]
+
+libmgba_tag = "0.2.0-2"
+libmgba_ver = "0.2.0"
+
+# This is a list of requirements for `pip`, akin to `requirements.txt`.
+required_modules = [
+    "numpy~=1.26.1",
+    "Flask~=2.3.2",
+    "Flask-Cors~=4.0.0",
+    "ruamel.yaml~=0.18.2",
+    "pypresence~=4.3.0",
+    "obsws-python~=1.6.0",
+    "pandas~=2.1.1",
+    "discord-webhook~=1.2.1",
+    "jsonschema~=4.17.3",
+    "rich~=13.5.2",
+    "cffi~=1.16.0",
+    "Pillow~=10.0.1",
+    "sounddevice~=0.4.6",
+    "requests~=2.31.0",
+    "pyperclip3~=0.4.1"
+]
+
+if platform.system() == "Windows":
+    required_modules.extend([
+        "pywin32>=306",
+        "psutil~=5.9.5"
+    ])
+
+
+def get_requirements_hash() -> str:
+    """
+    This is used to check whether (a) the requirements have changed or (b) the system's Python version
+    has changed, both of which indicates that we should re-check the requirements.
+    :return: A hash of all the current requirements, as well as this system's Python version.
+    """
+    import hashlib
+    requirements_block = "\n".join([
+        *required_modules,
+        platform.python_version(),
+        libmgba_ver,
+        libmgba_tag,
+        recommended_python_version,
+        *supported_python_versions,
+    ])
+    return hashlib.sha1(requirements_block.encode("utf-8")).hexdigest()
+
+
+def update_requirements(ask_for_confirmation: bool = True) -> bool:
+    """
+    This will run `pip install` for all requirements configured above, as well as check that
+    `libmgba-py` is present and that the Python environment (version, 64-bit) is compatible.
+
+    It will throw an error _and exit the program_ if an incompatibility is found.
+
+    :param ask_for_confirmation: Whether the user should be asked for confirmation before
+                                 installing any packages. This option is here so we can
+                                 install requirements non-interactively in the pyinstaller
+                                 build process.
+    :return: Whether updating the requirements succeeded.
+    """
+    python_version_tuple = platform.python_version_tuple()
+    python_version = f"{str(python_version_tuple[0])}.{str(python_version_tuple[1])}"
+    if python_version not in supported_python_versions:
+        supported_versions_list = ", ".join(supported_python_versions)
+        print(f"ERROR: The Python version you are using (Python {platform.python_version()}) is not supported.\n")
+        print(f"Supported versions are: {supported_versions_list}")
+        print(f"It is recommended that you install Python {recommended_python_version}.")
+        sys.exit(1)
+
+    # Some dependencies only work with 64-bit Python. Since this isn't the 90s anymore,
+    # we'll just require that.
+    if platform.architecture()[0] != "64bit":
+        print(f"ERROR: A 64-bit version of Python is required in order to run {pokebot_name} {pokebot_version}.\n")
+        print(f"You are currently running a {platform.architecture()[0]} version.")
+        sys.exit(1)
+
+    # To avoid surprising the user by installing packages in the global Python environment,
+    # we ask for confirmation first. This is skipped if we're inside a virtualenv.
+    if ask_for_confirmation and not is_virtualenv():
+        print(f"The following Python modules need to be checked and possibly installed:\n")
+        for module in required_modules:
+            print(f"  * {module}")
+        print("")
+        response = input("Install those modules? [y/N] ")
+        print("")
+        if response.lower() != "y":
+            print("Not installing any requirements -- the bot might not work this way!")
+            return False
+
+    # Run `pip install` on all required modules.
+    import subprocess
+
+    pip_flags = ["--disable-pip-version-check", "--no-python-version-warning"]
+    for module in required_modules:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", *pip_flags, module],
+            stderr=sys.stderr, stdout=sys.stdout
+        )
+
+    # Make sure that `libmgba-py` is installed.
+    print("")
+    libmgba_directory = get_base_path() / "mgba"
+    if not libmgba_directory.is_dir():
+        match platform.system():
+            case "Windows":
+                libmgba_url = (
+                    f"https://github.com/hanzi/libmgba-py/releases/download/{libmgba_tag}/"
+                    f"libmgba-py_{libmgba_ver}_win64.zip"
+                )
+
+            case "Linux":
+                linux_release = platform.freedesktop_os_release()
+                supported_linux_releases = [("ubuntu", "23.04"), ("debian", "12")]
+                if (linux_release["ID"], linux_release["VERSION_ID"]) not in supported_linux_releases:
+                    print(
+                        f'You are running an untested version of Linux ({linux_release["PRETTY_NAME"]}). '
+                        f"Currently, only {supported_linux_releases} have been tested and confirmed working."
+                    )
+                    input("Press enter to install libmgba-py anyway...")
+                libmgba_url = (
+                    f"https://github.com/hanzi/libmgba-py/releases/download/{libmgba_tag}/"
+                    f"libmgba-py_{libmgba_ver}_ubuntu-lunar.zip"
+                )
+
+            case _:
+                print(f"ERROR: {platform.system()} is unsupported. Only Windows and Linux are currently supported.")
+                sys.exit(1)
+
+        import io
+        import requests
+        import zipfile
+
+        response = requests.get(libmgba_url)
+        if response.status_code == 200:
+            print("Unzipping libmgba into `./mgba`...")
+            with zipfile.ZipFile(io.BytesIO(response.content)) as zip_handle:
+                zip_handle.extractall(get_base_path())
+
+    # Mark the requirements for the current bot version as checked, so we do not
+    # have to run all of this again until the next update.
+    with open(get_base_path() / ".last-requirements-check", "w") as file:
+        file.write(get_requirements_hash())
+
+    print("")
+
+    return True
+
+
+def check_requirements() -> bool:
+    """
+    Checks whether the dependencies of this app are up-to-date, and if necessary runs
+    `update_requirements()` to fetch them.
+
+    :return: Whether requirements are up-to-date.
+    """
+
+    # Never check requirements if we are in a bundle generated by pyinstaller, since all the
+    # requirements should already be included. Also, it's not possible to download requirements
+    # inside a bundle anyway.
+    if is_bundled_app():
+        return True
+
+    # We do not want to do download requirements every single time the bot is started.
+    # As a quick sanity check, we store the current bot version in `.last-requirements-check`.
+    # If that file is present and contains the current bot version, we skip the check.
+    requirements_file = get_base_path() / ".last-requirements-check"
+    requirements_hash = get_requirements_hash()
+    if requirements_file.is_file():
+        with open(requirements_file, "r") as file:
+            if file.read() != requirements_hash:
+                print(
+                    f"This is a newer version of {pokebot_name} than you have run before, "
+                    f"or you have updated your Python version.\n"
+                    f"We will have to check again if all requirements are met."
+                )
+                print("")
+                return update_requirements()
+    else:
+        print(
+            f"Seems like this is the first time you are running {pokebot_name}!\n"
+            "We will check if your system meets all the requirements to run it."
+        )
+        print("")
+        return update_requirements()
+
+
+if __name__ == '__main__':
+    update_requirements()


### PR DESCRIPTION
This adds a GitHub Actions workflow that will automatically create a release whenever a tag is pushed/created.

(See: https://github.com/hanzi/pokebot-gen3/actions/runs/6671930024 and https://github.com/hanzi/pokebot-gen3/releases/tag/test-tag7)

While doing so, it will update `modules/version.py` to contain the name of the tag as version number, and also create a little changelog in the release description.

If the original source code from the Git repository is run, the version number will either be generated by the current commit hash (e.g. `dev-a1b2c3d`) or just be 'dev' if no Git information could be found.

Apart from that, this changes a couple of things to improve pyinstaller packaging.

Unfortunately, using pyinstaller bundles for distribution is not really going to work because Windows Defender will just reject those .exe files because they are unsigned.

Signing them would require a certificate that costs a couple hundred USD per year, so that's not really worth it. And explaining to people that they should click to ignore the warning seems questionable at best, and would probably mean at least the same amount of questions in the support channel.

Also, I have extracted the requirements-related stuff into a `requirements.py` again, to clean up the code in `pokebot.py` a bit and to allow manual triggering of a requirements fetch.

`pokebot.py` (and now also `import.py`) will still call the functions therein, so people don't _have to_ run `requirements.py`.