### PR TITLE
[webhook] webhook for custom filter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -540,11 +540,11 @@ All HTTP responses are in JSON format.
 <details>
 <summary>Click to expand</summary>
 
-All Pokémon encounters are checked by custom catch filters, use this file if you are after a very Pokémon that match very specific criteria, some examples are provided (most are disabled by default).
+All Pokémon encounters are checked by custom catch filters, use this file if you are after Pokémon that match very specific criteria, some examples are provided (most are disabled by default).
 
-These filters are checked *after* the catch block list, so if Wurmple is on your catch block list, the Wurmple evolution examples will still be checked.
+These filters are checked *after* the catch block list, so if Wurmple is on your [catch block list](#catchblockyml---catch-block-config), the Wurmple evolution example below will still be checked.
 
-If you are not familiar with Python, it is highly recommended to use an IDE such as [PyCharm](https://www.jetbrains.com/pycharm/) to edit this file as any syntax errors will be highlighted, and the `pokemon` object will auto-complete/show available parameters to filter on.
+If you are not familiar with Python, it is highly recommended to use an IDE such as [PyCharm](https://www.jetbrains.com/pycharm/) to edit this file as any syntax errors will be highlighted, and the `pokemon` object will auto-complete and show available parameters for you to filter on.
 
 - `return "any message"` (string) - will command the bot to catch the current encounter, the string returned will be added to the Discord webhook if `custom_filter_pokemon_encounter` is enabled in [discord.yml](#discordyml---discord-integration-config)
 - `pass` - will skip the check, and continue to check other criteria further down the file

--- a/Readme.md
+++ b/Readme.md
@@ -416,6 +416,8 @@ Each webhook type also supports pinging @users or @roles.
 
 ![Discord_G2hvTZG21a](https://github.com/40Cakes/pokebot-gen3/assets/16377135/3f04d1cf-4040-4163-80d2-13cac84eed1f)
 
+`custom_filter_pokemon_encounter` - [Custom catch filter](#customcatchfilterspy---custom-catch-filters) encounters
+
 </details>
 
 ## `catch_block.yml` - Catch block config
@@ -530,6 +532,43 @@ All HTTP responses are in JSON format.
 `GET /emulator` returns information about the emulator core + the current loaded game/profile
 
 `GET /fps` returns a list of emulator FPS (frames per second), in intervals of 1 second, for the previous 60 seconds
+
+</details>
+
+## `customcatchfilters.py` - Custom catch filters
+
+<details>
+<summary>Click to expand</summary>
+
+All Pokémon encounters are checked by custom catch filters, use this file if you are after a very Pokémon that match very specific criteria, some examples are provided (most are disabled by default).
+
+These filters are checked *after* the catch block list, so if Wurmple is on your catch block list, the Wurmple evolution examples will still be checked.
+
+If you are not familiar with Python, it is highly recommended to use an IDE such as [PyCharm](https://www.jetbrains.com/pycharm/) to edit this file as any syntax errors will be highlighted, and the `pokemon` object will auto-complete/show available parameters to filter on.
+
+- `return "any message"` (string) - will command the bot to catch the current encounter, the string returned will be added to the Discord webhook if `custom_filter_pokemon_encounter` is enabled in [discord.yml](#discordyml---discord-integration-config)
+- `pass` - will skip the check, and continue to check other criteria further down the file
+- `save_pk3(pokemon)` instead of `return "any message"` will [dump a .pk3 file](#save-raw-pokémon-data-pk3) and continue without pausing the bot until auto-catch is ready
+
+The following example will catch any shiny Wurmple that will evolve into Silcoon/Beautifly, and ignore any that would evolve into Cascoon/Dustox:
+
+```py
+# Shiny Wurmple evolving based on evolution
+if pokemon.is_shiny and pokemon.species.name == "Wurmple":
+    if pokemon.wurmple_evolution == "silcoon":
+        return "Shiny Wurmple evolving into Silcoon/Beautifly"
+    if pokemon.wurmple_evolution == "cascoon":
+        pass
+```
+
+The following example will catch any Pokémon with all perfect IVs:
+```py
+# Pokémon with perfect IVs
+if pokemon.ivs.sum() == (6 * 31):
+    return "Pokémon with perfect IVs"
+```
+
+- **Note**: you must restart the bot after editing this file for changes to take effect!
 
 </details>
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -144,6 +144,16 @@ properties:
                     - ~
                     - user
                     - role
+    custom_filter_pokemon_encounter:
+        type: object
+        properties:
+            enable:
+                type: boolean
+            ping_mode:
+                enum:
+                    - ~
+                    - user
+                    - role
 """
 
 obs_schema = """

--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -34,7 +34,8 @@ def encounter_pokemon(pokemon: Pokemon) -> None:
     context.message = f"Encountered a {pokemon.species.name} with a shiny value of {pokemon.shiny_value:,}!"
 
     # TODO temporary until auto-catch is ready
-    custom_found = total_stats.custom_catch_filters(pokemon)
+    custom_filter_matched = total_stats.custom_catch_filters(pokemon)
+    custom_found = custom_filter_matched != total_stats.CustomFilterMatched.NONE
     if pokemon.is_shiny or custom_found:
         if pokemon.is_shiny:
             if not config["logging"]["save_pk3"]["all"] and config["logging"]["save_pk3"]["shiny"]:
@@ -51,10 +52,10 @@ def encounter_pokemon(pokemon: Pokemon) -> None:
                 save_pk3(pokemon)
             state_tag = "customfilter"
             console.print("[bold green]Custom filter Pokemon found!")
-            context.message = "Custom filter triggered! Bot has been switched to manual mode so you can catch it."
+            context.message = f"Custom filter triggered ({custom_filter_matched})! Bot has been switched to manual mode so you can catch it."
 
             alert_title = "Custom filter triggered!"
-            alert_message = f"Found a {pokemon.species.name} that matched one of your filters."
+            alert_message = f"Found a {pokemon.species.name} that matched one of your filters. ({custom_filter_matched})"
         else:
             state_tag = ""
             alert_title = None

--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -30,12 +30,13 @@ def encounter_pokemon(pokemon: Pokemon) -> None:
         config_catch_block = load_config("catch_block.yml", catch_block_schema)
         block_list = config_catch_block["block_list"]
 
-    total_stats.log_encounter(pokemon, block_list)
+    custom_filter_result = total_stats.custom_catch_filters(pokemon)
+    custom_found = isinstance(custom_filter_result, str)
+
+    total_stats.log_encounter(pokemon, block_list, custom_filter_result)
     context.message = f"Encountered a {pokemon.species.name} with a shiny value of {pokemon.shiny_value:,}!"
 
     # TODO temporary until auto-catch is ready
-    custom_filter_matched = total_stats.custom_catch_filters(pokemon)
-    custom_found = custom_filter_matched != total_stats.CustomFilterMatched.NONE
     if pokemon.is_shiny or custom_found:
         if pokemon.is_shiny:
             if not config["logging"]["save_pk3"]["all"] and config["logging"]["save_pk3"]["shiny"]:
@@ -52,10 +53,10 @@ def encounter_pokemon(pokemon: Pokemon) -> None:
                 save_pk3(pokemon)
             state_tag = "customfilter"
             console.print("[bold green]Custom filter Pokemon found!")
-            context.message = f"Custom filter triggered ({custom_filter_matched})! Bot has been switched to manual mode so you can catch it."
+            context.message = f"Custom filter triggered ({custom_filter_result})! Bot has been switched to manual mode so you can catch it."
 
             alert_title = "Custom filter triggered!"
-            alert_message = f"Found a {pokemon.species.name} that matched one of your filters. ({custom_filter_matched})"
+            alert_message = f"Found a {pokemon.species.name} that matched one of your filters. ({custom_filter_result})"
         else:
             state_tag = ""
             alert_title = None

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -8,7 +8,7 @@ from threading import Thread
 from datetime import datetime
 
 from modules.config import config
-from modules.console import console, print_stats
+from modules.console import print_stats
 from modules.context import context
 from modules.csv import log_encounter_to_csv
 from modules.files import read_file, write_file
@@ -37,17 +37,13 @@ class TotalStats:
             }
 
             if (self.config_dir_path / "customcatchfilters.py").is_file():
-                custom_catch_filters_module = importlib.import_module(
+                self.custom_catch_filters = importlib.import_module(
                     ".customcatchfilters", f"profiles.{context.profile.path.name}"
-                )
-                self.custom_catch_filters = custom_catch_filters_module.custom_catch_filters
-                self.CustomFilterMatched = custom_catch_filters_module.CustomFilterMatched
+                ).custom_catch_filters
             else:
                 from profiles.customcatchfilters import custom_catch_filters
-                from profiles.customcatchfilters import CustomFilterMatched
 
                 self.custom_catch_filters = custom_catch_filters
-                self.CustomFilterMatched = CustomFilterMatched
 
             if (self.config_dir_path / "customhooks.py").is_file():
                 self.custom_hooks = importlib.import_module(
@@ -306,13 +302,13 @@ class TotalStats:
             },
         }
 
-    def log_encounter(self, pokemon: Pokemon, block_list: list) -> None:
+    def log_encounter(self, pokemon: Pokemon, block_list: list, custom_filter_result: str | bool) -> None:
         if "pokemon" not in self.total_stats:
             self.total_stats["pokemon"] = {}
         if "totals" not in self.total_stats:
             self.total_stats["totals"] = {}
 
-        if not pokemon.species.name in self.total_stats["pokemon"]:  # Set up a Pokémon stats if first encounter
+        if pokemon.species.name not in self.total_stats["pokemon"]:  # Set up a Pokémon stats if first encounter
             self.total_stats["pokemon"].update({pokemon.species.name: {}})
 
         self.update_incremental_stats(pokemon)
@@ -348,12 +344,11 @@ class TotalStats:
         print_stats(self.total_stats, pokemon, self.session_pokemon, self.get_encounter_rate())
 
         # Run custom code in custom_hooks in a thread
-        custom_filter_matched = total_stats.custom_catch_filters(pokemon)
         hook = (
             Pokemon(pokemon.data),
             copy.deepcopy(self.total_stats),
             copy.deepcopy(block_list),
-            (custom_filter_matched != total_stats.CustomFilterMatched.NONE, custom_filter_matched)
+            copy.deepcopy(custom_filter_result)
         )
         Thread(target=self.custom_hooks, args=(hook,)).start()
 

--- a/profiles/customcatchfilters.py
+++ b/profiles/customcatchfilters.py
@@ -1,41 +1,21 @@
-# TODO add list of available fields to filter on
-from enum import StrEnum
 from modules.console import console
 from modules.files import save_pk3
 from modules.pokemon import Pokemon
 
 
-class CustomFilterMatched(StrEnum):
-    """
-    Enum class to get which custom filter was matched
-    Add your custom filters down below
-    """
-    NONE = "No filter matched"
-    UNKNOWN = "Unknown filter matched"
-    SHINY_SILCOON_OR_BEAUTIFLY = "Shiny Wurmple evolving into Silcoon/Beautifly"
-    SHINY_CASCOON_OR_DUSTOX = "Shiny Wurmple evolving into Cascoon/Dustox"
-    PERFECT_IVS = "Pokémon with perfect ivs"
-    ZERO_IVS = "Pokémon with all IVs to 0"
-    SIX_IDENTICAL_IVS = "Pokémon with 6 identical IVs of any value"
-    FOUR_OR_MORE_MAX_IVS = "Pokémon with 4 or more max IVs in any stat"
-    IVS_GREATER_EQUAL_170 = "Pokémon with IVs sum greater or equal to 170"
-    POOCHYENA_PECHA_BERRY = "Poochyena holding a pecha berry"
-    PERFECT_ATK_SPATK_SPD = "Pokémon with perfect attack, spAttack and speed"
-
-
-def custom_catch_filters(pokemon: Pokemon) -> CustomFilterMatched:
+def custom_catch_filters(pokemon: Pokemon) -> str | bool:
     """
     Check the current encounter, catch if it matches any of the following criteria.
     Some examples are provided (most are disabled by default).
     These filters are checked *after* catch block list, so if Wurmple is on your catch block list, the Wurmple evolution
     examples below will still be checked.
+    If you use an IDE such as PyCharm, the pokemon class will auto-complete/show available options to filter on
 
-    This function returns a CustomFilterMatched, a string enum giving details on the filter that matched.
-    If you do not want to give detail on the filter that matched, you can use `return CustomFilterMatched.UNKNOWN`
-    - `return CustomFilterMatched.XXXX` will command the bot to catch the current encounter (Where XXXX is an enum case from CustomFilterMatched not equal CustomFilterMatched.NONE)
+    - return "any message" - will command the bot to catch the current encounter, the string returned will be added to
+    the Discord webhook if `custom_filter_pokemon_encounter` is enabled in discord.yml
     - `pass` - will skip the check, and continue to check other criteria further down this file
-    - `save_pk3(pokemon)` instead of `return CustomFilterMatched.XXXX` will dump a .pk3 file and continue without pausing the bot until
-    auto-catch is ready
+    - `save_pk3(pokemon)` instead of `return "any message"` will dump a .pk3 file and continue without pausing the bot
+    until auto-catch is ready
 
     Note: you must restart the bot after editing this file for changes to take effect!
 
@@ -97,53 +77,56 @@ def custom_catch_filters(pokemon: Pokemon) -> CustomFilterMatched:
         ]
 
         if pokemon.species.name not in exceptions:
-            # Catch shiny Wurmple based on evolution
+            # Shiny Wurmple evolving based on evolution
             if pokemon.is_shiny and pokemon.species.name == "Wurmple":
                 evolution = "Silcoon/Beautifly" if pokemon.wurmple_evolution == "silcoon" else "Cascoon/Dustox"
                 if evolution == "Silcoon/Beautifly":
-                    pass  # ❌ disabled
-                    # return CustomFilterMatched.SHINY_SILCOON_OR_BEAUTIFLY
+                    # return "Shiny Wurmple evolving into Silcoon/Beautifly"
+                    pass
                 if evolution == "Cascoon/Dustox":
-                    pass  # ❌ disabled
-                    # return CustomFilterMatched.SHINY_CASCOON_OR_DUSTOX
+                    # return "Shiny Wurmple evolving into Cascoon/Dustox"
+                    pass
 
-            # Catch perfect IV Pokémon
+            # Pokémon with perfect IVs
             if pokemon.ivs.sum() == (6 * 31):
-                return CustomFilterMatched.PERFECT_IVS  # ✅ enabled
+                return "Pokémon with perfect IVs"
+                #pass
 
-            # Catch zero IV Pokémon
+            # Pokémon with all 0 IVs
             if pokemon.ivs.sum() == 0:
-                return CustomFilterMatched.ZERO_IVS # ✅ enabled
+                return "Pokémon with all 0 IVs"
+                #pass
 
-            # Catch Pokémon with 6 identical IVs of any value
+            # Pokémon with 6 identical IVs of any value
             if all(v == ivs[0] for v in ivs):
-                return CustomFilterMatched.SIX_IDENTICAL_IVS # ✅ enabled
+                return "Pokémon with 6 identical IVs of any value"
+                #pass
 
-            # Catch Pokémon with 4 or more max IVs in any stat
+            # Pokémon with 4 or more max IVs in any stat
             max_ivs = sum(1 for v in ivs if v == 31)
             if max_ivs > 4:
-                pass  # ❌ disabled
-                # return CustomFilterMatched.FOUR_OR_MORE_MAX_IVS
+                # return "Pokémon with 4 or more max IVs in any stat"
+                pass
 
-            # Catch Pokémon with a good IV sum of greater than or equal to 170
+            # Pokémon with IVs sum greater or equal to 170
             if pokemon.ivs.sum() >= 170:
-                pass  # ❌ disabled
-                # return CustomFilterMatched.IVS_GREATER_EQUAL_170
+                # return "Pokémon with IVs sum greater or equal to 170"
+                pass
 
-            # Catch all Poochyena with a Pecha Berry
+            # Poochyena holding a Pecha Berry
             if pokemon.species.name == "Poochyena" and pokemon.held_item and pokemon.held_item.name == "Pecha Berry":
-                pass  # ❌ disable
-                # return CustomFilterMatched.POOCHYENA_PECHA_BERRY
+                # return "Poochyena holding a Pecha Berry"
+                pass
 
-            # Catch any Pokémon with perfect attack, spAttack and speed
+            # Pokémon with perfect attack, spAttack and speed
             if pokemon.ivs.attack == 31 and pokemon.ivs.special_attack == 31 and pokemon.ivs.speed == 31:
-                pass  # ❌ disable
-                # return CustomFilterMatched.PERFECT_ATK_SPATK_SPD
+                # return "Pokémon with perfect attack, spAttack and speed"
+                pass
 
         ### Edit above this line ###
 
-        return CustomFilterMatched.NONE
+        return False
     except:
         console.print_exception(show_locals=True)
         console.print("[red bold]Failed to check Pokemon, potentially due to invalid custom catch filter...")
-        return CustomFilterMatched.NONE
+        return False

--- a/profiles/customcatchfilters.py
+++ b/profiles/customcatchfilters.py
@@ -5,19 +5,7 @@ from modules.pokemon import Pokemon
 
 def custom_catch_filters(pokemon: Pokemon) -> str | bool:
     """
-    Check the current encounter, catch if it matches any of the following criteria.
-    Some examples are provided (most are disabled by default).
-    These filters are checked *after* catch block list, so if Wurmple is on your catch block list, the Wurmple evolution
-    examples below will still be checked.
-    If you use an IDE such as PyCharm, the pokemon class will auto-complete/show available options to filter on
-
-    - return "any message" - will command the bot to catch the current encounter, the string returned will be added to
-    the Discord webhook if `custom_filter_pokemon_encounter` is enabled in discord.yml
-    - `pass` - will skip the check, and continue to check other criteria further down this file
-    - `save_pk3(pokemon)` instead of `return "any message"` will dump a .pk3 file and continue without pausing the bot
-    until auto-catch is ready
-
-    Note: you must restart the bot after editing this file for changes to take effect!
+    See readme for documentation: https://github.com/40Cakes/pokebot-gen3#customcatchfilterspy---custom-catch-filters
 
     :param pokemon: Pokémon object of the current encounter
     """
@@ -79,11 +67,10 @@ def custom_catch_filters(pokemon: Pokemon) -> str | bool:
         if pokemon.species.name not in exceptions:
             # Shiny Wurmple evolving based on evolution
             if pokemon.is_shiny and pokemon.species.name == "Wurmple":
-                evolution = "Silcoon/Beautifly" if pokemon.wurmple_evolution == "silcoon" else "Cascoon/Dustox"
-                if evolution == "Silcoon/Beautifly":
+                if pokemon.wurmple_evolution == "silcoon":
                     # return "Shiny Wurmple evolving into Silcoon/Beautifly"
                     pass
-                if evolution == "Cascoon/Dustox":
+                if pokemon.wurmple_evolution == "cascoon":
                     # return "Shiny Wurmple evolving into Cascoon/Dustox"
                     pass
 

--- a/profiles/customcatchfilters.py
+++ b/profiles/customcatchfilters.py
@@ -1,20 +1,40 @@
 # TODO add list of available fields to filter on
-# TODO add option for a Discord webhook when a custom is caught
+from enum import StrEnum
 from modules.console import console
 from modules.files import save_pk3
 from modules.pokemon import Pokemon
 
 
-def custom_catch_filters(pokemon: Pokemon) -> bool:
+class CustomFilterMatched(StrEnum):
+    """
+    Enum class to get which custom filter was matched
+    Add your custom filters down below
+    """
+    NONE = "No filter matched"
+    UNKNOWN = "Unknown filter matched"
+    SHINY_SILCOON_OR_BEAUTIFLY = "Shiny Wurmple evolving into Silcoon/Beautifly"
+    SHINY_CASCOON_OR_DUSTOX = "Shiny Wurmple evolving into Cascoon/Dustox"
+    PERFECT_IVS = "Pokémon with perfect ivs"
+    ZERO_IVS = "Pokémon with all IVs to 0"
+    SIX_IDENTICAL_IVS = "Pokémon with 6 identical IVs of any value"
+    FOUR_OR_MORE_MAX_IVS = "Pokémon with 4 or more max IVs in any stat"
+    IVS_GREATER_EQUAL_170 = "Pokémon with IVs sum greater or equal to 170"
+    POOCHYENA_PECHA_BERRY = "Poochyena holding a pecha berry"
+    PERFECT_ATK_SPATK_SPD = "Pokémon with perfect attack, spAttack and speed"
+
+
+def custom_catch_filters(pokemon: Pokemon) -> CustomFilterMatched:
     """
     Check the current encounter, catch if it matches any of the following criteria.
     Some examples are provided (most are disabled by default).
     These filters are checked *after* catch block list, so if Wurmple is on your catch block list, the Wurmple evolution
     examples below will still be checked.
 
-    - `return True` will command the bot to catch the current encounter
+    This function returns a CustomFilterMatched, a string enum giving details on the filter that matched.
+    If you do not want to give detail on the filter that matched, you can use `return CustomFilterMatched.UNKNOWN`
+    - `return CustomFilterMatched.XXXX` will command the bot to catch the current encounter (Where XXXX is an enum case from CustomFilterMatched not equal CustomFilterMatched.NONE)
     - `pass` - will skip the check, and continue to check other criteria further down this file
-    - `save_pk3(pokemon)` instead of `return True` will dump a .pk3 file and continue without pausing the bot until
+    - `save_pk3(pokemon)` instead of `return CustomFilterMatched.XXXX` will dump a .pk3 file and continue without pausing the bot until
     auto-catch is ready
 
     Note: you must restart the bot after editing this file for changes to take effect!
@@ -82,42 +102,48 @@ def custom_catch_filters(pokemon: Pokemon) -> bool:
                 evolution = "Silcoon/Beautifly" if pokemon.wurmple_evolution == "silcoon" else "Cascoon/Dustox"
                 if evolution == "Silcoon/Beautifly":
                     pass  # ❌ disabled
+                    # return CustomFilterMatched.SHINY_SILCOON_OR_BEAUTIFLY
                 if evolution == "Cascoon/Dustox":
                     pass  # ❌ disabled
+                    # return CustomFilterMatched.SHINY_CASCOON_OR_DUSTOX
 
             # Catch perfect IV Pokémon
             if pokemon.ivs.sum() == (6 * 31):
-                return True  # ✅ enabled
+                return CustomFilterMatched.PERFECT_IVS  # ✅ enabled
 
             # Catch zero IV Pokémon
             if pokemon.ivs.sum() == 0:
-                return True  # ✅ enabled
+                return CustomFilterMatched.ZERO_IVS # ✅ enabled
 
             # Catch Pokémon with 6 identical IVs of any value
             if all(v == ivs[0] for v in ivs):
-                return True  # ✅ enabled
+                return CustomFilterMatched.SIX_IDENTICAL_IVS # ✅ enabled
 
             # Catch Pokémon with 4 or more max IVs in any stat
             max_ivs = sum(1 for v in ivs if v == 31)
             if max_ivs > 4:
                 pass  # ❌ disabled
+                # return CustomFilterMatched.FOUR_OR_MORE_MAX_IVS
 
             # Catch Pokémon with a good IV sum of greater than or equal to 170
             if pokemon.ivs.sum() >= 170:
                 pass  # ❌ disabled
+                # return CustomFilterMatched.IVS_GREATER_EQUAL_170
 
             # Catch all Poochyena with a Pecha Berry
             if pokemon.species.name == "Poochyena" and pokemon.held_item and pokemon.held_item.name == "Pecha Berry":
                 pass  # ❌ disable
+                # return CustomFilterMatched.POOCHYENA_PECHA_BERRY
 
             # Catch any Pokémon with perfect attack, spAttack and speed
             if pokemon.ivs.attack == 31 and pokemon.ivs.special_attack == 31 and pokemon.ivs.speed == 31:
                 pass  # ❌ disable
+                # return CustomFilterMatched.PERFECT_ATK_SPATK_SPD
 
         ### Edit above this line ###
 
-        return False
+        return CustomFilterMatched.NONE
     except:
         console.print_exception(show_locals=True)
         console.print("[red bold]Failed to check Pokemon, potentially due to invalid custom catch filter...")
-        return False
+        return CustomFilterMatched.NONE

--- a/profiles/customhooks.py
+++ b/profiles/customhooks.py
@@ -9,6 +9,7 @@ from modules.context import context
 from modules.discord import discord_message
 from modules.pokemon import Pokemon
 from modules.runtime import get_sprites_path
+from modules.version import pokebot_version
 
 
 def custom_hooks(hook) -> None:
@@ -59,23 +60,28 @@ def custom_hooks(hook) -> None:
 
         def PhaseSummary() -> dict:
             from modules.stats import total_stats  # TODO prevent instantiating TotalStats class before profile selected
+
+            sparkle = "✨" if stats["totals"].get("phase_lowest_sv", -1) < 8 else ""
             return {
-                "Phase Encounters": f"{stats['totals'].get('phase_encounters', 0):,} ({total_stats.get_encounter_rate():,}/h)",
+                "Phase Encounters": f"{stats['totals'].get('phase_encounters', -1):,} ({total_stats.get_encounter_rate():,}/h)",
                 "Phase IV Sum Records": (
-                    f":arrow_up: `{stats['totals'].get('phase_highest_iv_sum', 0):,}` IV {stats['totals'].get('phase_highest_iv_sum_pokemon', 'N/A')}\n"
-                    f":arrow_down: `{stats['totals'].get('phase_lowest_iv_sum', 0):,}` IV {stats['totals'].get('phase_lowest_iv_sum_pokemon', 'N/A')}"
+                    f":arrow_up: `{stats['totals'].get('phase_highest_iv_sum', -1):,}` IV {stats['totals'].get('phase_highest_iv_sum_pokemon', 'N/A')}\n"
+                    f":arrow_down: `{stats['totals'].get('phase_lowest_iv_sum', -1):,}` IV {stats['totals'].get('phase_lowest_iv_sum_pokemon', 'N/A')}"
                 ),
                 "Phase SV Records": (
-                    f":arrow_up: `{stats['totals'].get('phase_highest_sv', 0):,}` SV {stats['totals'].get('phase_highest_sv_pokemon', 'N/A')}\n"
-                    f":arrow_down: `{stats['totals'].get('phase_lowest_sv', 0):,}` SV ✨ {stats['totals'].get('phase_lowest_sv_pokemon', 'N/A')} ✨"
+                    f":arrow_up: `{stats['totals'].get('phase_highest_sv', -1):,}` SV {stats['totals'].get('phase_highest_sv_pokemon', 'N/A')}\n"
+                    f":arrow_down: `{stats['totals'].get('phase_lowest_sv', -1):,}` SV {sparkle}{stats['totals'].get('phase_lowest_sv_pokemon', 'N/A')}{sparkle}"
                 ),
                 "Phase Same Pokémon Streak": (
-                    f"{stats['totals'].get('phase_streak', 0):,} {stats['totals'].get('phase_streak_pokemon', 'N/A')} were encountered in a row!"
+                    f"{stats['totals'].get('phase_streak', -1):,} {stats['totals'].get('phase_streak_pokemon', 'N/A')} were encountered in a row!"
                 ),
                 "Total Encounters": (
-                    f"{stats['totals'].get('encounters', 0):,} ({stats['totals'].get('shiny_encounters', 0):,}✨)"
+                    f"{stats['totals'].get('encounters', -1):,} ({stats['totals'].get('shiny_encounters', -1):,}✨)"
                 ),
             }
+
+        def Footer() -> str:
+            return f"ID: {config['discord']['bot_id']} | {context.rom.game_name}\nPokéBot {pokebot_version}"
 
         try:
             # Discord shiny Pokémon encountered
@@ -109,7 +115,7 @@ def custom_hooks(hook) -> None:
                     }
                     | PhaseSummary(),
                     embed_thumbnail=get_sprites_path() / "pokemon" / "shiny" / f"{pokemon.species.safe_name}.png",
-                    embed_footer=f"PokéBot ID: {config['discord']['bot_id']} | {context.rom.game_name}",
+                    embed_footer=Footer(),
                     embed_color="ffd242",
                 )
         except:
@@ -136,7 +142,7 @@ def custom_hooks(hook) -> None:
                     embed=True,
                     embed_description=f"{stats['pokemon'][pokemon.species.name].get('encounters', 0):,} {pokemon.species.name} encounters!",
                     embed_thumbnail=get_sprites_path() / "pokemon" / "normal" / f"{pokemon.species.safe_name}.png",
-                    embed_footer=f"PokéBot ID: {config['discord']['bot_id']} | {context.rom.game_name}",
+                    embed_footer=Footer(),
                     embed_color="50C878",
                 )
         except:
@@ -164,7 +170,7 @@ def custom_hooks(hook) -> None:
                     embed=True,
                     embed_description=f"{stats['pokemon'][pokemon.species.name].get('shiny_encounters', 0):,} shiny ✨ {pokemon.species.name} ✨ encounters!",
                     embed_thumbnail=get_sprites_path() / "pokemon" / "shiny" / f"{pokemon.species.safe_name}.png",
-                    embed_footer=f"PokéBot ID: {config['discord']['bot_id']} | {context.rom.game_name}",
+                    embed_footer=Footer(),
                     embed_color="ffd242",
                 )
         except:
@@ -211,7 +217,7 @@ def custom_hooks(hook) -> None:
                     embed=True,
                     embed_description=f"{stats['totals'].get('encounters', 0):,} total encounters!",
                     embed_thumbnail=get_sprites_path() / "items" / f"{embed_thumbnail}.png",
-                    embed_footer=f"PokéBot ID: {config['discord']['bot_id']} | {context.rom.game_name}",
+                    embed_footer=Footer(),
                     embed_color="50C878",
                 )
         except:
@@ -246,7 +252,7 @@ def custom_hooks(hook) -> None:
                     content=f"💀 The current phase has reached {stats['totals'].get('phase_encounters', 0):,} encounters!\n{discord_ping}",
                     embed=True,
                     embed_fields=PhaseSummary(),
-                    embed_footer=f"PokéBot ID: {config['discord']['bot_id']} | {context.rom.game_name}",
+                    embed_footer=Footer(),
                     embed_color="D70040",
                 )
         except:
@@ -277,7 +283,7 @@ def custom_hooks(hook) -> None:
                     }
                     | PhaseSummary(),
                     embed_thumbnail=get_sprites_path() / "pokemon" / "anti-shiny" / f"{pokemon.species.safe_name}.png",
