### PR TITLE
Fix issue that prevented all ROMs from being loaded properly, improve Tasks debug tab

### DIFF
--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -199,11 +199,18 @@ class TasksTab(DebugTab):
         callback1 = read_symbol("gMain", 0, 4)
         callback2 = read_symbol("gMain", 4, 4)
 
-        cb1_addr = unpack_uint32(callback1) - 1
-        cb2_addr = unpack_uint32(callback2) - 1
+        cb1_addr = max(0, unpack_uint32(callback1) - 1)
+        cb2_addr = max(0, unpack_uint32(callback2) - 1)
 
-        self._cb1_label.config(text=get_symbol_name(cb1_addr, pretty_name=True))
-        self._cb2_label.config(text=get_symbol_name(cb2_addr, pretty_name=True))
+        cb1_symbol = get_symbol_name(cb1_addr, pretty_name=True)
+        if cb1_symbol == "":
+            cb1_symbol = hex(cb1_addr)
+        cb2_symbol = get_symbol_name(cb1_addr, pretty_name=True)
+        if cb2_symbol == "":
+            cb2_symbol = hex(cb2_addr)
+
+        self._cb1_label.config(text=cb1_symbol)
+        self._cb2_label.config(text=cb2_symbol)
 
         data = {}
         index = 0

--- a/modules/memory.py
+++ b/modules/memory.py
@@ -82,7 +82,7 @@ def parse_tasks(pretty_names: bool = False) -> list:
         for x in range(16):
             name = get_symbol_name(unpack_uint32(gTasks[(x * 40) : (x * 40 + 4)]) - 1, pretty_names)
             if name == "":
-                name = str(gTasks[(x * 40) : (x * 40 + 4)])
+                name = "0x" + gTasks[(x * 40) : (x * 40 + 4)].hex()
             tasks.append(
                 {
                     "func": name,

--- a/modules/roms.py
+++ b/modules/roms.py
@@ -104,7 +104,7 @@ class InvalidROMError(Exception):
     pass
 
 
-rom_cache: list[ROM] = []
+rom_cache: dict[str, ROM] = {}
 
 
 def list_available_roms(force_recheck: bool = False) -> list[ROM]:
@@ -123,27 +123,29 @@ def list_available_roms(force_recheck: bool = False) -> list[ROM]:
     :return: List of all the valid ROMS that have been found
     """
     global rom_cache
-    if force_recheck or len(rom_cache) == 0:
-        if not ROMS_DIRECTORY.is_dir():
-            raise RuntimeError(f"Directory {str(ROMS_DIRECTORY)} does not exist!")
 
+    if force_recheck:
         rom_cache.clear()
-        for file in ROMS_DIRECTORY.iterdir():
-            if file.is_file():
+
+    if not ROMS_DIRECTORY.is_dir():
+        raise RuntimeError(f"Directory {str(ROMS_DIRECTORY)} does not exist!")
+
+    for file in ROMS_DIRECTORY.iterdir():
+        if file.is_file():
+            if force_recheck or str(file) not in rom_cache:
                 try:
-                    rom_cache.append(load_rom_data(file))
+                    rom_cache[str(file)] = load_rom_data(file)
                 except InvalidROMError:
                     pass
 
-    return rom_cache
+    return list(rom_cache.values())
 
 
 def load_rom_data(file: Path) -> ROM:
     # Prefer cached data so we can skip the expensive stuff below
     global rom_cache
-    for rom in rom_cache:
-        if rom.file == file:
-            return rom
+    if str(file) in rom_cache:
+        return rom_cache[str(file)]
 
     # GBA cartridge headers are 0xC0 bytes long, so any files smaller than that cannot be a ROM
     if file.stat().st_size < 0xC0:
@@ -179,6 +181,6 @@ def load_rom_data(file: Path) -> ROM:
             game_name += f" (Rev {revision})"
 
         rom = ROM(file, game_name, game_title, game_code[:3], ROMLanguage(game_code[3]), maker_code, revision)
-        rom_cache.append(rom)
+        rom_cache[str(file)] = rom
 
         return rom

--- a/modules/roms.py
+++ b/modules/roms.py
@@ -130,15 +130,15 @@ def list_available_roms(force_recheck: bool = False) -> list[ROM]:
     if not ROMS_DIRECTORY.is_dir():
         raise RuntimeError(f"Directory {str(ROMS_DIRECTORY)} does not exist!")
 
+    result = []
     for file in ROMS_DIRECTORY.iterdir():
         if file.is_file():
-            if force_recheck or str(file) not in rom_cache:
-                try:
-                    rom_cache[str(file)] = load_rom_data(file)
-                except InvalidROMError:
-                    pass
+            try:
+                result.append(load_rom_data(file))
+            except InvalidROMError:
+                pass
 
-    return list(rom_cache.values())
+    return result
 
 
 def load_rom_data(file: Path) -> ROM:


### PR DESCRIPTION
This fixes an issue with the ROM cache that prevented the full list of ROMs from being loaded after the profiles selection screen has been shown.

It also updates the Tasks debug tab so that is shows the hex address of callbacks and task functions if no symbol could be found -- which will make it a bit easier to find those offsets in other locales.