### PR TITLE
Fix 'audio' button not being enabled when shiny is encountered

### DIFF
--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -73,9 +73,8 @@ def encounter_pokemon(pokemon: Pokemon) -> None:
                     return
 
             context.bot_mode = "Manual"
-            context.emulator.set_speed_factor(1)
-            context.emulator.set_throttle(True)
-            context.emulator.set_video_enabled(True)
+            context.emulation_speed = 1
+            context.video = True
 
             if alert_title is not None and alert_message is not None:
                 desktop_notification(title=alert_title, message=alert_message)


### PR DESCRIPTION
This was reported by Johnny on the discord.

The encounter handler configures the emulator directly (turning on video, enabling throttle to 1×) without going through the context/GUI, which means that the button states never get updated.

(The audio button is disabled when in unthrottled mode, so you couldn't turn off the sound again once it started blaring during the shiny encounter. Devious.)