### PR TITLE
Some more fixes to Discord config parsing

### DIFF
--- a/modules/config/schemas_v1.py
+++ b/modules/config/schemas_v1.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 from confz import BaseConfig
-from pydantic import field_validator, Field
+from pydantic import ConfigDict, field_validator, Field
 from pydantic.types import Annotated, ClassVar, NonNegativeInt, PositiveInt
 
 
@@ -58,12 +58,16 @@ class Discord(BaseConfig):
 class DiscordWebhook(BaseConfig):
     """Schema for the different webhooks sections contained in the Discord config."""
 
+    # This allows `ping_id` to just be an integer, even though it is treated like a string later on.
+    model_config = ConfigDict(coerce_numbers_to_str=True)
+
     enable: bool = False
     first_interval: PositiveInt | None = 8192  # Only used by phase_summary.
     consequent_interval: PositiveInt | None = 5000  # Only used by phase_summary.
     interval: PositiveInt = 5
     ping_mode: Literal["user", "role", None] = None
     ping_id: str | None = None
+    webhook_url: str | None = None
 
 
 class General(BaseConfig):

--- a/modules/config/schemas_v1.py
+++ b/modules/config/schemas_v1.py
@@ -62,9 +62,9 @@ class DiscordWebhook(BaseConfig):
     model_config = ConfigDict(coerce_numbers_to_str=True)
 
     enable: bool = False
-    first_interval: PositiveInt | None = 8192  # Only used by phase_summary.
-    consequent_interval: PositiveInt | None = 5000  # Only used by phase_summary.
-    interval: PositiveInt = 5
+    first_interval: PositiveInt | None = 0  # Only used by phase_summary.
+    consequent_interval: PositiveInt | None = 0  # Only used by phase_summary.
+    interval: PositiveInt = 0
     ping_mode: Literal["user", "role", None] = None
     ping_id: str | None = None
     webhook_url: str | None = None

--- a/profiles/customhooks.py
+++ b/profiles/customhooks.py
@@ -100,7 +100,7 @@ def custom_hooks(hook) -> None:
                 )
 
                 discord_message(
-                    webhook_url=config.discord.shiny_pokemon_encounter.get("webhook_url", None),
+                    webhook_url=config.discord.shiny_pokemon_encounter.webhook_url,
                     content=f"Encountered a shiny ✨ {pokemon.species.name} ✨! {block}\n{discord_ping}",
                     embed=True,
                     embed_title="Shiny encountered!",
@@ -127,7 +127,7 @@ def custom_hooks(hook) -> None:
             if (
                 config.discord.pokemon_encounter_milestones.enable
                 and stats["pokemon"][pokemon.species.name].get("encounters", -1)
-                % config.discord.pokemon_encounter_milestones.get("interval", 0)
+                % config.discord.pokemon_encounter_milestones.interval
                 == 0
             ):
                 # Discord pings
@@ -138,7 +138,7 @@ def custom_hooks(hook) -> None:
                     case "user":
                         discord_ping = f"📢 <@{config.discord.pokemon_encounter_milestones.ping_id}>"
                 discord_message(
-                    webhook_url=config.discord.pokemon_encounter_milestones.get("webhook_url", None),
+                    webhook_url=config.discord.pokemon_encounter_milestones.webhook_url,
                     content=f"🎉 New milestone achieved!\n{discord_ping}",
                     embed=True,
                     embed_description=f"{stats['pokemon'][pokemon.species.name].get('encounters', 0):,} {pokemon.species.name} encounters!",
@@ -155,7 +155,7 @@ def custom_hooks(hook) -> None:
                 config.discord.shiny_pokemon_encounter_milestones.enable
                 and pokemon.is_shiny
                 and stats["pokemon"][pokemon.species.name].get("shiny_encounters", -1)
-                % config.discord.shiny_pokemon_encounter_milestones.get("interval", 0)
+                % config.discord.shiny_pokemon_encounter_milestones.interval
                 == 0
             ):
                 # Discord pings
@@ -181,7 +181,7 @@ def custom_hooks(hook) -> None:
             # Discord total encounter milestones
             if (
                 config.discord.total_encounter_milestones.enable
-                and stats["totals"].get("encounters", -1) % config.discord.total_encounter_milestones.get("interval", 0)
+                and stats["totals"].get("encounters", -1) % config.discord.total_encounter_milestones.interval
                 == 0
             ):
                 # Discord pings
@@ -229,12 +229,12 @@ def custom_hooks(hook) -> None:
                 config.discord.phase_summary.enable
                 and not pokemon.is_shiny
                 and (
-                    stats["totals"].get("phase_encounters", -1) == config.discord.phase_summary.get("first_interval", 0)
+                    stats["totals"].get("phase_encounters", -1) == config.discord.phase_summary.first_interval
                     or (
                         stats["totals"].get("phase_encounters", -1)
                         > config.discord.phase_summary.get("first_interval", 0)
                         and stats["totals"].get("phase_encounters", -1)
-                        % config.discord.phase_summary.get("consequent_interval", 0)
+                        % config.discord.phase_summary.consequent_interval
                         == 0
                     )
                 )
@@ -268,7 +268,7 @@ def custom_hooks(hook) -> None:
                     case "user":
                         discord_ping = f"📢 <@{config.discord.anti_shiny_pokemon_encounter.ping_id}>"
                 discord_message(
-                    webhook_url=config.discord.anti_shiny_pokemon_encounter.get("webhook_url", None),
+                    webhook_url=config.discord.anti_shiny_pokemon_encounter.webhook_url,
                     content=f"Encountered an anti-shiny 💀 {pokemon.species.name} 💀!\n{discord_ping}",
                     embed=True,
                     embed_title="Anti-Shiny encountered!",


### PR DESCRIPTION
Things still broke with custom `discord.yml`:

- `ping_id` was expected to be a string, so you'd have to write `ping_id: "123"` in the YAML file whereas some folks (understandably) just wrote `ping_id: 123` which gave them a cryptic parsing error.
- The new config schema did not account for the _optional_ `webhook_url` option in Discord webhook settings. Neither did the old one, but the old JSON Schema stuff didn't seem to mind if there was an extra key in the dictionary.
- Some more Discord settings were still being queried as if they were a dict, instead of the new object.