### PR TITLE
Add event streaming endpoint to HTTP server

### DIFF
--- a/modules/http.py
+++ b/modules/http.py
@@ -1,12 +1,21 @@
-from flask_cors import CORS
-from flask import Flask, jsonify, request
+import io
+import time
+from pathlib import Path
 
+from flask import Flask, jsonify, request, Response
+from flask_cors import CORS
+
+from modules.config import available_bot_modes
 from modules.context import context
-from modules.items import get_items
-from modules.pokemon import get_party
-from modules.stats import total_stats
 from modules.game import _event_flags
-from modules.memory import get_event_flag, get_game_state
+from modules.http_stream import add_subscriber
+from modules.items import get_items
+from modules.main import work_queue
+from modules.map import get_map_data_for_current_position
+from modules.memory import get_event_flag, get_game_state, GameState
+from modules.pokemon import get_party, get_opponent
+from modules.stats import total_stats
+from modules.state_cache import state_cache
 from modules.trainer import trainer
 
 
@@ -16,6 +25,53 @@ def http_server() -> None:
     """
     server = Flask(__name__)
     CORS(server)
+
+    @server.route("/stream_events", methods=["GET"])
+    def http_get_events_stream():
+        subscribed_topics = request.args.getlist("topic")
+        if len(subscribed_topics) == 0:
+            return Response("You need to provide at least one `topic` parameter in the query.", status=422)
+
+        try:
+            queue, unsubscribe = add_subscriber(subscribed_topics)
+        except ValueError as e:
+            return Response(str(e), status=422)
+
+        def stream():
+            try:
+                yield "retry: 1000\n\n"
+                while True:
+                    yield queue.get()
+                    yield "\n\n"
+            except GeneratorExit:
+                unsubscribe()
+
+        return Response(stream(), mimetype='text/event-stream')
+
+    @server.route("/stream_video", methods=["GET"])
+    def http_get_video_stream():
+        fps = request.args.get("fps", "30")
+        if not fps.isdigit():
+            fps = 30
+        else:
+            fps = int(fps)
+        fps = min(fps, 60)
+
+        def stream():
+            sleep_after_frame = 1 / fps
+            png_data = io.BytesIO()
+            yield "--frame\r\n"
+            while True:
+                if context.video:
+                    png_data.seek(0)
+                    context.emulator.get_current_screen_image().convert("RGB").save(png_data, format="PNG")
+                    png_data.seek(0)
+                    yield "Content-Type: image/png\r\n\r\n"
+                    yield png_data.read()
+                    yield "\r\n--frame\r\n"
+                time.sleep(sleep_after_frame)
+
+        return Response(stream(), mimetype="multipart/x-mixed-replace; boundary=frame")
 
     @server.route("/trainer", methods=["GET"])
     def http_get_trainer():
@@ -27,9 +83,37 @@ def http_server() -> None:
     def http_get_bag():
         return jsonify(get_items())
 
+    @server.route("/map", methods=["GET"])
+    def http_get_map():
+        map_data = get_map_data_for_current_position()
+        return jsonify({
+            "map": map_data.dict_for_map(),
+            "player_position": map_data.local_position,
+            "tiles": map_data.dicts_for_all_tiles(),
+        })
+
     @server.route("/party", methods=["GET"])
     def http_get_party():
-        return jsonify([p.to_dict() for p in get_party()])
+        cached_party = state_cache.party
+        if cached_party.age_in_frames > 5:
+            work_queue.put_nowait(get_party)
+            while cached_party.age_in_frames > 5:
+                time.sleep(0.05)
+
+        return jsonify([p.to_dict() for p in cached_party.value])
+
+    @server.route("/opponent", methods=["GET"])
+    def http_get_opponent():
+        if state_cache.game_state != GameState.BATTLE:
+            result = None
+        else:
+            cached_opponent = state_cache.opponent
+            if cached_opponent.value is not None:
+                result = cached_opponent.value.to_dict()
+            else:
+                result = None
+
+        return jsonify(result)
 
     @server.route("/encounter_log", methods=["GET"])
     def http_get_encounter_log():
@@ -93,7 +177,39 @@ def http_server() -> None:
         else:
             return jsonify(list(reversed(context.emulator._performance_tracker.fps_history)))
 
-    @server.route("/", methods=["GET"])
+    @server.route("/emulator", methods=["POST"])
+    def http_post_emulator():
+        new_settings = request.json
+        if not isinstance(new_settings, dict):
+            return Response("This endpoint expects a JSON object as its payload.", status=422)
+
+        for key in new_settings:
+            if key == "emulation_speed":
+                if new_settings["emulation_speed"] not in [0, 1, 2, 3, 4]:
+                    return Response(
+                        f"Setting `emulation_speed` contains an invalid value ('{new_settings['emulation_speed']}')",
+                        status=422)
+                context.emulation_speed = new_settings["emulation_speed"]
+            elif key == "bot_mode":
+                if new_settings["bot_mode"] not in available_bot_modes:
+                    return Response(
+                        f"Setting `bot_mode` contains an invalid value ('{new_settings['bot_mode']}'). Possible values are: {', '.join(available_bot_modes)}",
+                        status=422)
+                context.bot_mode = new_settings["bot_mode"]
+            elif key == "video_enabled":
+                if not isinstance(new_settings["video_enabled"], bool):
+                    return Response("Setting `video_enabled` did not contain a boolean value.", status=422)
+                context.video = new_settings["video_enabled"]
+            elif key == "audio_enabled":
+                if not isinstance(new_settings["audio_enabled"], bool):
+                    return Response("Setting `audio_enabled` did not contain a boolean value.", status=422)
+                context.audio = new_settings["audio_enabled"]
+            else:
+                return Response(f"Unrecognised setting: '{key}'.", status=422)
+
+        return http_get_emulator()
+
+    @server.route("/routes", methods=["GET"])
     def http_get_routes():
         routes = {}
 
@@ -105,6 +221,12 @@ def http_server() -> None:
         routes.pop("/static/<path:filename>")
 
         return jsonify(routes)
+
+    @server.route("/", methods=["GET"])
+    def http_index():
+        index_file = Path(__file__).parent / "web" / "http_example.html"
+        with open(index_file, "rb") as file:
+            return Response(file.read(), content_type="text/html; charset=utf-8")
 
     server.run(
         debug=False,

--- a/modules/http_stream.py
+++ b/modules/http_stream.py
@@ -1,0 +1,217 @@
+import json
+import queue
+from enum import IntFlag, auto
+from threading import Thread
+from time import sleep, time
+
+from modules.console import console
+from modules.context import context
+from modules.main import work_queue
+from modules.map import get_map_data_for_current_position
+from modules.memory import get_game_state, GameState
+from modules.pokemon import get_party, get_opponent
+from modules.state_cache import state_cache
+from modules.stats import total_stats
+
+update_interval_in_ms = 1000 / 30
+queue_size = 10
+
+
+class DataSubscription(IntFlag):
+    Party = auto()
+    Opponent = auto()
+    GameState = auto()
+    Map = auto()
+    MapTile = auto()
+    BotMode = auto()
+    Message = auto()
+    EmulatorSettings = auto()
+    PerformanceData = auto()
+
+    @classmethod
+    def all_names(cls):
+        return cls.__members__.keys()
+
+
+timer_thread: Thread
+subscribers: list[tuple[int, queue.Queue, int, callable]] = []
+subscriptions = {}
+for name in DataSubscription.all_names():
+    subscriptions[name] = 0
+max_client_id: int = 0
+
+
+def add_subscriber(subscribed_topics: list[str]) -> tuple[queue.Queue:, callable]:
+    for topic in subscribed_topics:
+        if topic not in DataSubscription.all_names():
+            raise ValueError(f"Topic '{topic}' does not exist.")
+
+    global max_client_id
+
+    max_client_id += 1
+    client_id = max_client_id
+
+    def unsubscribe():
+        for index in range(len(subscribers)):
+            if subscribers[index][0] == client_id:
+                global subscriptions
+                for topic in subscribed_topics:
+                    subscriptions[topic] -= 1
+                del subscribers[index]
+                return
+
+    global subscriptions
+    subscription_flags = 0
+    for topic in subscribed_topics:
+        subscription_flags |= getattr(DataSubscription, topic)
+        subscriptions[topic] += 1
+
+    message_queue = queue.Queue(maxsize=queue_size)
+    subscribers.append((client_id, message_queue, subscription_flags, unsubscribe))
+
+    if len(subscribers) == 1:
+        global timer_thread
+        timer_thread = Thread(target=run_watcher)
+        timer_thread.start()
+
+    return message_queue, unsubscribe
+
+
+def run_watcher():
+    from modules.trainer import trainer
+
+    update_interval = update_interval_in_ms / 1000
+    previous_second = int(time())
+    previous_game_state = {
+        "trainer_map": trainer.get_map(),
+        "trainer_local_coords": trainer.get_coords(),
+        "party": state_cache.party.frame,
+        "opponent": state_cache.opponent.frame,
+        "game_state": get_game_state(),
+    }
+    previous_emulator_state = {
+        "bot_mode": context.bot_mode,
+        "emulation_speed": context.emulation_speed,
+        "audio_enabled": context.audio,
+        "video_enabled": context.video,
+        "message": context.message,
+    }
+
+    while len(subscribers) > 0:
+        current_second = int(time())
+        current_game_state = get_game_state()
+
+        if current_second != previous_second and subscriptions["PerformanceData"] > 0:
+            send_message(
+                DataSubscription.PerformanceData,
+                data={
+                    "fps": context.emulator.get_current_fps(),
+                    "frame_count": context.emulator.get_frame_count(),
+                    "current_time_spent_in_bot_fraction": context.emulator.get_current_time_spent_in_bot_fraction(),
+                    "encounter_rate": total_stats.get_encounter_rate(),
+                },
+                event_type="PerformanceData")
+
+        if subscriptions["Party"] > 0:
+            if state_cache.party.age_in_frames >= 60:
+                # If the cached party data is too old, tell the main thread to update it at the next
+                # possible opportunity.
+                work_queue.put_nowait(get_party)
+            if state_cache.party.frame > previous_game_state["party"]:
+                previous_game_state["party"] = state_cache.party.frame
+                data = list(map(lambda x: x.to_dict() if x is not None else None, state_cache.party.value))
+                send_message(DataSubscription.Party, data=data, event_type="Party")
+
+        if subscriptions["Opponent"] > 0:
+            if current_game_state == GameState.BATTLE:
+                if state_cache.opponent.age_in_frames >= 60:
+                    # If the cached opponent data is too old, tell the main thread to update it at the next
+                    # possible opportunity.
+                    work_queue.put_nowait(get_opponent)
+                if state_cache.opponent.frame > previous_game_state["opponent"]:
+                    previous_game_state["opponent"] = state_cache.opponent.frame
+                    data = state_cache.opponent.value
+                    if data is not None:
+                        data = data.to_dict()
+                    send_message(DataSubscription.Opponent, data=data, event_type="Opponent")
+            elif previous_game_state["game_state"] == GameState.BATTLE:
+                send_message(DataSubscription.Opponent, data=None, event_type="Opponent")
+
+        if subscriptions["GameState"] > 0:
+            if current_game_state != previous_game_state["game_state"]:
+                send_message(DataSubscription.GameState, data=current_game_state.name, event_type="GameState")
+
+        if subscriptions["Map"] > 0 or subscriptions["MapTile"] > 0:
+            if current_game_state == GameState.OVERWORLD:
+                current_map = trainer.get_map()
+                current_coords = trainer.get_coords()
+                if current_map != previous_game_state["trainer_map"]:
+                    try:
+                        map_data = get_map_data_for_current_position()
+                        data = {
+                            "map": map_data.dict_for_map(),
+                            "player_position": map_data.local_position,
+                            "tiles": map_data.dicts_for_all_tiles()
+                        }
+
+                        send_message(DataSubscription.Map, data=data, event_type="MapChange")
+                        previous_game_state["trainer_map"] = current_map
+                    except:
+                        # If fetching map data failed for any reason, ignore the error and continue.
+                        pass
+                if current_coords != previous_game_state["trainer_local_coords"]:
+                    try:
+                        send_message(DataSubscription.Map, data=get_map_data_for_current_position().local_position,
+                                     event_type="MapTileChange")
+                        previous_game_state["trainer_local_coords"] = current_coords
+                    except:
+                        # If fetching map data failed for any reason, ignore the error and continue.
+                        pass
+
+        if subscriptions["BotMode"] > 0:
+            if context.bot_mode != previous_emulator_state["bot_mode"]:
+                previous_emulator_state["bot_mode"] = context.bot_mode
+                send_message(DataSubscription.BotMode, data=context.bot_mode, event_type="BotMode")
+
+        if subscriptions["Message"] > 0:
+            if context.message != previous_emulator_state["message"]:
+                previous_emulator_state["message"] = context.message
+                send_message(DataSubscription.Message, data=context.message, event_type="Message")
+
+        if subscriptions["EmulatorSettings"] > 0:
+            if context.emulation_speed != previous_emulator_state["emulation_speed"]:
+                previous_emulator_state["emulation_speed"] = context.emulation_speed
+                send_message(DataSubscription.EmulatorSettings, data=context.emulation_speed,
+                             event_type="EmulationSpeed")
+
+            if context.audio != previous_emulator_state["audio_enabled"]:
+                previous_emulator_state["audio_enabled"] = context.audio
+                send_message(DataSubscription.EmulatorSettings, data=context.audio, event_type="AudioEnabled")
+
+            if context.video != previous_emulator_state["video_enabled"]:
+                previous_emulator_state["video_enabled"] = context.video
+                send_message(DataSubscription.EmulatorSettings, data=context.video, event_type="VideoEnabled")
+
+        if current_game_state != previous_game_state["game_state"]:
+            previous_game_state["game_state"] = current_game_state
+
+        if current_second != previous_second:
+            previous_second = current_second
+
+        sleep(update_interval)
+
+
+def send_message(subscription_flag: DataSubscription, data: str | list | tuple | dict | int | float | None,
+                 event_type: str | None = None) -> None:
+    if event_type is not None:
+        message = f"event: {event_type}\ndata: {json.dumps(data)}"
+    else:
+        message = f"data: {json.dumps(data)}"
+
+    for index in reversed(range(len(subscribers))):
+        if subscribers[index][2] & subscription_flag:
+            try:
+                subscribers[index][1].put_nowait(message)
+            except queue.Full:
+                console.print(f'[yellow]Queue for client [bold]{subscribers[index][0]}[/] was full. Disconnecting.[/]')
+                subscribers[index][3]()

--- a/modules/map.py
+++ b/modules/map.py
@@ -585,6 +585,51 @@ class MapLocation:
     def is_dark_cave(self) -> bool:
         return bool(self._map_header[0x15] & 0b0001)
 
+    def all_tiles(self) -> list[list["MapLocation"]]:
+        result = []
+
+        for x in range(self.map_size[0]):
+            row = []
+            for y in range(self.map_size[1]):
+                row.append(MapLocation(self._map_header, self.map_group, self.map_number, (x, y)))
+            result.append(row)
+
+        return result
+
+    def dict_for_map(self) -> dict:
+        return {
+            "map_group": self.map_group,
+            "map_number": self.map_number,
+            "name": self.map_name,
+            "size": self.map_size,
+            "type": self.map_type,
+            "weather": self.weather,
+            "is_cycling_possible": self.is_cycling_possible,
+            "is_escaping_possible": self.is_escaping_possible,
+            "is_running_possible": self.is_running_possible,
+            "is_map_name_popup_shown": self.is_map_name_popup_shown,
+            "is_dark_cave": self.is_dark_cave,
+        }
+
+    def dict_for_tile(self) -> dict:
+        return {
+            "local_coordinates": self.local_position,
+            "elevation": self.elevation,
+            "type": self.tile_type,
+            "has_encounters": self.has_encounters,
+            "collision": self.collision,
+            "is_surfing_possible": self.is_surfable,
+        }
+
+    def dicts_for_all_tiles(self) -> list[list[dict]]:
+        result = []
+        for row in self.all_tiles():
+            result_row = []
+            for tile in row:
+                result_row.append(tile.dict_for_tile())
+            result.append(result_row)
+        return result
+
 
 class ObjectEvent:
     MOVEMENT_TYPES = ["NONE", "LOOK_AROUND", "WANDER_AROUND", "WANDER_UP_AND_DOWN", "WANDER_DOWN_AND_UP",

--- a/modules/state_cache.py
+++ b/modules/state_cache.py
@@ -1,0 +1,89 @@
+import time
+from typing import Generic, TypeVar, TYPE_CHECKING
+
+from modules.context import context
+
+if TYPE_CHECKING:
+    from modules.memory import GameState
+    from modules.pokemon import Pokemon
+
+T = TypeVar("T")
+
+
+class StateCacheItem(Generic[T]):
+    def __init__(self, initial_value: T):
+        self._value: T = initial_value
+        self.frame: int = 0
+        self.time: float = time.time()
+        self._last_check_frame: int = 0
+
+    @property
+    def value(self) -> T:
+        return self._value
+
+    @value.setter
+    def value(self, new_value: T):
+        self._value = new_value
+        self.frame = context.emulator.get_frame_count()
+        self.time = time.time()
+        self._last_check_frame = self.frame
+
+    @property
+    def age_in_seconds(self) -> float | None:
+        return time.time() - self.time
+
+    @property
+    def age_in_frames(self) -> int | None:
+        return context.emulator.get_frame_count() - self._last_check_frame
+
+    def checked(self) -> None:
+        self._last_check_frame = context.emulator.get_frame_count()
+
+
+class StateCache:
+    def __init__(self):
+        self._party: StateCacheItem[list["Pokemon"]] = StateCacheItem([])
+        self._opponent: StateCacheItem["Pokemon | None"] = StateCacheItem(None)
+        self._game_state: StateCacheItem["GameState | None"] = StateCacheItem(None)
+
+    @property
+    def party(self) -> StateCacheItem[list["Pokemon"]]:
+        return self._party
+
+    @party.setter
+    def party(self, party: list["Pokemon"]):
+        if len(self._party.value) != len(party):
+            self._party.value = party
+            return
+
+        for i in range(len(self._party.value)):
+            if self._party.value[i] != party[i]:
+                self._party.value = party
+                return
+
+        self._party.checked()
+
+    @property
+    def opponent(self) -> StateCacheItem["Pokemon | None"]:
+        return self._opponent
+
+    @opponent.setter
+    def opponent(self, opponent: "Pokemon | None"):
+        if self._opponent.value != opponent:
+            self._opponent.value = opponent
+        else:
+            self._opponent.checked()
+
+    @property
+    def game_state(self) -> StateCacheItem["GameState | None"]:
+        return self._game_state
+
+    @game_state.setter
+    def game_state(self, new_game_state: "GameState"):
+        if self._game_state.value != new_game_state:
+            self._game_state.value = new_game_state
+        else:
+            self._game_state.checked()
+
+
+state_cache: StateCache = StateCache()

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -286,7 +286,7 @@ class TotalStats:
     def get_log_obj(self, pokemon: Pokemon) -> dict:
         return {
             "time_encountered": time.time(),
-            "pokemon": pokemon.to_dict(),
+            "pokemon": pokemon.to_legacy_dict(),
             "snapshot_stats": {
                 "phase_encounters": self.total_stats["totals"]["phase_encounters"],
                 "species_encounters": self.total_stats["pokemon"][pokemon.species.name]["encounters"],
@@ -312,7 +312,7 @@ class TotalStats:
         self.update_iv_records(pokemon)
 
         if context.config.logging.log_encounters:
-            log_encounter_to_csv(self.total_stats, pokemon.to_dict(), self.stats_dir_path)
+            log_encounter_to_csv(self.total_stats, pokemon.to_legacy_dict(), self.stats_dir_path)
 
         self.update_shiny_averages(pokemon)
         self.append_encounter_timestamps()

--- a/modules/web/Readme.md
+++ b/modules/web/Readme.md
@@ -1,0 +1,133 @@
+PokéBot Event Stream
+=====================
+
+This is a way to receive continuous updates by the bot in JavaScript
+or any other client that is capable of handling `text/event-stream`.
+
+For a description of the protocol itself, see 
+[this page on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format).
+
+## How to use in JavaScript
+
+[All modern browsers](https://caniuse.com/eventsource) have a built-in
+client for this data type. You can use it like this:
+
+```javascript
+const connection = new EventSource("http://localhost:8888/stream_events?topic=...&topic=...");
+
+connection.addEventListener("PerformanceData", event => handlePerformanceData(JSON.parse(event.data)));
+connection.addEventListener("Opponent", ...);
+
+function handlePerformanceData(data) {
+    console.log(`FPS: ${data.fps}`);
+}
+```
+
+## Subscribing to topics
+
+For performance reasons, this endpoint requires you to specify which
+events you want to receive. This allows the bot to not check for changes
+in data that no one is interested in anyway.
+
+To specify which topics you would like to receive, you need to provide
+**one o more** `topic=...` query parameters, such as:
+
+`/stream_events?topic=PerformanceData`  
+or  
+`/stream_events?topic=PerformanceData&topic=Opponent&topic=Party`
+
+## Handling events
+
+The JavaScript client acts as an event emitter, so you can just call its
+`addEventHandler()` function (see the example code above) to handle them.
+
+The first argument is the event name (a list of which will follow below)
+and the second argument is a function that accepts the event.
+
+See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/message_event)
+for a description of the event object.
+
+Note that while all our events are JSON-encoded, the `event.data` property
+is _a string_. So you have to call `JSON.parse(event.data)` in order to get
+back the actual value/data object.
+
+## List of topics and events
+
+This directory contains TypeScript declaration files that describe the
+structure of event payloads. See [stream_events.d.ts](stream_events.d.ts).
+
+The following topics are available:
+
+### Topic `BotMode`
+
+This will send you a `BotMode` event each time the bot mode is changed.
+
+
+### Topic `EmulatorSettings`
+
+This will send you one of the following events whenever that respective
+setting in the bot is changed:
+
+- `EmulationSpeed`
+- `AudioEnabled`
+- `VideoEnabled`
+
+
+### Topic `GameState`
+
+This will send you a `GameState` event whenever the in-game 'state' changes.
+
+Game state is not something the game defines itself, but rather something the
+bot detects and then uses internally. There is no definite list of possible
+values as this might change regularly as bot development progresses.
+
+
+### Topic `Map`
+
+This will send you a `MapChange` event when the user _enters a new map_.
+
+
+### Topic `MapTile`
+
+This will send you a `MapTileChange` event whenever the user moves to a new
+tile. The data is exactly the same as for the `MapChange` event, but you will
+receive this one much more frequently due to it being fired on each new tile.
+
+If you subscribe to both the `Map` and `MapTile` topics, you will receive _both_
+a `MapChange` and a `MapTileChange` event (with identical data) when the user
+enters a new map.
+
+
+### Topic `Message`
+
+This will send you a `Message` event whenever the message displayed in the GUI
+changes.
+
+
+### Topic `Party`
+
+This will send you a `Party` event whenever something about the player's party
+changes.
+
+That is going to happen for every small change, such as a party Pokémon taking
+damage or its HP decreasing due to walking while poisoned.
+
+
+### Topic `PerformanceData`
+
+When subscribing to this topic, your client will receive an event every
+second containing some basic performance data (e.g. FPS, encounter rate, ...)
+
+This event is also called `PerformanceData`
+
+
+### Topic `Opponent`
+
+This will send you an `Opponent` event each time the opponent changes.
+
+That is going to happen when a wild encounter/trainer battle starts, when 
+the opponent switches Pokémon in a trainer battle, when the opposing Pokémon
+takes damage or uses a move (due to its PP decreasing) etc.
+
+This event will also be fired when a battle _ends_, in which case the payload
+is `null`.

--- a/modules/web/http_example.html
+++ b/modules/web/http_example.html
@@ -1,0 +1,576 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>PokéBot</title>
+    <!--
+    Note: This is just an example page, showing how to use the streaming API.
+          It is not meant to be used as a productive interface, so don't
+          expect too much of it.
+    -->
+</head>
+<body>
+<p>
+    <img src="/stream_video?fps=30" width="480" height="320" id="gba_video"/>
+</p>
+
+<p>
+    FPS: <strong id="fps"></strong> &middot;
+    Bot Percentage: <strong id="bot_percentage"></strong> &middot;
+    Encounter Rate: <strong id="encounter_rate"></strong><br/>
+    Bot Mode: <strong id="bot_mode"></strong> &middot;
+    Game State: <strong id="game_mode"></strong> &middot;
+    Emulation Speed: <strong id="emulation_speed"></strong> &middot;
+    Video Enabled: <strong id="video_enabled"></strong> &middot;
+    Audio Enabled: <strong id="audio_enabled"></strong><br/>
+    Message: <strong id="message"></strong>
+</p>
+
+<h2>Party</h2>
+
+<ol>
+    <li id="party0" class="party-entry"></li>
+    <li id="party1" class="party-entry"></li>
+    <li id="party2" class="party-entry"></li>
+    <li id="party3" class="party-entry"></li>
+    <li id="party4" class="party-entry"></li>
+    <li id="party5" class="party-entry"></li>
+</ol>
+
+<div class="encounter-container">
+    <div id="encounter">
+        <h2>Current Encounter</h2>
+        <p>None</p>
+    </div>
+</div>
+
+<h2>Map</h2>
+
+<canvas id="mini_map"></canvas>
+
+<p>
+    Current Map: <strong id="map_name"></strong> (type: <strong id="map_type"></strong>)<br/>
+    Weather: <strong id="weather"></strong><br/>
+    Properties: <strong id="map_properties"></strong>
+</p>
+
+<p>
+    Local Coordinates: <strong id="local_coords"></strong><br/>
+    Tile Type: <strong id="tile_type"></strong><br/>
+    Properties: <strong id="tile_properties"></strong>
+</p>
+
+<h2>Event Log</h2>
+
+<div id="log"></div>
+
+<script>
+    /**
+     * @type {MapLocation}
+     */
+    let mapData;
+
+    /*
+     * Populate initial data by calling the regular API endpoints.
+     *
+     * The streaming endpoint will only send _updates_ so this is still necessary.
+     */
+    fetch("/emulator")
+        .then(response => response.json())
+        .then(data => {
+            /** @var {PokeBotApi.GetEmulatorResponse} */
+            handleBotModeChange(data.bot_mode);
+            handleEmulationSpeedChange(data.emulation_speed);
+            handleVideoEnabledChange(data.video_enabled);
+            handleAudioEnabledChange(data.audio_enabled);
+            handlePerformanceData({fps: data.current_fps, current_time_spent_in_bot_fraction});
+            handleMessageChange(data.current_message);
+        });
+
+    fetch("/trainer")
+        .then(response => response.json())
+        .then(data => {
+            /** @var {PokeBotApi.GetTrainerResponse} */
+            handleGameStateChange(data.game_state);
+        });
+
+    fetch("/party")
+        .then(response => response.json())
+        .then(data => {
+            /** @var {PokeBotApi.GetPartyResponse} */
+            handlePartyChange(data);
+        });
+
+    fetch("/opponent")
+        .then(response => response.json())
+        .then(data => {
+            /** @var {PokeBotApi.GetOpponentResponse} */
+            handleOpponentChange(data);
+        });
+
+    fetch("/encounter_rate")
+        .then(response => response.json())
+        .then(data => {
+            /** @var {PokeBotApi.GetEncounterRateResponse} */
+            document.getElementById("encounter_rate").innerText = data.encounter_rate + "/hr";
+        });
+
+    fetch("/map")
+        .then(response => response.json())
+        .then(data => {
+            /** @var {PokeBotApi.GetMapResponse} */
+            handleMapChange(data);
+            handleMapTileChange(data.player_position);
+        })
+
+
+    /*
+     * Assemble URL for streaming endpoint including all events that we want to subscribe to.
+     *
+     * For this example, we are subscribing to _all_ available topics.
+     */
+    const url = new URL(window.location.origin + "/stream_events");
+    url.searchParams.append("topic", "BotMode");
+    url.searchParams.append("topic", "EmulatorSettings");
+    url.searchParams.append("topic", "GameState");
+    url.searchParams.append("topic", "Map");
+    url.searchParams.append("topic", "MapTile");
+    url.searchParams.append("topic", "Message");
+    url.searchParams.append("topic", "Party");
+    url.searchParams.append("topic", "PerformanceData");
+    url.searchParams.append("topic", "Opponent");
+
+    /*
+     * Initialise event-stream client and add event handlers for all the events we care about.
+     *
+     * In this example, we are handling all possible events.
+     */
+    const eventSource = new EventSource(url);
+    eventSource.addEventListener("PerformanceData", event => handlePerformanceData(JSON.parse(event.data)));
+    eventSource.addEventListener("Party", event => handlePartyChange(JSON.parse(event.data)));
+    eventSource.addEventListener("Opponent", event => handleOpponentChange(JSON.parse(event.data)));
+    eventSource.addEventListener("MapChange", event => handleMapChange(JSON.parse(event.data)));
+    eventSource.addEventListener("MapTileChange", event => handleMapTileChange(JSON.parse(event.data)));
+    eventSource.addEventListener("Message", event => handleMessageChange(JSON.parse(event.data)));
+    eventSource.addEventListener("GameState", event => handleGameStateChange(JSON.parse(event.data)));
+    eventSource.addEventListener("BotMode", event => handleBotModeChange(JSON.parse(event.data)));
+    eventSource.addEventListener("EmulationSpeed", event => handleEmulationSpeedChange(JSON.parse(event.data)));
+    eventSource.addEventListener("AudioEnabled", event => handleAudioEnabledChange(JSON.parse(event.data)));
+    eventSource.addEventListener("VideoEnabled", event => handleVideoEnabledChange(JSON.parse(event.data)));
+
+    function log(html)
+    {
+        const logContainer = document.getElementById("log");
+
+        const logLine         = document.createElement("p");
+        logLine.innerHTML     = html;
+        const currentDate     = document.createElement("small");
+        currentDate.innerText = "[" + (new Date).toLocaleString("en-GB") + "]";
+        logLine.prepend(currentDate);
+        logContainer.prepend(logLine);
+
+        while (logContainer.childElementCount > 100) {
+            logContainer.children.item(logContainer.childElementCount - 1).remove();
+        }
+    }
+
+    /**
+     * @param {StreamEvents.PerformanceData} data
+     */
+    function handlePerformanceData(data)
+    {
+        document.getElementById("fps").innerText            = data.fps.toLocaleString("en-GB");
+        document.getElementById("bot_percentage").innerText = (data.current_time_spent_in_bot_fraction * 100).toLocaleString("en-GB", {maximumFractionDigits: 1}) + "%";
+        if (typeof data.encounter_rate !== "undefined") {
+            document.getElementById("encounter_rate").innerText = data.encounter_rate.toLocaleString("en-GB") + "/hr";
+        }
+    }
+
+    /**
+     * @param {StreamEvents.Party} data
+     */
+    function handlePartyChange(data)
+    {
+        for (let index = 0; index < 6; index++) {
+            const listEntry = document.getElementById("party" + index);
+
+            const nameParts = [];
+            nameParts.push(data[index].species.name);
+
+            if (data[index].is_shiny) {
+                nameParts.push("✨");
+            }
+
+            if (data[index].nickname && data[index].nickname.toLowerCase() != data[index].species.name.toLowerCase()) {
+                nameParts.push(`“${data[index].nickname}”`);
+            }
+
+            nameParts.push(`(lvl. ${data[index].level}, ${data[index].gender})`)
+
+            listEntry.innerText = nameParts.join(" ");
+
+            const hpBar               = document.createElement("div");
+            hpBar.className           = "hp-bar";
+            const hpBarColoured       = document.createElement("div");
+            const hpPercentage        = (100 * data[index].current_hp / data[index].total_hp)
+            hpBarColoured.style.width = `${hpPercentage}%`;
+            if (hpPercentage < 20) {
+                hpBarColoured.style.backgroundColor = "#b00";
+            } else if (hpPercentage < 50) {
+                hpBarColoured.style.backgroundColor = "#cc0";
+            } else {
+                hpBarColoured.style.backgroundColor = "#080";
+            }
+            hpBar.append(hpBarColoured);
+            listEntry.append(hpBar);
+        }
+    }
+
+    /**
+     * @param {StreamEvents.Opponent} data
+     */
+    function handleOpponentChange(data)
+    {
+        const colours = {
+            "normal": "#a8a878",
+            "fire": "#f08030",
+            "water": "#6890f0",
+            "electric": "#f8d030",
+            "grass": "#78c850",
+            "ice": "#98d8d8",
+            "fighting": "#c03028",
+            "poison": "#a040a0",
+            "ground": "#e0c068",
+            "flying": "#a890f0",
+            "psychic": "#f85888",
+            "bug": "#a8b820",
+            "rock": "#b8a038",
+            "ghost": "#705898",
+            "dragon": "#7038f8",
+            "dark": "#705848",
+            "steel": "#b8b8d0",
+        };
+
+        const box = document.getElementById("encounter");
+        if (data === null) {
+            box.innerHTML             = `<h2>Current Encounter</h2><p>None</p>`;
+            box.style.borderColor     = "transparent";
+            box.style.backgroundColor = "transparent";
+            return;
+        }
+
+        const mainType = data.species.types[0].name.toLowerCase();
+        if (typeof colours[mainType] !== "undefined") {
+            box.style.borderColor     = colours[mainType];
+            box.style.backgroundColor = colours[mainType] + "55";
+        } else {
+            box.style.borderColor     = "transparent";
+            box.style.backgroundColor = "transparent";
+        }
+
+        box.innerHTML = `
+    <h2>Current Encounter</h2>
+    <p><strong>${data.species.name}</strong> encountered at <strong>${data.location_met}</strong></p>
+    <ul>
+        <li>PID: <strong>${data.personality_value}</strong></li>
+        <li>Level: <strong>${data.level}</strong></li>
+        <li>Item: <strong>${data.held_item ? data.held_item.name : "&mdash;"}</strong></li>
+        <li>Nature: <strong>${data.nature.name}</strong></li>
+        <li>Ability: <strong>${data.ability.name}</strong></li>
+        <li>Hidden Power: <strong>${data.hidden_power_type.name} (${data.hidden_power_damage})</strong></li>
+        <li>Shiny Value: <strong>${data.shiny_value}</strong></li>
+    </ul>
+    <table>
+        <thead>
+        <tr>
+            <th>HP</th>
+            <th>ATK</th>
+            <th>DEF</th>
+            <th>SPATK</th>
+            <th>SPDEF</th>
+            <th>SPD</th>
+            <th>Total</th>
+        </tr>
+        <tr>
+            <td>${data.ivs.hp}</td>
+            <td>${data.ivs.attack}</td>
+            <td>${data.ivs.defence}</td>
+            <td>${data.ivs.special_attack}</td>
+            <td>${data.ivs.special_defence}</td>
+            <td>${data.ivs.speed}</td>
+            <td>${Object.values(data.ivs).reduce((sum, v) => sum + v, 0)}</td>
+        </tr>
+        </thead>
+    </table>
+`;
+    }
+
+    function handleMapChange(data)
+    {
+        mapData = data;
+
+        log(`<strong>Map Changed</strong> - New map: ${data.map.name}`);
+
+        const mapProperties = [];
+        if (data.map.is_cycling_possible) {
+            mapProperties.push("Cycling possible");
+        }
+        if (data.map.is_escaping_possible) {
+            mapProperties.push("Escape Rope and Teleport possible");
+        }
+        if (data.map.is_running_possible) {
+            mapProperties.push("Running possible");
+        }
+        if (data.map.is_dark_cave) {
+            mapProperties.push("Dark Cave");
+        }
+        if (data.map.is_map_name_popup_shown) {
+            mapProperties.push("Map name popup shown when entering");
+        }
+
+        document.getElementById("map_name").innerText       = data.map.name;
+        document.getElementById("map_type").innerText       = data.map.type;
+        document.getElementById("weather").innerText        = data.map.weather;
+        document.getElementById("map_properties").innerText = mapProperties.join(", ");
+    }
+
+    /**
+     * @param {StreamEvents.MapChange} data
+     */
+    function handleMapTileChange(data)
+    {
+        mapData.player_position = data;
+        const [x, y] = data;
+        const tile = mapData.tiles[x][y];
+
+        log(`Moved to tile <strong>${x} / ${y}<strong>.`);
+
+        const tileProperties = [];
+        if (tile.collision) {
+            tileProperties.push("Collision");
+        }
+        if (tile.has_encounters) {
+            tileProperties.push("Has Wild Encounters");
+        }
+        if (tile.is_surfing_possible) {
+            tileProperties.push("Surfing Possible");
+        }
+
+        document.getElementById("local_coords").innerText    = tile.local_coordinates.join(" / ");
+        document.getElementById("tile_type").innerText       = tile.type;
+        document.getElementById("tile_properties").innerText = tileProperties.join(", ");
+
+        updateMiniMap();
+    }
+
+    /**
+     * @param {StreamEvents.MapTileChange} data
+     */
+    function handleMessageChange(data)
+    {
+        document.getElementById("message").innerText = data ?? "";
+    }
+
+    /**
+     * @param {StreamEvents.GameState} data
+     */
+    function handleGameStateChange(data)
+    {
+        document.getElementById("game_mode").innerText = data;
+    }
+
+    /**
+     * @param {StreamEvents.BotMode} data
+     */
+    function handleBotModeChange(data)
+    {
+        log(`Bot mode changed to <strong>${data}</strong>`);
+        document.getElementById("bot_mode").innerText = data;
+    }
+
+    /**
+     * @param {StreamEvents.EmulationSpeed} data
+     */
+    function handleEmulationSpeedChange(data)
+    {
+        let newValue;
+        if (data === 0) {
+            newValue = "unthrottled";
+        } else {
+            newValue = data + "×";
+        }
+        document.getElementById("emulation_speed").innerText = newValue;
+        log(`Emulation speed changed to <strong>${newValue}</strong>`);
+    }
+
+    /**
+     * @param {StreamEvents.AudioEnabled} data
+     */
+    function handleAudioEnabledChange(data)
+    {
+        document.getElementById("audio_enabled").innerText = data ? "yes" : "no";
+
+        if (data) {
+            log(`Audio was <strong>enabled</strong>`);
+        } else {
+            log(`Audio was <strong>disabled</strong>`);
+        }
+    }
+
+    /**
+     * @param {StreamEvents.VideoEnabled} data
+     */
+    function handleVideoEnabledChange(data)
+    {
+        document.getElementById("video_enabled").innerText = data ? "yes" : "no";
+
+        if (data) {
+            log(`Video was <strong>enabled</strong>`);
+        } else {
+            log(`Video was <strong>disabled</strong>`);
+        }
+    }
+
+    function updateMiniMap() {
+        const TILE_SIZE = 5;
+
+        /** @type {HTMLCanvasElement} */
+        const canvas = document.getElementById("mini_map");
+        const context = canvas.getContext("2d");
+
+        canvas.width = TILE_SIZE * mapData.map.size[0];
+        canvas.height = TILE_SIZE * mapData.map.size[1];
+
+        // Clear canvas.
+        context.fillStyle = "#DFB";
+        context.fillRect(0, 0, canvas.width, canvas.height);
+
+        for (let x = 0; x < mapData.tiles.length; x++) {
+            for (let y = 0; y < mapData.tiles[x].length; y++) {
+                const tile = mapData.tiles[x][y];
+                let colour = null;
+                if (
+                    tile.local_coordinates[0] === mapData.player_position[0] &&
+                    tile.local_coordinates[1] === mapData.player_position[1]
+                ) {
+                    colour = "red";
+                } else if (tile.type.includes("Water") || tile.type.includes("Current")) {
+                    if (tile.has_encounters) {
+                        colour = "#08F";
+                    } else {
+                        colour = "#0FF";
+                    }
+                } else if (tile.collision && tile.type.includes("Warp")) {
+                    colour = "#F0F";
+                } else if (tile.collision) {
+                    colour = "#000";
+                } else if (tile.has_encounters) {
+                    colour = "#080";
+                }
+
+                if (colour !== null) {
+                    context.fillStyle = colour;
+                    context.fillRect(
+                        x * TILE_SIZE,
+                        y * TILE_SIZE,
+                        TILE_SIZE,
+                        TILE_SIZE
+                    );
+                }
+            }
+        }
+
+        context.strokeStyle = "#F00";
+        context.lineWidth = 2;
+        context.beginPath();
+        context.arc(
+            mapData.player_position[0] * TILE_SIZE + (TILE_SIZE / 2),
+            mapData.player_position[1] * TILE_SIZE + (TILE_SIZE / 2),
+            TILE_SIZE * 1.5,
+            0,
+            2 * Math.PI
+        );
+        context.stroke();
+    }
+</script>
+
+<style>
+    #gba_video {
+        position: absolute;
+        top: 0;
+        right: 0;
+        border-left: 1px #000 solid;
+        border-bottom: 1px #000 solid;
+        image-rendering: crisp-edges;
+    }
+
+    .party-entry {
+        margin-bottom: .5rem;
+    }
+
+    .party-entry .hp-bar {
+        height: 3px;
+        width: 200px;
+        background-color: #ddd;
+    }
+
+    .party-entry .hp-bar div {
+        height: 100%;
+    }
+
+    .encounter-container {
+        border: 1px #ccc solid;
+    }
+
+    #encounter {
+        height: 275px;
+        padding: calc(1rem - 5px);
+        border: 5px transparent solid;
+    }
+
+    #encounter > *:first-child {
+        margin-top: 0;
+    }
+
+    #encounter > *:last-child {
+        margin-bottom: 0;
+    }
+
+    #encounter > ul {
+        margin: 0;
+        display: inline-block;
+        width: 300px;
+        vertical-align: top;
+    }
+
+    #encounter table {
+        display: inline-block;
+        vertical-align: top;
+    }
+
+    #encounter th, #encounter td {
+        text-align: center;
+        width: 80px;
+        padding: .25rem .5rem;
+        background-color: rgba(0, 0, 0, 0.2);
+    }
+
+    #mini_map {
+        border: 1px #000 solid;
+        float: right;
+        margin-right: 1rem;
+        margin-bottom: 1rem;
+    }
+
+    #log p {
+        margin: .5rem 0 0;
+    }
+
+    #log small {
+        font-size: 75%;
+        color: #888;
+        margin-right: 10px;
+    }
+</style>
+</body>
+</html>

--- a/modules/web/pokemon.d.ts
+++ b/modules/web/pokemon.d.ts
@@ -1,0 +1,426 @@
+type Gender = "male" | "female";
+type Language = "Japanese" | "English" | "French" | "Italian" | "German" | "Spanish";
+type GameName = "Ruby" | "Sapphire" | "Emerald" | "FireRed" | "LeafGreen" | "Colosseum/XD" | "?";
+type StatusCondition = "Healthy" | "Sleep" | "Poison" | "Burn" | "Freeze" | "Paralysis" | "BadPoison";
+type Marking = "Circle" | "Square" | "Triangle" | "Heart";
+type LevelUpType = "Medium Fast" | "Erratic" | "Fluctuating" | "Medium Slow" | "Fast" | "Slow";
+type TypeName =
+    "Normal"
+    | "Fighting"
+    | "Flying"
+    | "Poison"
+    | "Ground"
+    | "Rock"
+    | "Bug"
+    | "Ghost"
+    | "Steel"
+    | "???"
+    | "Fire"
+    | "Water"
+    | "Grass"
+    | "Electric"
+    | "Psychic"
+    | "Ice"
+    | "Dragon"
+    | "Dark";
+type ItemType =
+    "Mail"
+    | "UsableOutsideBattle"
+    | "UsableInCertainLocations"
+    | "PokeblockCase"
+    | "NotUsableOutsideBattle";
+type ItemPocket = "Items" | "PokeBalls" | "TmsAndHms" | "Berries" | "KeyItems";
+
+type StatsValues = {
+    hp: number;
+    attack: number;
+    defence: number;
+    speed: number;
+    special_attack: number;
+    special_defence: number;
+};
+
+export type Type = {
+    // Internal index number, not exposed anywhere in the game.
+    index: number;
+
+    // English name of this type.
+    name: string;
+
+    kind: "???" | "Physical" | "Special";
+}
+
+export type Item = {
+    // Internal index number, not exposed anywhere in the game.
+    index: number;
+
+    // English name of this item.
+    name: string;
+
+    // Buying price in the market.
+    price: number;
+
+    // Used for certain in-game checks, but not directly exposed to the player.
+    type: ItemType;
+
+    // Which bag pockets this item sorts into.
+    pocket: ItemPocket;
+
+    // An extra value whose meaning depends on the type of item.
+    // For repels, it indicates the number of steps the effect lasts for; HP/PP
+    // modifying items use it to indicate the number of HP/PP affected.
+    parameter: number;
+
+    // Used for mails and Poké Balls to indicate their type.
+    extra_parameter: number;
+};
+
+export type Move = {
+    // Internal index number, not exposed anywhere in the game.
+    index: number;
+
+    // English name of this move.
+    name: string;
+
+    type: Type;
+
+    // Value between 0 and 1, indicating how likely it is for this
+    // move to connect.
+    accuracy: number;
+
+    // Value between 0 and 1, indicating how likely it is for a
+    // _secondary effect_ (such as optional status changes, etc.)
+    // to connect.
+    secondary_accuracy: number;
+
+    pp: number;
+    priority: number;
+    base_power: number;
+
+    // Internal name of the effect for this move.
+    effect: string
+
+    // Whom this move will hit in a double battle.
+    target: "BOTH" | "DEPENDS" | "FOES_AND_ALLY" | "OPPONENTS_FIELD" | "RANDOM" | "SELECTED" | "USER";
+
+    makes_contact: boolean;
+    affected_by_protect: boolean;
+    affected_by_magic_coat: boolean;
+    affected_by_snatch: boolean;
+    usable_with_mirror_move: boolean;
+    affected_by_kings_rock: boolean;
+};
+
+export type LearnedMove = {
+    move: Move;
+
+    // Currently remaining number of PPs.
+    pp: number;
+
+    // Total PPs that this move can have.
+    total_pp: number;
+
+    // Amount of PPs that have been added by items for this Pokémon (this is the difference between `total_pp`
+    // and the move's base PP value.)
+    added_pps: number;
+};
+
+export type Ability = {
+    // Internal index number, not exposed anywhere in the game.
+    index: number;
+
+    // English name of this ability.
+    name: string;
+};
+
+export type Nature = {
+    // Internal index number, not exposed anywhere in the game.
+    index: number;
+
+    // English name of this nature.
+    name: string;
+
+    // Indicates how this nature affects certain stats values. One of these values
+    // could be `1.1` (to indicate a +10% modifier), one could be `0.9%` (for the -10%
+    // modifier) and the rest will be `1`.
+    modifiers: {
+        attack: number;
+        defence: number;
+        speed: number;
+        special_attack: number;
+        special_defence: number;
+    };
+};
+
+export type Species = {
+    // Internal index number, not exposed anywhere in the game.
+    index: number;
+
+    national_dex_number: number;
+    hoenn_dex_number: number;
+
+    // English name of this species.
+    name: string;
+
+    // The species name with any characters that might be problematic in file names
+    // replaced.
+    safe_name: string;
+
+    types: Type[];
+
+    // List of abilities that this species can have.
+    abilities: Ability[];
+
+    // List of items that this Pokémon could hold when encountered in the wild.
+    held_items: { item: Item; probability: number; }[];
+
+    // The likelihood (between 0 and 254 that a Pokémon is female.
+    // 0 = Pokémon is always male.
+    // 254 = Pokémon is always female.
+    // A special value means that this species is genderless/'Gender unknown'.
+    gender_ratio: number;
+
+    // Indicates how long it takes to hatch an egg of this species. (This value needs
+    // to be multiplied by 256 to get an _approximate_ number of steps needed to hatch
+    // it.)
+    egg_cycles: number;
+
+    base_stats: StatsValues;
+    base_friendship: number;
+    catch_rate: number;
+    safari_zone_flee_probability: number;
+    level_up_type: LevelUpType;
+    egg_groups: string[];
+    base_experience_yield: number;
+    ev_yield: StatsValues;
+};
+
+export type Pokemon = {
+    // Randomly generated value that does not do anything on its own, but from which
+    // a lot of other values are being derived.
+    personality_value: number;
+
+    // This is the _effective_ name that is being displayed in-game.
+    // For an egg, this will be `EGG`; for hatched Pokémon this will either be the
+    // nickname (if one exists) or alternatively the species name.
+    name: string;
+
+    // The nickname that the player has chosen, or alternatively just the name of
+    // the species (this is never empty.)
+    nickname: string;
+
+    // Language of the game that this Pokémon originates from.
+    // For eggs, this is always "Japanese" and will be changed after hatching.
+    language: Language;
+
+    // Name of the game that this Pokémon originates from.
+    game_of_origin: GameName;
+
+    // Level at which this Pokémon has been caught. If this is 0, it means the Pokémon
+    // has hatched from an egg.
+    level_met: number;
+
+    // Name of the in-game location that the Pokémon has been encountered/hatched at.
+    // For Pokémon with an unrecognised location, this will be "Traded".
+    location_met: string;
+
+    // Information about this Pokémon's OT.
+    original_trainer: {
+        id: number;
+        secret_id: number;
+        name: string;
+        gender: Gender;
+    };
+
+    is_egg: boolean;
+
+    species: Species;
+
+    held_item: Item | null;
+
+    // Total number of Experience that this Pokémon has collected.
+    total_exp: number;
+
+    // Value between 0 and 255.
+    friendship: number;
+
+    ability: Ability;
+
+    nature: Nature;
+
+    // Gender of the Pokémon. For Pokémon species that do not have a gender (e.g.
+    // Magnemite, Staryu, Ditto, Unown, ...) this is `null`.
+    gender: Gender | null;
+
+    // Current level of this Pokémon.
+    level: number;
+
+    // Current status condition of this Pokémon.
+    status_condition: StatusCondition;
+
+    // Turns remaining where this Pokémon will stay asleep.
+    // Obviously, this is only relevant if `status_condition` is "Sleep".
+    sleep_duration: number;
+
+    // Current effective status values of this Pokémon, calculated from base stats,
+    // level, EVs, IVs, and Nature.
+    stats: StatsValues;
+
+    // Total number of (max) HP that this Pokémon currently has.
+    total_hp: number;
+
+    // Current HP of this Pokémon (this is the value that decreases when the Pokémon
+    // gets punched in the face.)
+    current_hp: number;
+
+    // Information about learned moves. The index of this array corresponds to the
+    // move slot.
+    moves: [LearnedMove | null, LearnedMove | null, LearnedMove | null, LearnedMove | null];
+
+    evs: StatsValues;
+
+    ivs: StatsValues;
+
+    // Stats that are being used for the Pokémon Contest.
+    contest_conditions: {
+        coolness: number;
+        beauty: number;
+        cuteness: number;
+        smartness: number;
+        toughness: number;
+        feel: number;
+    };
+
+    // The type of Poké Ball that this Pokémon has been caught in.
+    poke_ball: Item;
+
+    pokerus_status: {
+        // This indicates the strain of Pokérus that a Pokémon has been infected
+        // with. It is 0 for Pokémon that have never had Pokérus.
+        strain: number;
+
+        // Days remaining for the current infection. If this is 0 and `strain` is
+        // anything other than 0, it means the Pokémon has been cured.
+        days_remaining: number;
+    };
+
+    // Symbols that have been set for this Pokémon and which are shown in the
+    // Summary Screen. They don't have any other in-game effect and are probably
+    // just meant for easier organisation.
+    markings: Marking[];
+
+    // Value calculated from OT and Personality Value that is used for checking
+    // whether a Pokémon is shiny or not. Not really useful on its own.
+    shiny_value: number;
+
+    // Whether this is a Shiny Pokémon.
+    is_shiny: boolean;
+
+    // Has no meaning for the game, just a mathematical curiosity.
+    is_anti_shiny: boolean;
+
+    hidden_power_type: Type;
+
+    // Base damage of the Hidden Power move.
+    hidden_power_damage: number;
+
+    // If this Pokémon is a Unown, indicates what letter it is.
+    unown_letter: string;
+
+    // If this Pokémon is a Wurmple, indicates what it will evolve into.
+    wurmple_evolution: "silcoon" | "cascoon";
+};
+
+export type MapType =
+    "None"
+    | "Town"
+    | "City"
+    | "Route"
+    | "Underground"
+    | "Underwater"
+    | "Ocean Route"
+    | "Unknown"
+    | "Indoor"
+    | "Secret Base";
+
+export type Weather =
+    "None"
+    | "Sunny Clouds"
+    | "Sunny"
+    | "Rain"
+    | "Snow"
+    | "Thunderstorm"
+    | "Fog (Horizontal)"
+    | "Volcanic Ash"
+    | "Sandstorm"
+    | "Fog (Diagonal)"
+    | "Underwater"
+    | "Shade"
+    | "Drought"
+    | "Downpour"
+    | "Underwater Bubbles"
+    | "Abnormal"
+    | "Route 119 Cycle"
+    | "Route 123 Cycle"
+
+type MapData = {
+    map_group: number;
+    map_number: number;
+
+    // In-game name of the current map.
+    name: string;
+
+    // Size in tiles.
+    size: [number, number];
+
+    type: MapType;
+
+    weather: Weather;
+
+    is_cycling_possible: boolean;
+
+    // Whether escape ropes can be used here.
+    is_escaping_possible: boolean;
+
+    is_running_possible: boolean;
+
+    // Indicates whether the game will show a little pop-up with the map name
+    // in the top-left corner when entering.
+    is_map_name_popup_shown: boolean;
+
+    // Indicates that this map is 'dark', i.e. HM Flash needs to be used in order
+    // to see properly.
+    is_dark_cave: boolean;
+};
+
+type MapTileData = {
+    local_coordinates: [number, number];
+
+    // Usually 3 for land tiles and 0 for water tiles, does not _really_ indicate
+    // whether this is a hill or not.
+    elevation: number;
+
+    type: string;
+
+    // Whether wild Pokémon might be encountered here.
+    has_encounters: boolean;
+
+    // Whether the player can collide with this tile, i.e. it is inaccessible.
+    // Since this data structure is currently only used for tiles the player is
+    // standing on, this should always be `false`.
+    collision: boolean;
+
+    // Whether this is a surfable water tile.
+    is_surfing_possible: boolean;
+};
+
+export type MapLocation = {
+    // General information about the map.
+    map: MapData;
+
+    // x and y coordinates of the current player location.
+    player_position: [number, number];
+
+    // Information about _all_ the tiles on that map, indexed by x/y.
+    tiles: MapTileData[][];
+};

--- a/modules/web/routes.d.ts
+++ b/modules/web/routes.d.ts
@@ -1,0 +1,150 @@
+import {MapLocation, Pokemon} from "./pokemon";
+
+declare module PokeBotApi {
+    /**
+     * Request body for `POST /emulator`
+     *
+     * The request must have `Content-Type: application/json`.
+     * The response for this request is `GetEmulatorResponse` (same
+     * as the one for `GET /emulator`.)
+     */
+    export type PostEmulatorRequest = {
+        // 0 = unthrottled, other values are speed multipliers.
+        emulation_speed?: 0 | 1 | 2 | 3 | 4;
+        bot_mode?: string;
+        video_enabled?: boolean;
+        audio_enabled?: boolean;
+    };
+
+    /**
+     * Response body for `GET /emulator` and `POST /emulator`.
+     */
+    export type GetEmulatorResponse = {
+        // 0 = unthrottled, other values are speed multipliers.
+        emulation_speed: 0 | 1 | 2 | 3 | 4;
+
+        video_enabled: boolean;
+        audio_enabled: boolean;
+
+        bot_mode: string;
+
+        // Message that is displayed in the GUI.
+        current_message: string;
+
+        // Number of frames since 'starting' the GBA (this will not reset
+        // when closing the bot because it is persisted in the save state,
+        // so from the perspective of the game the GBA was never turned
+        // off.)
+        frame_count: number;
+
+        current_fps: number;
+
+        // Value between 0 and 1, indicating how much time per frame has
+        // been spent in bot-related code (checking memory, deciding
+        // what buttons to press...) as opposed to the actual GBA
+        // emulation.
+        current_time_spent_in_bot_fraction: number;
+
+        // Currently running profile.
+        profile: { name: string; };
+
+        // Currently running game.
+        game: {
+            // In-ROM code for this game.
+            title: "POKEMON RUBY" | "POKEMON SAPP" | "POKEMON EMER" | "POKEMON FIRE" | "POKEMON LEAF";
+
+            // 'Version number' for this game, usually 0 or 1.
+            revision: number;
+
+            // More readable name of this game.
+            name: string;
+
+            // Game language.
+            // E = English; F = French; D = German; I = Italian; J = Japanese;
+            // S = Spanish.
+            language: "E" | "F" | "D" | "I" | "J" | "S";
+        }
+    };
+
+    /**
+     * Response body for `GET /fps`.
+     *
+     * This endpoint lists FPS values over time. The array index is equivalent
+     * to how many seconds ago that FPS value has been recorded.
+     */
+    export type GetFPSResponse = number[];
+
+    /**
+     * Response body for `GET /trainer`.
+     */
+    export type GetTrainerResponse = {
+        name: string;
+        gender: "boy" | "girl";
+
+        // Trainer ID.
+        tid: number;
+
+        // Secret ID.
+        sid: number;
+
+        // Current map group and map number.
+        map: [number, number];
+
+        // Name of the map the player is currently on.
+        map_name: string;
+
+        // Local coordinates (in tiles) on the current map.
+        coords: [number, number];
+
+        running_state: number;
+        tile_transition_state: number;
+        acro_bike_state: number;
+        on_bike: boolean;
+        facing_direction: "Down" | "Up" | "Left" | "Right";
+
+        game_state: string;
+    };
+
+    /**
+     * Response body for `GET /party`.
+     */
+    export type GetPartyResponse = Pokemon[];
+
+    /**
+     * Response body for `GET /opponent`.
+     */
+    export type GetOpponentResponse = Pokemon | null;
+
+    /**
+     * Response body for `GET /items`.
+     *
+     * There is a key for each bag pocket, and within each of those there is an object
+     * where the key is the name of an item and the value is the amount of said item.
+     */
+    export type GetItemsResponse = {
+        "PC": { [k: string]: number };
+        "Items": { [k: string]: number };
+        "Key Items": { [k: string]: number };
+        "Poké Balls": { [k: string]: number };
+        "TMs & HMs": { [k: string]: number };
+        "Berries": { [k: string]: number };
+    };
+
+    /**
+     * Response body for `GET /map`.
+     */
+    export type GetMapResponse = MapLocation;
+
+    /**
+     * Response body for `GET /encounter_rate`.
+     */
+    export type GetEncounterRateResponse = {
+        // Calculated average encounters per hour.
+        encounter_rate: number;
+    }
+
+    /**
+     * Respone body for `GET /event_flags`.
+     */
+    export type GetEventFlagsResponse = { [k: string]: number }
+}

--- a/modules/web/stream_events.d.ts
+++ b/modules/web/stream_events.d.ts
@@ -1,0 +1,46 @@
+import {MapLocation, Pokemon} from "./pokemon";
+
+declare module StreamEvents {
+    export type PerformanceData = {
+        // Most recently recorded FPS value (usually within the last second.)
+        fps: number;
+
+        // Number of frames that have been emulated since 'turning on' the virtual GBA.
+        // This does not reset after restarting the bot since we are using save states,
+        // so from the perspective of the game the GBA has been on the entire time.
+        frame_count: number;
+
+        // Value between 0 and 1, indicating how much of processing time has been used
+        // by the bot itself as opposed to the GBA emulation. This is not an indicator
+        // of how fast the bot is running in general.
+        current_time_spent_in_bot_fraction: number;
+
+        // Last calculated encounter rate.
+        encounter_rate: number;
+    };
+
+    // Lists Pokémon in the current party. May contain between 0 and 6 entries.
+    export type Party = Pokemon[];
+
+    // Contains data about the Pokémon that is currently being battled against, or NULL
+    // if there is no active battle.
+    export type Opponent = Pokemon | null;
+
+    export type MapChange = MapLocation;
+
+    // New x and y coordinates of the player position.
+    export type MapTileChange = [number, number];
+
+    export type Message = string;
+
+    export type GameState = string;
+
+    export type BotMode = string;
+
+    // 0 for unthrottled, otherwise the speed multiplier.
+    export type EmulationSpeed = 0 | 1 | 2 | 3 | 4;
+
+    export type AudioEnabled = boolean;
+
+    export type VideoEnabled = boolean;
+}


### PR DESCRIPTION
This PR adds some more features to the HTTP server.

First of all, there are 4 new 'regular' endpoints:  
- `GET /map` returns data about the current map and tile the player is standing on,
- `GET /opponent` returns data about the current encounter/active opponent in a trainer battle, or `null` if no battle is going on,
- `POST /emulator` allows changing a few emulator settings (speed, video, audio, bot mode) via API,
- `GET /party` has been changed to return the same data structure for Pokémon that we use internally, as opposed to the old format. This contains more information and it's probably also easier to just use the same structure everywhere.

Ok, now for the actual meat of this PR:

## Streaming API

This PR adds a `GET /stream_events` endpoint that can be used to continously receive updates in the form of [server-sent events (MDN documentation)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).

From a technical perspective, this is a persistent connection with `Content-Type: text/event-stream` where the bot can just push arbitrary data that can be conveniently handled using built-in JavaScript features.

There is a `modules/web/Readme.md` file that goes into more detail on how that works and how to use this.

There is also a `modules/web/http_example.html` file that acts as a showcase for all possible features of this endpoint. I have made it the default index page of the bot, even though it is not very pretty. But it makes it easier to see the API live in action.

## Video Stream

As a crude way to get the current video output, there is also `GET /stream_video`. This just continuously pushes the current PNG image and so likely increases CPU load by quite a bit (albeit in a different thread, so who cares.)

It's not meant to be consumed by JavaScript, but rather just included as an image on a HTML page (`<img src="/stream_video"/>`.)