-                    embed_footer=f"PokéBot ID: {config['discord']['bot_id']} | {context.rom.game_name}",
+                    embed_footer=Footer(),
                     embed_color="000000",
                 )
         except:
@@ -288,14 +294,14 @@ def custom_hooks(hook) -> None:
             if config["discord"]["custom_filter_pokemon_encounter"]["enable"] and isinstance(custom_filter_result, str):
                 # Discord pings
                 discord_ping = ""
-                match config['discord']['custom_filter_pokemon_encounter']["ping_mode"]:
+                match config["discord"]["custom_filter_pokemon_encounter"]["ping_mode"]:
                     case "role":
                         discord_ping = f"📢 <@&{config['discord']['custom_filter_pokemon_encounter']['ping_id']}>"
                     case "user":
                         discord_ping = f"📢 <@{config['discord']['custom_filter_pokemon_encounter']['ping_id']}>"
 
                 discord_message(
-                    webhook_url=config['discord']['custom_filter_pokemon_encounter'].get("webhook_url", None),
+                    webhook_url=config["discord"]["custom_filter_pokemon_encounter"].get("webhook_url", None),
                     content=f"Encountered a {pokemon.species.name} matching custom filter: `{custom_filter_result}`!\n{discord_ping}",
                     embed=True,
                     embed_title="Encountered Pokémon matching custom catch filter!",
@@ -309,7 +315,7 @@ def custom_hooks(hook) -> None:
                     }
                     | PhaseSummary(),
                     embed_thumbnail=get_sprites_path() / "pokemon" / "normal" / f"{pokemon.species.safe_name}.png",
