### PR TITLE
Expose some emulator info via the web server

### DIFF
--- a/modules/http.py
+++ b/modules/http.py
@@ -3,6 +3,7 @@ from flask import Flask, abort, jsonify
 
 from modules.config import config
 from modules.console import console
+from modules.context import context
 from modules.items import get_items
 from modules.pokemon import get_party
 from modules.stats import get_encounter_rate, encounter_log, stats, shiny_log
@@ -98,6 +99,37 @@ def http_server() -> None:
             except:
                 console.print_exception(show_locals=True)
                 abort(503)
+
+        @server.route("/emulator", methods=["GET"])
+        def http_get_emulator():
+            if context.emulator is None:
+                return jsonify(None)
+            else:
+                return jsonify({
+                    "emulation_speed": context.emulation_speed,
+                    "video_enabled": context.video,
+                    "audio_enabled": context.audio,
+                    "bot_mode": context.bot_mode,
+                    "current_message": context.message,
+                    "frame_count": context.emulator.get_frame_count(),
+                    "current_fps": context.emulator.get_current_fps(),
+                    "profile": {
+                        "name": context.profile.path.name
+                    },
+                    "game": {
+                        "title": context.rom.game_title,
+                        "name": context.rom.game_name,
+                        "language": str(context.rom.language),
+                        "revision": context.rom.revision
+                    }
+                })
+
+        @server.route("/fps", methods=["GET"])
+        def http_get_fps():
+            if context.emulator is None:
+                return jsonify(None)
+            else:
+                return jsonify(list(reversed(context.emulator._performance_tracker.fps_history)))
 
         server.run(
             debug=False,

--- a/modules/http.py
+++ b/modules/http.py
@@ -113,6 +113,7 @@ def http_server() -> None:
                     "current_message": context.message,
                     "frame_count": context.emulator.get_frame_count(),
                     "current_fps": context.emulator.get_current_fps(),
+                    "current_time_spent_in_bot_fraction": context.emulator.get_current_time_spent_in_bot_fraction(),
                     "profile": {
                         "name": context.profile.path.name
                     },


### PR DESCRIPTION
Adds two new routes:

### `GET /emulator`
```json
{
  "audio_enabled": false,
  "bot_mode": "manual",
  "current_fps": 586,
  "current_message": "",
  "current_time_spent_in_bot_fraction": 0.01400130620263396,
  "emulation_speed": 0,
  "frame_count": 206459,
  "game": {
    "language": "S",
    "name": "Pokémon Emerald (S)",
    "revision": 0,
    "title": "POKEMON EMER"
  },
  "profile": {
    "name": "Spanish"
  },
  "video_enabled": true
}
```

### `GET /fps`

This returns up to 60 seconds of FPS history, with the most recent one being index 0. So the index corresponds to how many seconds ago that FPS was recorded.

```json
[
  870,
  972,
  1179,
  1054,
  844,
  998,
  1037,
  708,
  907,
  245,
  60,
  60,
  60,
  60,
  59,
  60,
  59,
  60,
  60,
  17,
  0,
  0
]
```