### PR TITLE
Use more optimised data structures in stats system

### DIFF
--- a/modules/console.py
+++ b/modules/console.py
@@ -60,7 +60,7 @@ def sv_colour(value: int) -> str:
     return "red"
 
 
-def print_stats(total_stats: dict, pokemon: Pokemon, session_pokemon: list, encounter_rate: int) -> None:
+def print_stats(total_stats: dict, pokemon: Pokemon, session_pokemon: set, encounter_rate: int) -> None:
     type_colour = pokemon.species.types[0].name.lower()
     rich_name = f"[{type_colour}]{pokemon.species.name}[/]"
     console.print("\n")
@@ -178,7 +178,7 @@ def print_stats(total_stats: dict, pokemon: Pokemon, session_pokemon: list, enco
             stats_table.add_column("Total Encounters", justify="right", width=10)
             stats_table.add_column("Shiny Average", justify="right", width=10)
 
-            for p in sorted(set(session_pokemon)):
+            for p in sorted(session_pokemon):
                 stats_table.add_row(
                     p,
                     f"[red]{total_stats['pokemon'][p].get('phase_lowest_iv_sum', -1)}[/] / [green]{total_stats['pokemon'][p].get('phase_highest_iv_sum', -1)}",

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -4,6 +4,7 @@ import math
 import sys
 import time
 import importlib
+from collections import deque
 from threading import Thread
 from datetime import datetime
 
@@ -18,9 +19,9 @@ from modules.pokemon import Pokemon
 class TotalStats:
     def __init__(self):
         self.session_encounters: int = 0
-        self.session_pokemon: list = []
-        self.encounter_log: list[dict] = []
-        self.encounter_timestamps: list = []
+        self.session_pokemon: set = set()
+        self.encounter_log: deque[dict] = deque(maxlen=10)
+        self.encounter_timestamps: deque[float] = deque(maxlen=100)
         self.cached_timestamp: str = ""
         self.cached_encounter_rate: int = 0
 
@@ -65,13 +66,9 @@ class TotalStats:
 
     def append_encounter_timestamps(self) -> None:
         self.encounter_timestamps.append(time.time())
-        if len(self.encounter_timestamps) > 100:
-            self.encounter_timestamps = self.encounter_timestamps[-100:]
 
     def append_encounter_log(self, pokemon: Pokemon) -> None:
         self.encounter_log.append(self.get_log_obj(pokemon))
-        if len(self.encounter_log) > 10:
-            self.encounter_log = self.encounter_log[-10:]
 
     def append_shiny_log(self, pokemon: Pokemon) -> None:
         self.shiny_log["shiny_log"].append(self.get_log_obj(pokemon))
@@ -81,7 +78,7 @@ class TotalStats:
         return self.total_stats
 
     def get_encounter_log(self) -> list:
-        return self.encounter_log
+        return list(self.encounter_log)
 
     def get_shiny_log(self) -> list:
         return self.shiny_log["shiny_log"]
@@ -113,8 +110,7 @@ class TotalStats:
 
     def update_incremental_stats(self, pokemon: Pokemon) -> None:
         self.session_encounters += 1
-        self.session_pokemon.append(pokemon.species.name)
-        self.session_pokemon = list(set(self.session_pokemon))
+        self.session_pokemon.add(pokemon.species.name)
         self.total_stats["totals"]["encounters"] = self.total_stats["totals"].get("encounters", 0) + 1
         self.total_stats["totals"]["phase_encounters"] = self.total_stats["totals"].get("phase_encounters", 0) + 1
         self.total_stats["pokemon"][pokemon.species.name]["encounters"] = (
@@ -150,27 +146,27 @@ class TotalStats:
 
     def reset_phase_stats(self) -> None:
         # Reset phase stats
-        self.session_pokemon = []
-        self.total_stats["totals"].pop("phase_encounters", None)
-        self.total_stats["totals"].pop("phase_highest_sv", None)
-        self.total_stats["totals"].pop("phase_highest_sv_pokemon", None)
-        self.total_stats["totals"].pop("phase_lowest_sv", None)
-        self.total_stats["totals"].pop("phase_lowest_sv_pokemon", None)
-        self.total_stats["totals"].pop("phase_highest_iv_sum", None)
-        self.total_stats["totals"].pop("phase_highest_iv_sum_pokemon", None)
-        self.total_stats["totals"].pop("phase_lowest_iv_sum", None)
-        self.total_stats["totals"].pop("phase_lowest_iv_sum_pokemon", None)
-        self.total_stats["totals"].pop("current_streak", None)
-        self.total_stats["totals"].pop("phase_streak", None)
-        self.total_stats["totals"].pop("phase_streak_pokemon", None)
+        self.session_pokemon.clear()
+        self.total_stats["totals"]["phase_encounters"] = 0
+        self.total_stats["totals"]["phase_highest_sv"] = None
+        self.total_stats["totals"]["phase_highest_sv_pokemon"] = None
+        self.total_stats["totals"]["phase_lowest_sv"] = None
+        self.total_stats["totals"]["phase_lowest_sv_pokemon"] = None
+        self.total_stats["totals"]["phase_highest_iv_sum"] = None
+        self.total_stats["totals"]["phase_highest_iv_sum_pokemon"] = None
+        self.total_stats["totals"]["phase_lowest_iv_sum"] = None
+        self.total_stats["totals"]["phase_lowest_iv_sum_pokemon"] = None
+        self.total_stats["totals"]["current_streak"] = 0
+        self.total_stats["totals"]["phase_streak"] = 0
+        self.total_stats["totals"]["phase_streak_pokemon"] = None
 
         # Reset Pokémon phase stats
         for n in self.total_stats["pokemon"]:
-            self.total_stats["pokemon"][n].pop("phase_encounters", None)
-            self.total_stats["pokemon"][n].pop("phase_highest_sv", None)
-            self.total_stats["pokemon"][n].pop("phase_lowest_sv", None)
-            self.total_stats["pokemon"][n].pop("phase_highest_iv_sum", None)
-            self.total_stats["pokemon"][n].pop("phase_lowest_iv_sum", None)
+            self.total_stats["pokemon"][n]["phase_encounters"] = 0
+            self.total_stats["pokemon"][n]["phase_highest_sv"] = None
+            self.total_stats["pokemon"][n]["phase_lowest_sv"] = None
+            self.total_stats["pokemon"][n]["phase_highest_iv_sum"] = None
+            self.total_stats["pokemon"][n]["phase_lowest_iv_sum"] = None
 
     def update_sv_records(self, pokemon: Pokemon) -> None:
         # Pokémon phase highest shiny value
@@ -308,7 +304,7 @@ class TotalStats:
             self.total_stats["totals"] = {}
 
         if pokemon.species.name not in self.total_stats["pokemon"]:  # Set up a Pokémon stats if first encounter
-            self.total_stats["pokemon"].update({pokemon.species.name: {}})
+            self.total_stats["pokemon"][pokemon.species.name] = {}
 
         self.update_incremental_stats(pokemon)
         self.update_sv_records(pokemon)


### PR DESCRIPTION
This PR addresses the issue that some people had where the bot would gradually slow down over time and also use more and more memory.

I couldn't pinpoint the problem exactly, but it went away after changing two data structures in the stats system:

- I have converted the encounter log into double-ended queues (`deque`) which seem like the more appropriate type here. Since I have specified a maximum type, they will also automatically purge the oldest entry.
- The `session_pokemon` member has been converted to a `set` because that's what it essentially is -- it even got converted into one in a couple of places.

This avoids having to convert and slice these structures all the time. I'm guessing that the latter caused some of the old versions of the data to still be referenced somehow, so Python never got rid of them. No idea, but at least for me this change prevents any memory creep.

I've also replaced how stats being reset, but I don't think that really mattered as much.