### PR TITLE
Add more command-line arguments for controlling bot startup, also add always-on-top option

### DIFF
--- a/modules/gui/__init__.py
+++ b/modules/gui/__init__.py
@@ -1,7 +1,7 @@
 import os
 import platform
 from tkinter import Tk, ttk
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import PIL.Image
 import PIL.ImageTk
@@ -19,6 +19,7 @@ from modules.sprites import choose_random_sprite, crop_sprite_square
 from modules.version import pokebot_name, pokebot_version
 
 if TYPE_CHECKING:
+    from pokebot import StartupSettings
     from modules.profiles import Profile
 
 
@@ -28,6 +29,7 @@ class PokebotGui:
         self._current_screen = None
         self._main_loop = main_loop
         self._on_exit = on_exit
+        self._startup_settings: 'StartupSettings | None' = None
 
         self.window.geometry("540x400")
         self.window.resizable(False, True)
@@ -56,9 +58,13 @@ class PokebotGui:
         self._emulator_screen = EmulatorScreen(self.window)
         self._set_app_icon()
 
-    def run(self, preselected_profile: Union['Profile', None] = None) -> None:
-        if preselected_profile is not None:
-            self._run_profile(preselected_profile)
+    def run(self, startup_settings: "StartupSettings") -> None:
+        self._startup_settings = startup_settings
+        if startup_settings.always_on_top:
+            self.window.wm_attributes("-topmost", True)
+
+        if startup_settings.profile is not None:
+            self._run_profile(startup_settings.profile)
         else:
             self._enable_select_profile_screen()
 
@@ -121,9 +127,16 @@ class PokebotGui:
         context.profile = profile
         set_rom(profile.rom)
         context.emulator = LibmgbaEmulator(profile, self._emulator_screen.update)
+
+        if self._startup_settings:
+            context.audio = not self._startup_settings.no_audio
+            context.video = not self._startup_settings.no_video
+            context.emulation_speed = self._startup_settings.emulation_speed
+            context.debug = self._startup_settings.debug
+            context.bot_mode = self._startup_settings.bot_mode
+
         self._emulator_screen.enable()
         self._current_screen = self._emulator_screen
-
         self._main_loop(profile)
 
     def _handle_key_down_event(self, event):

--- a/modules/gui/emulator_screen.py
+++ b/modules/gui/emulator_screen.py
@@ -26,7 +26,10 @@ class EmulatorScreen:
         self._stepping_button: Union[Button, None] = None
         self._current_step: int = 0
 
-        if context.debug:
+        self._controls: EmulatorControls | None = None
+
+    def _initialise_controls(self, debug: bool = False) -> None:
+        if debug:
             controls = DebugEmulatorControls(self.window)
             controls.add_tab(TasksTab())
             controls.add_tab(BattleTab())
@@ -50,6 +53,7 @@ class EmulatorScreen:
         self.frame.rowconfigure(0, weight=1)
         self.frame.columnconfigure(0, weight=1)
 
+        self._initialise_controls(context.debug)
         self._add_canvas()
         self.scale = 2
 

--- a/pokebot.py
+++ b/pokebot.py
@@ -3,6 +3,7 @@
 import argparse
 import atexit
 import platform
+from dataclasses import dataclass
 
 from modules.runtime import is_bundled_app, get_base_path
 from modules.version import pokebot_name, pokebot_version
@@ -32,7 +33,18 @@ def on_exit() -> None:
 atexit.register(on_exit)
 
 
-def parse_arguments() -> argparse.Namespace:
+@dataclass
+class StartupSettings:
+    profile: 'Profile | None'
+    debug: bool
+    bot_mode: str
+    no_video: bool
+    no_audio: bool
+    emulation_speed: int
+    always_on_top: bool
+
+
+def parse_arguments() -> StartupSettings:
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description=f'{pokebot_name} {pokebot_version}')
     parser.add_argument(
@@ -40,21 +52,37 @@ def parse_arguments() -> argparse.Namespace:
         nargs='?',
         help='Profile to initialize. Otherwise, the profile selection menu will appear.',
     )
+    parser.add_argument('-m', '--bot-mode', choices=available_bot_modes, help='Initial bot mode (default: manual.)')
+    parser.add_argument('-s', '--emulation-speed', choices=['0', '1', '2', '3', '4'],
+                        help='Initial emulation speed (0 for unthrottled; default: 1.)')
+    parser.add_argument('-nv', '--no-video', action='store_true', help='Turn off video output by default.')
+    parser.add_argument('-na', '--no-audio', action='store_true', help='Turn off audio output by default.')
+    parser.add_argument('-t', '--always-on-top', action='store_true',
+                        help='Keep the bot window always on top of other windows.')
     parser.add_argument('-d', '--debug', action='store_true', help='Enable extra debug options and a debug menu.')
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    preselected_profile: Profile | None = None
+    if args.profile and profile_directory_exists(args.profile):
+        preselected_profile = load_profile_by_name(args.profile)
+
+    return StartupSettings(profile=preselected_profile, debug=bool(args.debug), bot_mode=args.bot_mode or "manual",
+                           no_video=bool(args.no_video), no_audio=bool(args.no_audio),
+                           emulation_speed=int(args.emulation_speed or "1"), always_on_top=bool(args.always_on_top))
 
 
 if __name__ == "__main__":
     if not is_bundled_app():
         from requirements import check_requirements
+
         check_requirements()
 
-    from modules.config import load_config_from_directory
+    from modules.config import load_config_from_directory, available_bot_modes
     from modules.context import context
     from modules.console import console
     from modules.gui import PokebotGui
     from modules.main import main_loop
-    from modules.profiles import profile_directory_exists, load_profile_by_name
+    from modules.profiles import Profile, profile_directory_exists, load_profile_by_name
 
     load_config_from_directory(get_base_path() / "profiles")
 
@@ -73,13 +101,8 @@ if __name__ == "__main__":
 
         win32api.SetConsoleCtrlHandler(win32_signal_handler, True)
 
-    parsed_args = parse_arguments()
-    preselected_profile = parsed_args.profile
-    context.debug = parsed_args.debug
-    if preselected_profile and profile_directory_exists(preselected_profile):
-        preselected_profile = load_profile_by_name(preselected_profile)
-
+    startup_settings = parse_arguments()
     console.print(f"Starting [bold cyan]{pokebot_name} {pokebot_version}![/]")
     gui = PokebotGui(main_loop, on_exit)
     context.gui = gui
-    gui.run(preselected_profile)
+    gui.run(startup_settings)


### PR DESCRIPTION
Adds some more option, probably mostly useful when testing a lot.

The 'always on top' option was requested by Johnny and easy to implement, so why not.

```
usage: pokebot.py [-h] [-m {manual,spin,starters,fishing,bunny_hop}] [-s {0,1,2,3,4}] [-nv] [-na] [-t] [-d] [profile]

PokéBot dev-da3d11b

positional arguments:
  profile               Profile to initialize. Otherwise, the profile selection menu will appear.

options:
  -h, --help            show this help message and exit
  -m {manual,spin,starters,fishing,bunny_hop}, --bot-mode {manual,spin,starters,fishing,bunny_hop}
                        Initial bot mode (default: manual.)
  -s {0,1,2,3,4}, --emulation-speed {0,1,2,3,4}
                        Initial emulation speed (0 for unthrottled; default: 1.)
  -nv, --no-video       Turn off video output by default.
  -na, --no-audio       Turn off audio output by default.
  -t, --always-on-top   Keep the bot window always on top of other windows.
  -d, --debug           Enable extra debug options and a debug menu.
```