-                    embed_footer=f"PokéBot ID: {config['discord']['bot_id']} | {context.rom.game_name}",
+                    embed_footer=Footer(),
                     embed_color="6a89cc",
                 )
         except:

--- a/profiles/customhooks.py
+++ b/profiles/customhooks.py
@@ -23,6 +23,7 @@ def custom_hooks(hook) -> None:
         pokemon: Pokemon = hook[0]
         stats = hook[1]
         block_list = hook[2]
+        custom_found, custom_filter_matched = hook[3]
 
         ### Your custom code goes here ###
 
@@ -276,6 +277,46 @@ def custom_hooks(hook) -> None:
                     embed_thumbnail=get_sprites_path() / "pokemon" / "anti-shiny" / f"{pokemon.species.safe_name}.png",
                     embed_footer=f"PokéBot ID: {config['discord']['bot_id']} | {context.rom.game_name}",
                     embed_color="000000",
+                )
+        except:
+            console.print_exception(show_locals=True)
+
+        try:
+            # Discord Pokémon matching custom filter encountered
+            webhook_config = config["discord"]["custom_filter_pokemon_encounter"]
+            if (
+                not pokemon.is_shiny
+                and not pokemon.is_anti_shiny
+                and webhook_config["enable"]
+                and custom_found
+            ):
+                # Discord pings
+                discord_ping = ""
+                match webhook_config["ping_mode"]:
+                    case "role":
+                        discord_ping = f"📢 <@&{webhook_config['ping_id']}>"
+                    case "user":
+                        discord_ping = f"📢 <@{webhook_config['ping_id']}>"
+
+                block = (
+                    "\n❌Skipping catching Pokémon matching custom filter (on catch block list)!" if pokemon.species.name in block_list else ""
+                )
+
+                discord_message(
+                    webhook_url=webhook_config.get("webhook_url", None),
+                    content=f"Encountered a {pokemon.species.name} matching custom filter `{custom_filter_matched}`! {block}\n{discord_ping}",
+                    embed=True,
+                    embed_title="Encountered Pokémon matching custom catch filter!",
+                    embed_description=f"{pokemon.nature.name} {pokemon.species.name} (Lv. {pokemon.level:,}) at {pokemon.location_met}!\nMatching custom filter **{custom_filter_matched}**",
+                    embed_fields={
+                        "Shiny Value": f"{pokemon.shiny_value:,}",
+                        "IVs": IVField(),
+                        "Held item": pokemon.held_item.name if pokemon.held_item else "None",
+                        f"{pokemon.species.name} Encounters": f"{stats['pokemon'][pokemon.species.name].get('encounters', 0):,} ({stats['pokemon'][pokemon.species.name].get('shiny_encounters', 0):,}✨)",
+                    },
+                    embed_thumbnail=get_sprites_path() / "pokemon" / "normal" / f"{pokemon.species.safe_name}.png",
+                    embed_footer=f"PokéBot ID: {config['discord']['bot_id']} | {context.rom.game_name}",
+                    embed_color="6a89cc",
                 )
         except:
             console.print_exception(show_locals=True)

