### PR TITLE
Windows: Prevent bot mode drop-down from closing whenever the bot message changes

### DIFF
--- a/modules/gui/emulator_controls.py
+++ b/modules/gui/emulator_controls.py
@@ -56,11 +56,6 @@ class EmulatorControls:
         if self.frame is None:
             return
 
-        # This avoids any other GUI element from having the focus. We don't want that because
-        # for example if the bot mode combobox is focussed, pressing Down might open the
-        # dropdown menu.
-        self.window.focus()
-
         if self.bot_mode_combobox.get() != context.bot_mode:
             self.bot_mode_combobox.current(available_bot_modes.index(context.bot_mode))
             self.last_known_bot_mode = context.bot_mode


### PR DESCRIPTION
This was caused by a `window.focus()` call that 'stole' the focus from the drop-down menu.

I didn't notice any detrimental change after removing the call, so that was probably just an outdated workaround.

The problem this was trying to solve is that when the drop-down was still in focus, pressing the Down key would re-open the menu (same with the Tab key, which would move the focus to the next button, or the Space key 'pressing' the currently focussed button.)

For that purpose, the GUI's `_handle_key_down_event` method returns `"break"` which stops propagation of the event (see [Tk docs](https://www.tcl.tk/man/tcl8.2.3/TkCmd/bind.html#M41) on the matter.) That workaround is never than the `window.focus()` call, which seems to have been made redundant by it.