### PR TITLE
Add support for Ubuntu 23.10

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ The bot is frame perfect and can cheat by reading data from any point in memory.
 
 - Windows (**64-bit**)
 - Linux (**64-bit**)
-  - Note: only tested and confirmed working on **Ubuntu 23.04** and **Debian 12**
+  - Note: only tested and confirmed working on **Ubuntu 23.04, 23.10** and **Debian 12**
 
 ### Download the Bot
 To download the latest bot from GitHub, go to the top of the page > click the green **Code** button > **Download ZIP**.

--- a/modules/gui/__init__.py
+++ b/modules/gui/__init__.py
@@ -118,13 +118,13 @@ class PokebotGui:
 
     def _enable_create_profile_screen(self) -> None:
         self._reset_screen()
-        self._create_profile_screen.enable()
         self._current_screen = self._create_profile_screen
+        self._create_profile_screen.enable()
 
     def _enable_select_profile_screen(self) -> None:
         self._reset_screen()
-        self._select_profile_screen.enable()
         self._current_screen = self._select_profile_screen
+        self._select_profile_screen.enable()
 
     def _run_profile(self, profile: "Profile") -> None:
         self._reset_screen()
@@ -139,8 +139,8 @@ class PokebotGui:
             context.debug = self._startup_settings.debug
             context.bot_mode = self._startup_settings.bot_mode
 
-        self._emulator_screen.enable()
         self._current_screen = self._emulator_screen
+        self._emulator_screen.enable()
         self._main_loop()
 
     def _handle_key_down_event(self, event):

--- a/modules/gui/create_profile_screen.py
+++ b/modules/gui/create_profile_screen.py
@@ -17,7 +17,7 @@ class CreateProfileScreen:
         self.window = window
         self.enable_profile_selection_screen = enable_profile_selection_screen
         self.run_profile = run_profile
-        self.frame: Union[ttk.Frame, None] = None
+        self.frame: ttk.Frame | None = None
 
     def enable(self) -> None:
         self.window.rowconfigure(0, weight=1)

--- a/requirements.py
+++ b/requirements.py
@@ -120,7 +120,7 @@ def update_requirements(ask_for_confirmation: bool = True) -> bool:
 
             case "Linux":
                 linux_release = platform.freedesktop_os_release()
-                supported_linux_releases = [("ubuntu", "23.04"), ("debian", "12")]
+                supported_linux_releases = [("ubuntu", "23.04"), ("ubuntu", "23.10"), ("debian", "12")]
                 if (linux_release["ID"], linux_release["VERSION_ID"]) not in supported_linux_releases:
                     print(
                         f'You are running an untested version of Linux ({linux_release["PRETTY_NAME"]}). '


### PR DESCRIPTION
The bot works without issues on recently released Ubuntu 23.10.

This adds it to the whitelist of Linux distributions.

It also fixes a visual glitch where the 'create profile' screen would still be visible in the background after creating a new profile from the first run (Birch) view.