### PR TITLE
Prevent the bot from stopping without giving any reason.

### DIFF
--- a/modules/memory.py
+++ b/modules/memory.py
@@ -1,4 +1,3 @@
-import sys
 import struct
 from enum import IntEnum
 
@@ -67,8 +66,6 @@ def write_symbol(name: str, data: bytes, offset: int = 0x0) -> bool:
         return True
     except SystemExit:
         raise
-    except:
-        sys.exit(1)
 
 
 def parse_tasks(pretty_names: bool = False) -> list:

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -7,7 +7,7 @@ import importlib
 from threading import Thread
 from datetime import datetime
 
-from modules.console import print_stats
+from modules.console import console, print_stats
 from modules.context import context
 from modules.csv import log_encounter_to_csv
 from modules.files import read_file, write_file
@@ -61,6 +61,7 @@ class TotalStats:
         except SystemExit:
             raise
         except:
+            console.print_exception()
             sys.exit(1)
 
     def append_encounter_timestamps(self) -> None:


### PR DESCRIPTION
Fixes #115

If the stats system cannot initialise for some reason, it catches _all_ errors, suppresses them and then just exits the process.

Most of the time that probably happened due to messed up `custom_hooks` or `custom_catch_filters` files (containing syntax errors or other problems that manifest on import.)

I have removed that catch-all handler entirely since Python's default behaviour should already be to just exit whenever there is an exception -- but at least now, there will be an error message.

I have searched the code base for similar snippets and found another one in `write_symbol()`, which I have also updated.