### PR TITLE
Catch PortAudio errors when toggling throttle

### DIFF
--- a/modules/libmgba.py
+++ b/modules/libmgba.py
@@ -313,10 +313,19 @@ class LibmgbaEmulator:
         self._throttled = is_throttled
 
         if self._audio_stream is not None:
-            if is_throttled and not was_throttled:
-                self._audio_stream.start()
-            elif not is_throttled and was_throttled:
-                self._audio_stream.stop()
+            try:
+                if is_throttled and not was_throttled:
+                    self._audio_stream.start()
+                elif not is_throttled and was_throttled:
+                    self._audio_stream.stop()
+            except sounddevice.PortAudioError as error:
+                if was_throttled:
+                    action = 'disabling'
+                else:
+                    action = 'enabling'
+
+                console.print(f"[bold red]Error while {action} audio:[/] [red]{str(error)}[/]")
+                self._reset_audio()
 
     def get_speed_factor(self) -> float:
         return self._speed_factor


### PR DESCRIPTION
(This fixes an issue that was reported by Story Zealot in the Discord.)

Toggling the emulator throttle enables or disables sound.

If an error occurred during these actions, we did not catch it and the user would see a lengthy exception report.

This adds the same error handling that we're already using for regular playback code.