### PR TITLE
Fix encounter handling code that broke with new config system

### DIFF
--- a/modules/stats.py
+++ b/modules/stats.py
@@ -327,7 +327,7 @@ class TotalStats:
             self.update_shiny_incremental_stats(pokemon)
 
             #  TODO fix all this OBS crap
-            for i in range(context.config.obs.get("shiny_delay", 1)):
+            for i in range(context.config.obs.shiny_delay):
                 context.emulator.run_single_frame()  # TODO bad (needs to be refactored so main loop advances frame)
 
             if context.config.obs.screenshot:

--- a/profiles/customhooks.py
+++ b/profiles/customhooks.py
@@ -332,7 +332,7 @@ def custom_hooks(hook) -> None:
                 time.sleep(3)  # Give the screenshot some time to save to disk
                 images = glob.glob(f"{config.obs.replay_dir}*.png")
                 image = max(images, key=os.path.getctime)
-                discord_message(webhook_url=config.obs.get("discord_webhook_url", None), image=image)
+                discord_message(webhook_url=config.obs.discord_webhook_url, image=image)
 
             # Run in a thread to not hold up other hooks
             Thread(target=OBSDiscordScreenshot).start()
@@ -346,7 +346,7 @@ def custom_hooks(hook) -> None:
             def OBSReplayBuffer():
                 from modules.obs import obs_hot_key
 
-                time.sleep(config.obs.get("replay_buffer_delay", 0))
+                time.sleep(config.obs.replay_buffer_delay)
                 obs_hot_key("OBS_KEY_F12", pressCtrl=True)
 
             # Run in a thread to not hold up other hooks


### PR DESCRIPTION
There appear to be some remnants of the first draft of the new config system, which still used dict-like structures.

This tragically crashes the bot when a shiny is encountered. Not the best time for that. 😉