### PR TITLE
Fix Rom file loading

### DIFF
--- a/modules/gui/create_profile_screen.py
+++ b/modules/gui/create_profile_screen.py
@@ -130,7 +130,7 @@ class CreateProfileScreen:
         entry.grid(column=1, row=0, sticky="EW")
         entry.bind('<Control-a>', lambda e: self.window.after(50, select_all, e.widget))
 
-        available_roms = list_available_roms()
+        available_roms = list_available_roms(force_recheck=True)
         rom_names = []
         for rom in available_roms:
             rom_names.append(rom.short_game_name)

--- a/modules/roms.py
+++ b/modules/roms.py
@@ -131,7 +131,7 @@ def list_available_roms(force_recheck: bool = False) -> list[ROM]:
         for file in ROMS_DIRECTORY.iterdir():
             if file.is_file():
                 try:
-                    rom_cache.append(load_rom_data(file))
+                    load_rom_data(file)
                 except InvalidROMError:
                     pass
 


### PR DESCRIPTION
This fixes two bugs

First Bug is that once the bot has profiles, only the roms registered in those profiles will be shown when creating a new Profile.

Second bug is that when loading the Rome Cash list every Rom was added twice once in `list_available_roms()` which calls `load_rom_data()` also adds it to the cache