### PR TITLE
Use newer syntax for optional type hints

### DIFF
--- a/modules/context.py
+++ b/modules/context.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from modules.gui import PokebotGui
@@ -9,9 +9,9 @@ if TYPE_CHECKING:
 
 class BotContext:
     def __init__(self, initial_bot_mode: str = 'manual'):
-        self.emulator: Union['LibmgbaEmulator', None] = None
-        self.gui: Union['PokebotGui', None] = None
-        self.profile: Union['Profile', None] = None
+        self.emulator: Optional["LibmgbaEmulator"] = None
+        self.gui: Optional["PokebotGui"] = None
+        self.profile: Optional["Profile"] = None
         self.debug: bool = False
 
         self._current_message: str = ''
@@ -102,7 +102,7 @@ class BotContext:
             self._update_gui()
 
     @property
-    def rom(self) -> Union['ROM', None]:
+    def rom(self) -> Optional["ROM"]:
         if self.profile:
             return self.profile.rom
         else:

--- a/modules/daycare.py
+++ b/modules/daycare.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Union
 
 from modules.memory import get_save_block, unpack_uint32
 from modules.pokemon import Pokemon, parse_pokemon
@@ -13,9 +12,7 @@ class DaycareCompatibility(IntEnum):
     High = 70
 
     @classmethod
-    def calculate_for(
-        cls, pokemon1: Union[Pokemon, None], pokemon2: Union[Pokemon, None]
-    ) -> tuple["DaycareCompatibility", str]:
+    def calculate_for(cls, pokemon1: Pokemon | None, pokemon2: Pokemon | None) -> tuple["DaycareCompatibility", str]:
         if pokemon1 is None or pokemon1.is_empty or pokemon2 is None or pokemon2.is_empty:
             return DaycareCompatibility.Incompatible, "Less than two Pokémon in daycare"
 
@@ -75,7 +72,7 @@ class DaycareData:
     compatibility: tuple[DaycareCompatibility, str]
 
 
-def get_daycare_data() -> Union[DaycareData, None]:
+def get_daycare_data() -> DaycareData | None:
     data = get_save_block(1, 0x3030, 0x120)
     if data is None:
         return None

--- a/modules/discord.py
+++ b/modules/discord.py
@@ -1,7 +1,6 @@
 import time
 from pathlib import Path
 from pypresence import Presence
-from typing import Union
 from discord_webhook import DiscordWebhook, DiscordEmbed
 from modules.console import console
 from modules.config import config
@@ -16,8 +15,8 @@ def discord_message(
     embed_title: str = None,
     embed_description: str = None,
     embed_fields: object = None,
-    embed_thumbnail: Union[str, Path] = None,
-    embed_image: Union[str, Path] = None,
+    embed_thumbnail: str | Path = None,
+    embed_image: str | Path = None,
     embed_footer: str = None,
     embed_color: str = "FFFFFF",
 ) -> None:

--- a/modules/libmgba.py
+++ b/modules/libmgba.py
@@ -4,7 +4,6 @@ import PIL.PngImagePlugin
 import time
 import zlib
 from collections import deque
-from typing import Union
 
 import sounddevice
 
@@ -92,7 +91,7 @@ class LibmgbaEmulator:
     # How often a frame should be drawn to the screen (can be less frequent than the emulation rate)
     _target_seconds_per_render = 1 / 60
 
-    _audio_stream: Union[sounddevice.RawOutputStream, None] = None
+    _audio_stream: sounddevice.RawOutputStream | None = None
 
     def __init__(self, profile: Profile, on_frame_callback: callable):
         console.print(f"Running [cyan]{libmgba_version_string()}[/]")

--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
-from typing import Literal, Union
+from typing import Literal
 
 import numpy
 
@@ -865,7 +865,7 @@ class Pokemon:
             return self.species.name.upper()
 
     @property
-    def language(self) -> ROMLanguage:
+    def language(self) -> ROMLanguage | None:
         if self.data[18] == 1:
             return ROMLanguage.Japanese
         elif self.data[18] == 2:
@@ -900,7 +900,7 @@ class Pokemon:
         return get_species_by_index(species_id)
 
     @property
-    def held_item(self) -> Union[Item, None]:
+    def held_item(self) -> Item | None:
         item_index = unpack_uint16(self._decrypted_data[34:36])
         if item_index == 0:
             return None
@@ -915,7 +915,7 @@ class Pokemon:
     def friendship(self) -> int:
         return self._decrypted_data[41]
 
-    def move(self, index: Literal[0, 1, 2, 3]) -> Union[LearnedMove, None]:
+    def move(self, index: Literal[0, 1, 2, 3]) -> LearnedMove | None:
         offset = 44 + index * 2
         move_index = unpack_uint16(self._decrypted_data[offset: offset + 2])
         if move_index == 0:
@@ -927,7 +927,7 @@ class Pokemon:
         return LearnedMove(move=move, total_pp=total_pp, pp=pp, added_pps=total_pp - move.pp)
 
     @property
-    def moves(self) -> tuple[Union[Move, None], Union[Move, None], Union[Move, None], Union[Move, None]]:
+    def moves(self) -> tuple[Move | None, Move | None, Move | None, Move | None]:
         return self.move(0), self.move(1), self.move(2), self.move(3)
 
     @property
@@ -1308,7 +1308,7 @@ class Pokemon:
         }
 
 
-def parse_pokemon(data: bytes) -> Union[Pokemon, None]:
+def parse_pokemon(data: bytes) -> Pokemon | None:
     pokemon = Pokemon(data)
     if not pokemon.is_empty and pokemon.is_valid:
         return pokemon

--- a/modules/profiles.py
+++ b/modules/profiles.py
@@ -1,5 +1,4 @@
 import sys
-import typing
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -57,7 +56,7 @@ class Profile:
 
     rom: ROM
     path: Path
-    last_played: typing.Union[datetime, None]
+    last_played: datetime | None
 
 
 def list_available_profiles() -> list[Profile]:

--- a/modules/save_import.py
+++ b/modules/save_import.py
@@ -1,7 +1,7 @@
 import binascii
 import os
 import zlib
-from typing import IO, Union
+from typing import IO
 
 from modules.memory import unpack_uint32
 from modules.profiles import Profile, create_profile
@@ -73,7 +73,7 @@ def migrate_save_state(file: IO, profile_name: str, selected_rom: ROM) -> Profil
     return profile
 
 
-def get_state_data_from_mgba_state_file(file: IO) -> tuple[bytes, Union[bytes, None]]:
+def get_state_data_from_mgba_state_file(file: IO) -> tuple[bytes, bytes | None]:
     state_data = file.read(0x61000)
     savegame_data = None
 
@@ -102,7 +102,7 @@ def get_state_data_from_mgba_state_file(file: IO) -> tuple[bytes, Union[bytes, N
     return state_data, savegame_data
 
 
-def get_state_data_from_png(file: IO) -> tuple[bytes, Union[bytes, None]]:
+def get_state_data_from_png(file: IO) -> tuple[bytes, bytes | None]:
     state_data = None
     savegame_data = None
 


### PR DESCRIPTION
This replaces the `Union[Foo, None]` type hints that I've been using everywhere so far by the newer `Foo | None` syntax that is available since Python 3.10 (the earliest version we support.)

Thanks to @unixtreme  for pointing this one out!