### PR TITLE
Fix gBattleTypeFlags for Ruby and Sapphire

### DIFF
--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -1519,7 +1519,7 @@ def opponent_changed() -> bool:
     try:
         global last_opid
         opponent_pid = read_symbol("gEnemyParty", size=4)
-        g_battle_type_flags = read_symbol("gBattleTypeFlags")
+        g_battle_type_flags = read_symbol("gBattleTypeFlags", size=4)
         if (
             opponent_pid != last_opid
             and opponent_pid != b"\x00\x00\x00\x00"


### PR DESCRIPTION
the symbols for Ruby and Sapphire have no size for `gBattleTypeFlags`.
hardcoding the size fixes the bot not detecting any pokemon at all.