--- a/profiles/discord.yml
+++ b/profiles/discord.yml
@@ -52,3 +52,11 @@ anti_shiny_pokemon_encounter:
   ping_mode:
   ping_id:
   #webhook_url:
+
+
+# Custom filter Pokémon encountered
+custom_filter_pokemon_encounter:
+  enable: false
+  ping_mode:
+  ping_id:
+  #webhook_url:


### PR DESCRIPTION
## Goal of the PR
Add a webhook for custom filters

## How to test?
- Set enable to true in the section `custom_filter_pokemon_encounter` of  the file `discord.yml`
- Enable some of the custom filters in `custom_catch_filters.py`


**Note:**
There is a new way to enable custom filters. Instead of returning a boolean, you can return a `CustomFilterMatched` which allows to know exactly which filter matched. You can return CustomFilterMatched.NONE in case no filters matched, or CustomFilterMatched.UNKNOWN, if you don't want to have the details

### Results you can get from this
![image](https://github.com/40Cakes/pokebot-gen3/assets/73167421/5ddb8335-a276-4feb-89c3-c71d858ed220)
![image](https://github.com/40Cakes/pokebot-gen3/assets/73167421/bad0b3d5-5957-4f73-b162-1083b77d820a)


### Impacts

Changing the return type from a boolean to a CustomFilterMatched may cause some breaking changes if some people already have custom filters for a given profile. Let me know what you think about it.

This also impacts #108 as the discord schema has been updated