### PR TITLE
Split player data into Player and PlayerAvatar

### DIFF
--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -21,7 +21,7 @@ from modules.memory import (
     set_event_flag,
     get_event_flag,
 )
-from modules.player import get_player, AvatarFlags, TileTransitionState
+from modules.player import get_player, get_player_avatar, AvatarFlags, TileTransitionState
 from modules.pokemon import get_party, get_species_by_index
 from modules.tasks import get_tasks, task_is_active
 
@@ -556,13 +556,14 @@ class PlayerTab(DebugTab):
 
     def _get_data(self):
         player = get_player()
+        player_avatar = get_player_avatar()
         party = get_party()
 
         flags = {}
         active_flags = []
         for flag in AvatarFlags:
-            flags[flag.name] = flag in player.flags
-            if flag in player.flags:
+            flags[flag.name] = flag in player_avatar.flags
+            if flag in player_avatar.flags:
                 active_flags.append(flag.name)
 
         if len(active_flags) == 0:
@@ -575,15 +576,17 @@ class PlayerTab(DebugTab):
             "Gender": player.gender,
             "Trainer ID": player.trainer_id,
             "Secret ID": player.secret_id,
-            "Map": player.map_group_and_number,
-            "Map Name": player.map_name,
-            "Local Coordinates": player.local_coordinates,
+            "Money": f"${player.money:,}",
+            "Coins": f"{player.coins:,}",
+            "Registered Item": player.registered_item.name if player.registered_item is not None else "None",
+            "Map Group and Number": player_avatar.map_group_and_number,
+            "Local Coordinates": player_avatar.local_coordinates,
             "Flags": flags,
-            "On Bike": player.is_on_bike,
-            "Running State": player.running_state.name,
-            "Acro Bike State": player.acro_bike_state.name,
-            "Tile Transition State": player.tile_transition_state.name,
-            "Facing Direction": player.facing_direction,
+            "On Bike": player_avatar.is_on_bike,
+            "Running State": player_avatar.running_state.name,
+            "Acro Bike State": player_avatar.acro_bike_state.name,
+            "Tile Transition State": player_avatar.tile_transition_state.name,
+            "Facing Direction": player_avatar.facing_direction,
         }
 
         for i in range(0, 6):
@@ -717,7 +720,7 @@ class MapTab(DebugTab):
         root.add(frame, text="Map")
 
     def update(self, emulator: "LibmgbaEmulator"):
-        player = get_player()
+        player = get_player_avatar()
         show_different_tile = self._marker_rectangle is not None and task_is_active("Task_WeatherMain")
         self._map.update()
 
@@ -771,7 +774,7 @@ class MapTab(DebugTab):
         tile_x = click_location[0] // tile_size
         tile_y = (click_location[1] + half_tile_size) // tile_size
 
-        current_map_data = get_player().map_location
+        current_map_data = get_player_avatar().map_location
         actual_x = current_map_data.local_position[0] + (tile_x - 7)
         actual_y = current_map_data.local_position[1] + (tile_y - 5)
         if (
@@ -800,7 +803,7 @@ class MapTab(DebugTab):
             map_group, map_number = self._selected_map
             map_data = get_map_data(map_group, map_number, self._selected_tile)
         else:
-            map_data = get_player().map_location
+            map_data = get_player_avatar().map_location
 
         map_objects = get_map_objects()
         object_list = {"__value": len(map_objects)}

--- a/modules/http.py
+++ b/modules/http.py
@@ -45,7 +45,7 @@ def http_server() -> None:
             except GeneratorExit:
                 unsubscribe()
 
-        return Response(stream(), mimetype='text/event-stream')
+        return Response(stream(), mimetype="text/event-stream")
 
     @server.route("/stream_video", methods=["GET"])
     def http_get_video_stream():
@@ -224,13 +224,15 @@ def http_server() -> None:
                 if new_settings["emulation_speed"] not in [0, 1, 2, 3, 4]:
                     return Response(
                         f"Setting `emulation_speed` contains an invalid value ('{new_settings['emulation_speed']}')",
-                        status=422)
+                        status=422,
+                    )
                 context.emulation_speed = new_settings["emulation_speed"]
             elif key == "bot_mode":
                 if new_settings["bot_mode"] not in available_bot_modes:
                     return Response(
                         f"Setting `bot_mode` contains an invalid value ('{new_settings['bot_mode']}'). Possible values are: {', '.join(available_bot_modes)}",
-                        status=422)
+                        status=422,
+                    )
                 context.bot_mode = new_settings["bot_mode"]
             elif key == "video_enabled":
                 if not isinstance(new_settings["video_enabled"], bool):

--- a/modules/http_stream.py
+++ b/modules/http_stream.py
@@ -42,7 +42,7 @@ for name in DataSubscription.all_names():
 max_client_id: int = 0
 
 
-def add_subscriber(subscribed_topics: list[str]) -> tuple[queue.Queue:, callable]:
+def add_subscriber(subscribed_topics: list[str]) -> tuple[queue.Queue :, callable]:
     for topic in subscribed_topics:
         if topic not in DataSubscription.all_names():
             raise ValueError(f"Topic '{topic}' does not exist.")
@@ -119,7 +119,8 @@ def run_watcher():
                     "current_time_spent_in_bot_fraction": context.emulator.get_current_time_spent_in_bot_fraction(),
                     "encounter_rate": total_stats.get_encounter_rate(),
                 },
-                event_type="PerformanceData")
+                event_type="PerformanceData",
+            )
 
         if subscriptions["Player"] > 0:
             if state_cache.player.age_in_frames >= 60:
@@ -174,7 +175,7 @@ def run_watcher():
                         data = {
                             "map": map_data.dict_for_map(),
                             "player_position": map_data.local_position,
-                            "tiles": map_data.dicts_for_all_tiles()
+                            "tiles": map_data.dicts_for_all_tiles(),
                         }
 
                         send_message(DataSubscription.Map, data=data, event_type="MapChange")
@@ -196,8 +197,9 @@ def run_watcher():
         if subscriptions["EmulatorSettings"] > 0:
             if context.emulation_speed != previous_emulator_state["emulation_speed"]:
                 previous_emulator_state["emulation_speed"] = context.emulation_speed
-                send_message(DataSubscription.EmulatorSettings, data=context.emulation_speed,
-                             event_type="EmulationSpeed")
+                send_message(
+                    DataSubscription.EmulatorSettings, data=context.emulation_speed, event_type="EmulationSpeed"
+                )
 
             if context.audio != previous_emulator_state["audio_enabled"]:
                 previous_emulator_state["audio_enabled"] = context.audio
@@ -216,8 +218,11 @@ def run_watcher():
         sleep(update_interval)
 
 
-def send_message(subscription_flag: DataSubscription, data: str | list | tuple | dict | int | float | None,
-                 event_type: str | None = None) -> None:
+def send_message(
+    subscription_flag: DataSubscription,
+    data: str | list | tuple | dict | int | float | None,
+    event_type: str | None = None,
+) -> None:
     if event_type is not None:
         message = f"event: {event_type}\ndata: {json.dumps(data)}"
     else:
@@ -228,5 +233,5 @@ def send_message(subscription_flag: DataSubscription, data: str | list | tuple |
             try:
                 subscribers[index][1].put_nowait(message)
             except queue.Full:
-                console.print(f'[yellow]Queue for client [bold]{subscribers[index][0]}[/] was full. Disconnecting.[/]')
+                console.print(f"[yellow]Queue for client [bold]{subscribers[index][0]}[/] was full. Disconnecting.[/]")
                 subscribers[index][3]()

--- a/modules/http_stream.py
+++ b/modules/http_stream.py
@@ -8,7 +8,7 @@ from modules.console import console
 from modules.context import context
 from modules.main import work_queue
 from modules.memory import get_game_state, GameState
-from modules.player import get_player
+from modules.player import get_player, get_player_avatar
 from modules.pokemon import get_party, get_opponent
 from modules.state_cache import state_cache
 from modules.stats import total_stats
@@ -18,6 +18,7 @@ queue_size = 10
 
 
 class DataSubscription(IntFlag):
+    Player = auto()
     Party = auto()
     Opponent = auto()
     GameState = auto()
@@ -81,9 +82,9 @@ def run_watcher():
     update_interval = update_interval_in_ms / 1000
     previous_second = int(time())
 
-    if state_cache.player.value is not None:
-        map_group_and_number = state_cache.player.value.map_group_and_number
-        map_local_coordinates = state_cache.player.value.local_coordinates
+    if state_cache.player_avatar.value is not None:
+        map_group_and_number = state_cache.player_avatar.value.map_group_and_number
+        map_local_coordinates = state_cache.player_avatar.value.local_coordinates
     else:
         map_group_and_number = (-1, -1)
         map_local_coordinates = (-1, -1)
@@ -92,6 +93,7 @@ def run_watcher():
         "party": state_cache.party.frame,
         "opponent": state_cache.opponent.frame,
         "player": state_cache.player.frame,
+        "player_avatar": state_cache.player_avatar.frame,
         "map_group_and_number": map_group_and_number,
         "map_local_coordinates": map_local_coordinates,
         "game_state": get_game_state(),
@@ -118,6 +120,15 @@ def run_watcher():
                     "encounter_rate": total_stats.get_encounter_rate(),
                 },
                 event_type="PerformanceData")
+
+        if subscriptions["Player"] > 0:
+            if state_cache.player.age_in_frames >= 60:
+                # If the cached party data is too old, tell the main thread to update it at the next
+                # possible opportunity.
+                work_queue.put_nowait(get_player)
+            if state_cache.player.frame > previous_game_state["player"]:
+                previous_game_state["player"] = state_cache.player.frame
+                send_message(DataSubscription.Player, data=state_cache.player.value.to_dict(), event_type="Player")
 
         if subscriptions["Party"] > 0:
             if state_cache.party.age_in_frames >= 60:
@@ -150,16 +161,16 @@ def run_watcher():
 
         if subscriptions["Map"] > 0 or subscriptions["MapTile"] > 0:
             if current_game_state == GameState.OVERWORLD:
-                if state_cache.player.age_in_frames > 4:
-                    # If the cached player data is too old, tell the main thread to update it at the next
+                if state_cache.player_avatar.age_in_frames > 4:
+                    # If the cached player avatar data is too old, tell the main thread to update it at the next
                     # possible opportunity.
-                    work_queue.put_nowait(get_player)
-                elif state_cache.player.value is not None:
-                    previous_game_state["player"] = state_cache.player.frame
-                    current_map = state_cache.player.value.map_group_and_number
-                    current_coords = state_cache.player.value.local_coordinates
+                    work_queue.put_nowait(get_player_avatar)
+                elif state_cache.player_avatar.value is not None:
+                    previous_game_state["player_avatar"] = state_cache.player_avatar.frame
+                    current_map = state_cache.player_avatar.value.map_group_and_number
+                    current_coords = state_cache.player_avatar.value.local_coordinates
                     if current_map != previous_game_state["map_group_and_number"]:
-                        map_data = state_cache.player.value.map_location
+                        map_data = state_cache.player_avatar.value.map_location
                         data = {
                             "map": map_data.dict_for_map(),
                             "player_position": map_data.local_position,

--- a/modules/map.py
+++ b/modules/map.py
@@ -1134,9 +1134,9 @@ class ObjectEvent:
 
 
 def get_map_data_for_current_position() -> MapLocation:
-    from modules.player import get_player
+    from modules.player import get_player_avatar
 
-    player = get_player()
+    player = get_player_avatar()
 
     map_group, map_number = player.map_group_and_number
     return MapLocation(read_symbol("gMapHeader"), map_group, map_number, player.local_coordinates)

--- a/modules/modes/general.py
+++ b/modules/modes/general.py
@@ -3,7 +3,7 @@ from enum import Enum
 from modules.context import context
 from modules.memory import get_game_state, GameState
 from modules.tasks import get_task
-from modules.player import get_player, RunningState, TileTransitionState, AcroBikeState
+from modules.player import get_player_avatar, RunningState, TileTransitionState, AcroBikeState
 
 
 class TaskFishing(Enum):
@@ -36,7 +36,7 @@ class ModeSpin:
 
     def step(self):
         while True:
-            player = get_player()
+            player = get_player_avatar()
             match (player.running_state, player.tile_transition_state):
                 case (RunningState.NOT_MOVING, TileTransitionState.NOT_MOVING):
                     context.emulator.press_button(self.get_next_direction(player.facing_direction))
@@ -68,7 +68,7 @@ class ModeFishing:
 class ModeBunnyHop:
     def step(self):
         while True:
-            player = get_player()
+            player = get_player_avatar()
             match (player.acro_bike_state, player.tile_transition_state, player.is_on_bike):
                 case (AcroBikeState.NORMAL, TileTransitionState.NOT_MOVING, False):
                     context.emulator.press_button("Select")  # TODO assumes player has the Acro Bike registered

--- a/modules/modes/legendaries.py
+++ b/modules/modes/legendaries.py
@@ -6,7 +6,7 @@ from modules.data.map import MapRSE
 from modules.gui.multi_select_window import MultiSelector, Selection, MultiSelectWindow
 from modules.memory import get_game_state, GameState, get_event_flag, read_symbol
 from modules.navigation import follow_path
-from modules.player import get_player
+from modules.player import get_player_avatar
 
 
 class ModeAncientLegendariesStates(Enum):
@@ -17,7 +17,7 @@ class ModeAncientLegendariesStates(Enum):
 class ModeAncientLegendaries:
     def __init__(self):
         if not context.selected_pokemon:
-            player = get_player()
+            player = get_player_avatar()
             sprites = Path(__file__).parent.parent.parent / "sprites" / "pokemon" / "normal"
 
             conditions = {
@@ -114,7 +114,7 @@ class ModeAncientLegendaries:
 
     def step(self):
         while True:
-            player = get_player()
+            player_avatar = get_player_avatar()
 
             match self.state, context.selected_pokemon:
                 case ModeAncientLegendariesStates.INTERACT, "Kyogre":
@@ -125,7 +125,7 @@ class ModeAncientLegendaries:
                                 continue
                             else:
                                 follow_path(  # TODO follow_path() needs reworking (not a generator)
-                                    [(player.local_coordinates[0], 26), (9, 26)]
+                                    [(player_avatar.local_coordinates[0], 26), (9, 26)]
                                 )
                         case GameState.BATTLE:
                             return
@@ -138,7 +138,7 @@ class ModeAncientLegendaries:
                                 continue
                             else:
                                 follow_path(  # TODO follow_path() needs reworking (not a generator)
-                                    [(player.local_coordinates[0], 26), (17, 26)]
+                                    [(player_avatar.local_coordinates[0], 26), (17, 26)]
                                 )
                         case GameState.BATTLE:
                             return
@@ -159,14 +159,14 @@ class ModeAncientLegendaries:
                             return
 
                 case ModeAncientLegendariesStates.LEAVE_ROOM, "Kyogre":
-                    if player.local_coordinates == (9, 26):
+                    if player_avatar.local_coordinates == (9, 26):
                         context.emulator.hold_button("Down")
                         context.emulator.press_button("B")
                     else:
                         context.emulator.release_button("Down")
                         follow_path(  # TODO follow_path() needs reworking (not a generator)
                             [
-                                (player.local_coordinates[0], 27),
+                                (player_avatar.local_coordinates[0], 27),
                                 (18, 27),
                                 (18, 14),
                                 (14, 14),
@@ -184,14 +184,14 @@ class ModeAncientLegendaries:
                         return
 
                 case ModeAncientLegendariesStates.LEAVE_ROOM, "Groudon":
-                    if player.local_coordinates == (17, 26):
+                    if player_avatar.local_coordinates == (17, 26):
                         context.emulator.hold_button("Left")
                         context.emulator.press_button("B")
                     else:
                         context.emulator.release_button("Left")
                         follow_path(  # TODO follow_path() needs reworking (not a generator)
                             [
-                                (player.local_coordinates[0], 26),
+                                (player_avatar.local_coordinates[0], 26),
                                 (7, 26),
                                 (7, 15),
                                 (9, 15),

--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -10,7 +10,7 @@ from modules.files import get_rng_state_history, save_rng_state_history
 from modules.gui.multi_select_window import Selection, MultiSelector, MultiSelectWindow
 from modules.memory import read_symbol, get_game_state, GameState, write_symbol, unpack_uint32, pack_uint32
 from modules.navigation import follow_path
-from modules.player import get_player
+from modules.player import get_player_avatar
 from modules.pokemon import get_party, opponent_changed
 from modules.tasks import get_task, task_is_active
 
@@ -55,84 +55,84 @@ class ModeStarterStates(Enum):
 class ModeStarters:
     def __init__(self) -> None:
         if not context.selected_pokemon:
-            player = get_player()
+            player_avatar = get_player_avatar()
             sprites = Path(__file__).parent.parent.parent / "sprites" / "pokemon" / "normal"
             conditions = {
                 "Bulbasaur": bool(
                     (
                         context.rom.game_title in ["POKEMON FIRE", "POKEMON LEAF"]
-                        and player.map_group_and_number == MapFRLG.PALLET_TOWN_D.value
-                        and player.local_coordinates == (8, 5)
-                        and player.facing_direction == "Up"
+                        and player_avatar.map_group_and_number == MapFRLG.PALLET_TOWN_D.value
+                        and player_avatar.local_coordinates == (8, 5)
+                        and player_avatar.facing_direction == "Up"
                     )
                 ),
                 "Charmander": bool(
                     (
                         context.rom.game_title in ["POKEMON FIRE", "POKEMON LEAF"]
-                        and player.map_group_and_number == MapFRLG.PALLET_TOWN_D.value
-                        and player.local_coordinates == (10, 5)
-                        and player.facing_direction == "Up"
+                        and player_avatar.map_group_and_number == MapFRLG.PALLET_TOWN_D.value
+                        and player_avatar.local_coordinates == (10, 5)
+                        and player_avatar.facing_direction == "Up"
                     )
                 ),
                 "Squirtle": bool(
                     (
                         context.rom.game_title in ["POKEMON FIRE", "POKEMON LEAF"]
-                        and player.map_group_and_number == MapFRLG.PALLET_TOWN_D.value
-                        and player.local_coordinates == (9, 5)
-                        and player.facing_direction == "Up"
+                        and player_avatar.map_group_and_number == MapFRLG.PALLET_TOWN_D.value
+                        and player_avatar.local_coordinates == (9, 5)
+                        and player_avatar.facing_direction == "Up"
                     )
                 ),
                 "Chikorita": bool(
                     (
                         context.rom.game_title == "POKEMON EMER"
-                        and player.map_group_and_number == MapRSE.LITTLEROOT_TOWN_E.value
-                        and player.local_coordinates == (10, 5)
-                        and player.facing_direction == "Up"
+                        and player_avatar.map_group_and_number == MapRSE.LITTLEROOT_TOWN_E.value
+                        and player_avatar.local_coordinates == (10, 5)
+                        and player_avatar.facing_direction == "Up"
                     )
                 ),
                 "Cyndaquil": bool(
                     (
                         context.rom.game_title == "POKEMON EMER"
-                        and player.map_group_and_number == MapRSE.LITTLEROOT_TOWN_E.value
-                        and player.local_coordinates == (8, 5)
-                        and player.facing_direction == "Up"
+                        and player_avatar.map_group_and_number == MapRSE.LITTLEROOT_TOWN_E.value
+                        and player_avatar.local_coordinates == (8, 5)
+                        and player_avatar.facing_direction == "Up"
                     )
                 ),
                 "Totodile": bool(
                     (
                         context.rom.game_title == "POKEMON EMER"
-                        and player.map_group_and_number == MapRSE.LITTLEROOT_TOWN_E.value
-                        and player.local_coordinates == (9, 5)
-                        and player.facing_direction == "Up"
+                        and player_avatar.map_group_and_number == MapRSE.LITTLEROOT_TOWN_E.value
+                        and player_avatar.local_coordinates == (9, 5)
+                        and player_avatar.facing_direction == "Up"
                     )
                 ),
                 "Treecko": bool(
                     (
                         context.rom.game_title in ["POKEMON RUBY", "POKEMON SAPP", "POKEMON EMER"]
-                        and player.map_group_and_number == MapRSE.ROUTE_101.value
+                        and player_avatar.map_group_and_number == MapRSE.ROUTE_101.value
                         and (
-                            (player.local_coordinates == (7, 15) and player.facing_direction == "Up")
-                            or (player.local_coordinates == (8, 14) and player.facing_direction == "Left")
+                            (player_avatar.local_coordinates == (7, 15) and player_avatar.facing_direction == "Up")
+                            or (player_avatar.local_coordinates == (8, 14) and player_avatar.facing_direction == "Left")
                         )
                     )
                 ),
                 "Torchic": bool(
                     (
                         context.rom.game_title in ["POKEMON RUBY", "POKEMON SAPP", "POKEMON EMER"]
-                        and player.map_group_and_number == MapRSE.ROUTE_101.value
+                        and player_avatar.map_group_and_number == MapRSE.ROUTE_101.value
                         and (
-                            (player.local_coordinates == (7, 15) and player.facing_direction == "Up")
-                            or (player.local_coordinates == (8, 14) and player.facing_direction == "Left")
+                            (player_avatar.local_coordinates == (7, 15) and player_avatar.facing_direction == "Up")
+                            or (player_avatar.local_coordinates == (8, 14) and player_avatar.facing_direction == "Left")
                         )
                     )
                 ),
                 "Mudkip": bool(
                     (
                         context.rom.game_title in ["POKEMON RUBY", "POKEMON SAPP", "POKEMON EMER"]
-                        and player.map_group_and_number == MapRSE.ROUTE_101.value
+                        and player_avatar.map_group_and_number == MapRSE.ROUTE_101.value
                         and (
-                            (player.local_coordinates == (7, 15) and player.facing_direction == "Up")
-                            or (player.local_coordinates == (8, 14) and player.facing_direction == "Left")
+                            (player_avatar.local_coordinates == (7, 15) and player_avatar.facing_direction == "Up")
+                            or (player_avatar.local_coordinates == (8, 14) and player_avatar.facing_direction == "Left")
                         )
                     )
                 ),
@@ -166,7 +166,7 @@ class ModeStarters:
                         sprite=sprites / "Squirtle.png",
                     ),
                 ]
-            elif context.rom.game_title == "POKEMON EMER" and player.map_group_and_number == MapRSE.LITTLEROOT_TOWN_E.value:
+            elif context.rom.game_title == "POKEMON EMER" and player_avatar.map_group_and_number == MapRSE.LITTLEROOT_TOWN_E.value:
                 selections = [
                     Selection(
                         button_label="Chikorita",
@@ -263,7 +263,7 @@ class ModeStarters:
 
     def step(self):
         while True:
-            player = get_player()
+            player_avatar = get_player_avatar()
 
             match self.region:
                 case Regions.KANTO_STARTERS:
@@ -320,6 +320,8 @@ class ModeStarters:
                         case ModeStarterStates.CONFIRM_STARTER:
                             if len(get_party()) == 0:
                                 # Uncomment the following to _guarantee_ a shiny being generated. For testing purposes.
+                                # from modules.player import get_player
+                                # player = get_player()
                                 # write_symbol("gRngValue",
                                 #              generate_guaranteed_shiny_rng_seed(player.trainer_id, player.secret_id))
                                 context.emulator.press_button("A")
@@ -329,7 +331,7 @@ class ModeStarters:
 
                         case ModeStarterStates.EXIT_MENUS:
                             if not config.cheats.starters:
-                                if player.facing_direction != "Down":
+                                if player_avatar.facing_direction != "Down":
                                     context.emulator.press_button("B")
                                     context.emulator.hold_button("Down")
                                 else:
@@ -342,7 +344,7 @@ class ModeStarters:
 
                         case ModeStarterStates.FOLLOW_PATH:
                             follow_path(
-                                [(player.local_coordinates[0], 7), (7, 7), (7, 8)]
+                                [(player_avatar.local_coordinates[0], 7), (7, 7), (7, 8)]
                             )  # TODO Revisit FollowPath rework
                             self.update_state(ModeStarterStates.OPPONENT_CRY_START)
 
@@ -538,6 +540,8 @@ class ModeStarters:
                                 confirm = task_is_active(self.task_confirm)
                                 if confirm and get_game_state() != GameState.BATTLE:
                                     # Uncomment the following to _guarantee_ a shiny being generated. For testing purposes.
+                                    # from modules.player import get_player
+                                    # player = get_player()
                                     # write_symbol("gRngValue",
                                     #              generate_guaranteed_shiny_rng_seed(player.trainer_id, player.secret_id))
                                     context.emulator.press_button("A")

--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -138,7 +138,6 @@ class ModeStarters:
                 ),
             }
 
-
             if context.rom.game_title in ["POKEMON FIRE", "POKEMON LEAF"]:
                 selections = [
                     Selection(
@@ -166,7 +165,10 @@ class ModeStarters:
                         sprite=sprites / "Squirtle.png",
                     ),
                 ]
-            elif context.rom.game_title == "POKEMON EMER" and player_avatar.map_group_and_number == MapRSE.LITTLEROOT_TOWN_E.value:
+            elif (
+                context.rom.game_title == "POKEMON EMER"
+                and player_avatar.map_group_and_number == MapRSE.LITTLEROOT_TOWN_E.value
+            ):
                 selections = [
                     Selection(
                         button_label="Chikorita",
@@ -457,8 +459,8 @@ class ModeStarters:
                                     continue
 
                         case ModeStarterStates.CHECK_STARTER:
-                            #config.cheats.starters = True  # TODO temporary until menu navigation is ready
-                            #if config.cheats.starters:  # TODO check Pokémon summary screen once menu navigation merged
+                            # config.cheats.starters = True  # TODO temporary until menu navigation is ready
+                            # if config.cheats.starters:  # TODO check Pokémon summary screen once menu navigation merged
 
                             self.update_state(ModeStarterStates.LOG_STARTER)
                             continue

--- a/modules/navigation.py
+++ b/modules/navigation.py
@@ -4,7 +4,7 @@ from modules.memory import get_game_state, GameState
 from modules.pokemon import opponent_changed, get_opponent
 from modules.tasks import task_is_active
 from modules.temp import temp_run_from_battle
-from modules.player import get_player, TileTransitionState
+from modules.player import get_player_avatar, TileTransitionState
 
 
 def follow_path(coords: list, run: bool = True) -> bool:  # TODO needs a rework
@@ -35,7 +35,7 @@ def follow_path(coords: list, run: bool = True) -> bool:  # TODO needs a rework
                     context.emulator.press_button("B")
                     context.emulator.run_single_frame()  # TODO bad (needs to be refactored so main loop advances frame)
 
-            player = get_player()
+            player = get_player_avatar()
             if player.tile_transition_state == TileTransitionState.NOT_MOVING:
                 trainer_coords = player.local_coordinates
                 # Check if map changed to desired map

--- a/modules/player.py
+++ b/modules/player.py
@@ -2,12 +2,12 @@ from enum import IntFlag, IntEnum, Enum
 from functools import cached_property
 from typing import Literal
 
-from modules.game import decode_string
 from modules.context import context
+from modules.game import decode_string
 from modules.map import MapLocation, ObjectEvent
-from modules.memory import get_save_block, read_symbol, unpack_uint16
+from modules.memory import get_save_block, read_symbol, unpack_uint16, unpack_uint32
+from modules.pokemon import get_item_by_index, Item
 from modules.state_cache import state_cache
-from modules.data.map import MapRSE, MapFRLG
 
 
 # https://github.com/pret/pokeemerald/blob/104e81b359d287668cee613f6604020a6e7228a3/include/global.fieldmap.h
@@ -18,8 +18,8 @@ class AvatarFlags(IntFlag):
     Surfing = 1 << 3
     Underwater = 1 << 4
     Controllable = 1 << 5
-    ForciblyMoving = 1 << 6
-    Dash = 1 << 7
+    ForcedMove = 1 << 6
+    Running = 1 << 7
 
 
 class RunningState(IntEnum):
@@ -50,66 +50,36 @@ class FacingDirection(Enum):
     Right = 0x44
 
 
-class Player:
-    def __init__(self, object_event: ObjectEvent, player_avatar_data: bytes):
+class PlayerAvatar:
+    def __init__(self, object_event: ObjectEvent, player_avatar_data: bytes, map_group_and_number: bytes):
         self._object_event = object_event
         self._player_avatar_data = player_avatar_data
-
-        if context.rom.game_title in ["POKEMON EMER", "POKEMON RUBY", "POKEMON SAPP"]:
-            self._map_data = MapRSE
-        else:
-            self._map_data = MapFRLG
+        self._map_group_and_number = map_group_and_number
 
     def __eq__(self, other):
-        if isinstance(other, Player):
-            return other._object_event == self._object_event and other._player_avatar_data == self._player_avatar_data
+        if isinstance(other, PlayerAvatar):
+            return other._object_event == self._object_event and \
+                other._player_avatar_data == self._player_avatar_data and \
+                other._map_group_and_number == self._map_group_and_number
         else:
             return NotImplemented
 
     def __ne__(self, other):
-        if isinstance(other, Player):
-            return other._object_event != self._object_event or other._player_avatar_data != self._player_avatar_data
+        if isinstance(other, PlayerAvatar):
+            return other._object_event != self._object_event or \
+                other._player_avatar_data != self._player_avatar_data or \
+                other._map_group_and_number == self._map_group_and_number
         else:
             return NotImplemented
 
     @property
-    def name(self) -> str:
-        return decode_string(get_save_block(2, size=8))
-
-    @property
-    def gender(self) -> Literal["male", "female"]:
-        if get_save_block(2, 0x8, 1) == b'\x00':
-            return "male"
-        else:
-            return "female"
-
-    @property
-    def trainer_id(self) -> int:
-        return unpack_uint16(get_save_block(2, 0xA, 2))
-
-    @property
-    def secret_id(self) -> int:
-        return unpack_uint16(get_save_block(2, 0xC, 2))
-
-    @property
     def map_group_and_number(self) -> tuple[int, int]:
-        data = get_save_block(1, offset=4, size=2)
-        return data[0], data[1]
+        return self._map_group_and_number[0], self._map_group_and_number[1]
 
     @cached_property
     def map_location(self) -> MapLocation:
         return MapLocation(read_symbol("gMapHeader"), self._object_event.map_group, self._object_event.map_num,
                            self._object_event.current_coords)
-
-    @property
-    def map_name(self) -> str:
-        try:
-            if context.rom.game_title in ["POKEMON EMER", "POKEMON RUBY", "POKEMON SAPP"]:
-                return MapRSE(self.map_group_and_number).name
-            else:
-                return MapFRLG(self.map_group_and_number).name
-        except ValueError:
-            return "UNKNOWN"
 
     @property
     def local_coordinates(self) -> tuple[int, int]:
@@ -141,19 +111,84 @@ class Player:
         return self._object_event.facing_direction
 
     def to_dict(self) -> dict:
+        flags = {}
+        for flag in AvatarFlags:
+            flags[flag.name] = flag in self.flags
+
         return {
-            "name": self.name,
-            "gender": self.gender,
-            "tid": self.trainer_id,
-            "sid": self.secret_id,
-            "map": self.map_group_and_number,
-            "map_name": self.map_name,
-            "coords": self.local_coordinates,
+            "map_group_and_number": self.map_group_and_number,
+            "local_coordinates": self.local_coordinates,
             "running_state": self.running_state.name,
             "tile_transition_state": self.tile_transition_state.name,
             "acro_bike_state": self.acro_bike_state.name,
             "on_bike": self.is_on_bike,
             "facing": self.facing_direction,
+            "flags": flags,
+        }
+
+
+class Player:
+    def __init__(self, save_block_1: bytes, save_block_2: bytes, encryption_key: bytes):
+        self._save_block_1 = save_block_1
+        self._save_block_2 = save_block_2
+        self._encryption_key = encryption_key
+
+    def __eq__(self, other):
+        if isinstance(other, Player):
+            return other._save_block_1 == self._save_block_1 and other._save_block_2 == self._save_block_2
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, Player):
+            return other._save_block_1 != self._save_block_1 or other._save_block_2 != self._save_block_2
+        else:
+            return NotImplemented
+
+    @property
+    def name(self) -> str:
+        return decode_string(self._save_block_2[0:8])
+
+    @property
+    def gender(self) -> Literal["male", "female"]:
+        if self._save_block_2[8] == 0:
+            return "male"
+        else:
+            return "female"
+
+    @property
+    def trainer_id(self) -> int:
+        return unpack_uint16(self._save_block_2[0x0A:0x0C])
+
+    @property
+    def secret_id(self) -> int:
+        return unpack_uint16(self._save_block_2[0x0C:0x0E])
+
+    @property
+    def money(self) -> int:
+        return unpack_uint32(self._save_block_1[0:4]) ^ unpack_uint32(self._encryption_key)
+
+    @property
+    def coins(self) -> int:
+        return unpack_uint16(self._save_block_1[4:6]) ^ (unpack_uint32(self._encryption_key) & 0xFFFF)
+
+    @property
+    def registered_item(self) -> Item | None:
+        item_index = unpack_uint16(self._save_block_1[6:8])
+        if item_index == 0:
+            return None
+        else:
+            return get_item_by_index(item_index)
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "gender": self.gender,
+            "trainer_id": self.trainer_id,
+            "secret_id": self.secret_id,
+            "money": self.money,
+            "coins": self.coins,
+            "registered_item": self.registered_item.name if self.registered_item is not None else None,
         }
 
 
@@ -161,11 +196,32 @@ def get_player() -> Player:
     if state_cache.player.age_in_frames == 0:
         return state_cache.player.value
 
+    if context.rom.game_title in ["POKEMON EMER", "POKEMON RUBY", "POKEMON SAPP"]:
+        save_block_1_offset = 0x490
+        encryption_key_offset = 0xAC
+    else:
+        save_block_1_offset = 0x290
+        encryption_key_offset = 0xF20
+
+    save_block_1 = get_save_block(1, offset=save_block_1_offset, size=0x08)
+    save_block_2 = get_save_block(2, size=0x0E)
+    encryption_key = get_save_block(2, encryption_key_offset, 4)
+
+    player = Player(save_block_1, save_block_2, encryption_key)
+    state_cache.player = player
+    return player
+
+
+def get_player_avatar() -> PlayerAvatar:
+    if state_cache.player_avatar.age_in_frames == 0:
+        return state_cache.player_avatar.value
+
     player_avatar_data = read_symbol("gPlayerAvatar")
     object_event_id = player_avatar_data[5]
     object_event = ObjectEvent(read_symbol("gObjectEvents", object_event_id * 0x24, 0x24))
+    map_group_and_number = get_save_block(1, offset=4, size=2)
 
-    player = Player(object_event, player_avatar_data)
-    state_cache.player = player
+    player_avatar = PlayerAvatar(object_event, player_avatar_data, map_group_and_number)
+    state_cache.player_avatar = player_avatar
 
-    return player
+    return player_avatar

--- a/modules/player.py
+++ b/modules/player.py
@@ -58,17 +58,21 @@ class PlayerAvatar:
 
     def __eq__(self, other):
         if isinstance(other, PlayerAvatar):
-            return other._object_event == self._object_event and \
-                other._player_avatar_data == self._player_avatar_data and \
-                other._map_group_and_number == self._map_group_and_number
+            return (
+                other._object_event == self._object_event
+                and other._player_avatar_data == self._player_avatar_data
+                and other._map_group_and_number == self._map_group_and_number
+            )
         else:
             return NotImplemented
 
     def __ne__(self, other):
         if isinstance(other, PlayerAvatar):
-            return other._object_event != self._object_event or \
-                other._player_avatar_data != self._player_avatar_data or \
-                other._map_group_and_number == self._map_group_and_number
+            return (
+                other._object_event != self._object_event
+                or other._player_avatar_data != self._player_avatar_data
+                or other._map_group_and_number == self._map_group_and_number
+            )
         else:
             return NotImplemented
 
@@ -78,8 +82,12 @@ class PlayerAvatar:
 
     @cached_property
     def map_location(self) -> MapLocation:
-        return MapLocation(read_symbol("gMapHeader"), self._object_event.map_group, self._object_event.map_num,
-                           self._object_event.current_coords)
+        return MapLocation(
+            read_symbol("gMapHeader"),
+            self._object_event.map_group,
+            self._object_event.map_num,
+            self._object_event.current_coords,
+        )
 
     @property
     def local_coordinates(self) -> tuple[int, int]:
@@ -91,8 +99,7 @@ class PlayerAvatar:
 
     @property
     def is_on_bike(self) -> bool:
-        return AvatarFlags.OnAcroBike in self.flags \
-            or AvatarFlags.OnMachBike in self.flags
+        return AvatarFlags.OnAcroBike in self.flags or AvatarFlags.OnMachBike in self.flags
 
     @property
     def running_state(self) -> RunningState:

--- a/modules/state_cache.py
+++ b/modules/state_cache.py
@@ -5,7 +5,7 @@ from modules.context import context
 
 if TYPE_CHECKING:
     from modules.memory import GameState
-    from modules.player import Player
+    from modules.player import Player, PlayerAvatar
     from modules.pokemon import Pokemon
     from modules.tasks import TaskList
 
@@ -47,6 +47,7 @@ class StateCache:
         self._party: StateCacheItem[list["Pokemon"]] = StateCacheItem([])
         self._opponent: StateCacheItem["Pokemon | None"] = StateCacheItem(None)
         self._player: StateCacheItem["Player | None"] = StateCacheItem(None)
+        self._player_avatar: StateCacheItem["PlayerAvatar | None"] = StateCacheItem(None)
         self._tasks: StateCacheItem["TaskList | None"] = StateCacheItem(None)
         self._game_state: StateCacheItem["GameState | None"] = StateCacheItem(None)
 
@@ -84,8 +85,21 @@ class StateCache:
 
     @player.setter
     def player(self, player: "Player"):
-        if self._opponent.value is None or player != self._opponent.value:
+        if self._player.value is None or player != self._player.value:
             self._player.value = player
+        else:
+            self._player.checked()
+
+    @property
+    def player_avatar(self) -> StateCacheItem["PlayerAvatar | None"]:
+        return self._player_avatar
+
+    @player_avatar.setter
+    def player_avatar(self, player_avatar: "PlayerAvatar"):
+        if self._player_avatar.value is None or player_avatar != self._player_avatar.value:
+            self._player_avatar.value = player_avatar
+        else:
+            self._player_avatar.checked()
 
     @property
     def tasks(self) -> StateCacheItem["TaskList | None"]:

--- a/modules/web/Readme.md
+++ b/modules/web/Readme.md
@@ -121,6 +121,12 @@ second containing some basic performance data (e.g. FPS, encounter rate, ...)
 This event is also called `PerformanceData`
 
 
+### Topic `Player`
+
+This will send you a `Player` event whenever some basic data of the player
+changes, such as name, cash, coins, and the registered (select) item.
+
+
 ### Topic `Opponent`
 
 This will send you an `Opponent` event each time the opponent changes.

--- a/modules/web/http_example.html
+++ b/modules/web/http_example.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>PokéBot</title>
     <!--
     Note: This is just an example page, showing how to use the streaming API.
@@ -10,32 +11,74 @@
     -->
 </head>
 <body>
-<p>
-    <img src="/stream_video?fps=30" width="480" height="320" id="gba_video"/>
-</p>
+<div id="screen_loading">Loading Data&hellip;</div>
+<div id="screen_connection_lost">Connection Lost.<br/>Retrying&hellip;</div>
 
-<p>
-    FPS: <strong id="fps"></strong> &middot;
-    Bot Percentage: <strong id="bot_percentage"></strong> &middot;
-    Encounter Rate: <strong id="encounter_rate"></strong><br/>
-    Bot Mode: <strong id="bot_mode"></strong> &middot;
-    Game State: <strong id="game_mode"></strong> &middot;
-    Emulation Speed: <strong id="emulation_speed"></strong> &middot;
-    Video Enabled: <strong id="video_enabled"></strong> &middot;
-    Audio Enabled: <strong id="audio_enabled"></strong><br/>
-    Message: <strong id="message"></strong>
-</p>
+<div id="first_row">
+    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=" alt="Emulator Video" id="gba_video"/>
 
-<h2>Party</h2>
+    <div id="emulator_card">
+        <p id="performance_data">
+            FPS: <strong id="fps"></strong> &middot;
+            Bot Percentage: <strong id="bot_percentage"></strong> &middot;
+            Encounter Rate: <strong id="encounter_rate"></strong>
+        </p>
 
-<ol>
-    <li id="party0" class="party-entry"></li>
-    <li id="party1" class="party-entry"></li>
-    <li id="party2" class="party-entry"></li>
-    <li id="party3" class="party-entry"></li>
-    <li id="party4" class="party-entry"></li>
-    <li id="party5" class="party-entry"></li>
-</ol>
+        <ul>
+            <li>Bot Mode: <strong id="bot_mode"></strong></li>
+            <li>Game State: <strong id="game_mode"></strong></li>
+            <li>Emulation Speed: <strong id="emulation_speed"></strong></li>
+            <li>Video Enabled: <strong id="video_enabled"></strong></li>
+            <li>Audio Enabled: <strong id="audio_enabled"></strong></li>
+            <li>Message: <strong id="message"></strong></li>
+        </ul>
+    </div>
+</div>
+
+<div id="second_row">
+    <div id="trainer_card">
+        <h2>Player Data</h2>
+
+        <ul>
+            <li>Player Name: <strong id="player_name"></strong></li>
+            <li>Gender: <strong id="player_gender"></strong></li>
+            <li>Trainer ID: <strong id="trainer_id"></strong></li>
+            <li>Secret ID: <strong id="secret_id"></strong></li>
+            <li>Money: <strong id="player_money"></strong></li>
+            <li>Coins: <strong id="player_coins"></strong></li>
+            <li>Registered (Select) Item: <strong id="registered_item"></strong></li>
+        </ul>
+    </div>
+
+    <div id="party_card">
+        <h2>Party</h2>
+
+        <ol>
+            <li id="party0" class="party-entry"></li>
+            <li id="party1" class="party-entry"></li>
+            <li id="party2" class="party-entry"></li>
+            <li id="party3" class="party-entry"></li>
+            <li id="party4" class="party-entry"></li>
+            <li id="party5" class="party-entry"></li>
+        </ol>
+    </div>
+
+    <div id="map_card">
+        <h2>Map</h2>
+
+        <ul>
+            <li>Current Map: <strong id="map_name"></strong> (type: <strong id="map_type"></strong>)</li>
+            <li>Weather: <strong id="weather"></strong></li>
+            <li>Properties: <strong id="map_properties"></strong></li>
+        </ul>
+
+        <ul>
+            <li>Local Coordinates: <strong id="local_coords"></strong></li>
+            <li>Tile Type: <strong id="tile_type"></strong></li>
+            <li>Properties: <strong id="tile_properties"></strong></li>
+        </ul>
+    </div>
+</div>
 
 <div class="encounter-container">
     <div id="encounter">
@@ -44,21 +87,9 @@
     </div>
 </div>
 
-<h2>Map</h2>
+<h2 id="mini_map_headline">Mini Map</h2>
 
 <canvas id="mini_map"></canvas>
-
-<p>
-    Current Map: <strong id="map_name"></strong> (type: <strong id="map_type"></strong>)<br/>
-    Weather: <strong id="weather"></strong><br/>
-    Properties: <strong id="map_properties"></strong>
-</p>
-
-<p>
-    Local Coordinates: <strong id="local_coords"></strong><br/>
-    Tile Type: <strong id="tile_type"></strong><br/>
-    Properties: <strong id="tile_properties"></strong>
-</p>
 
 <h2>Event Log</h2>
 
@@ -75,58 +106,67 @@
      *
      * The streaming endpoint will only send _updates_ so this is still necessary.
      */
-    fetch("/emulator")
-        .then(response => response.json())
-        .then(data => {
-            /** @var {PokeBotApi.GetEmulatorResponse} */
-            handleBotModeChange(data.bot_mode);
-            handleEmulationSpeedChange(data.emulation_speed);
-            handleVideoEnabledChange(data.video_enabled);
-            handleAudioEnabledChange(data.audio_enabled);
-            handlePerformanceData({
-                fps: data.current_fps,
-                current_time_spent_in_bot_fraction: data.current_time_spent_in_bot_fraction,
-                encounter_rate: 0,
-                frame_count: 0,
-            });
-            handleMessageChange(data.current_message);
-        });
+    const initialDataFetchPromises = [
+        fetch("/emulator")
+            .then(response => response.json())
+            .then(data => {
+                /** @var {PokeBotApi.GetEmulatorResponse} */
+                handleBotModeChange(data.bot_mode);
+                handleEmulationSpeedChange(data.emulation_speed);
+                handleVideoEnabledChange(data.video_enabled);
+                handleAudioEnabledChange(data.audio_enabled);
+                handlePerformanceData({
+                    fps: data.current_fps,
+                    current_time_spent_in_bot_fraction: data.current_time_spent_in_bot_fraction,
+                    encounter_rate: 0,
+                    frame_count: 0,
+                });
+                handleMessageChange(data.current_message);
+            }),
 
-    fetch("/player")
-        .then(response => response.json())
-        .then(data => {
-            /** @var {PokeBotApi.GetPlayerResponse} */
-            handleGameStateChange(data.game_state);
-        });
+        fetch("/game_state")
+            .then(response => response.json())
+            .then(data => {
+                /** @var {PokeBotApi.GetGameStateResponse} */
+                handleGameStateChange(data);
+            }),
 
-    fetch("/party")
-        .then(response => response.json())
-        .then(data => {
-            /** @var {PokeBotApi.GetPartyResponse} */
-            handlePartyChange(data);
-        });
+        fetch("/player")
+            .then(response => response.json())
+            .then(data => {
+                /** @var {PokeBotApi.GetPlayerResponse} */
+                handlePlayerChange(data);
+            }),
 
-    fetch("/opponent")
-        .then(response => response.json())
-        .then(data => {
-            /** @var {PokeBotApi.GetOpponentResponse} */
-            handleOpponentChange(data);
-        });
+        fetch("/party")
+            .then(response => response.json())
+            .then(data => {
+                /** @var {PokeBotApi.GetPartyResponse} */
+                handlePartyChange(data);
+            }),
 
-    fetch("/encounter_rate")
-        .then(response => response.json())
-        .then(data => {
-            /** @var {PokeBotApi.GetEncounterRateResponse} */
-            document.getElementById("encounter_rate").innerText = data.encounter_rate + "/hr";
-        });
+        fetch("/opponent")
+            .then(response => response.json())
+            .then(data => {
+                /** @var {PokeBotApi.GetOpponentResponse} */
+                handleOpponentChange(data);
+            }),
 
-    fetch("/map")
-        .then(response => response.json())
-        .then(data => {
-            /** @var {PokeBotApi.GetMapResponse} */
-            handleMapChange(data);
-            handleMapTileChange(data.player_position);
-        })
+        fetch("/encounter_rate")
+            .then(response => response.json())
+            .then(data => {
+                /** @var {PokeBotApi.GetEncounterRateResponse} */
+                document.getElementById("encounter_rate").innerText = data.encounter_rate + "/hr";
+            }),
+
+        fetch("/map")
+            .then(response => response.json())
+            .then(data => {
+                /** @var {PokeBotApi.GetMapResponse} */
+                handleMapChange(data);
+                handleMapTileChange(data.player_position);
+            }),
+    ];
 
 
     /*
@@ -150,18 +190,31 @@
      *
      * In this example, we are handling all possible events.
      */
-    const eventSource = new EventSource(url);
-    eventSource.addEventListener("PerformanceData", event => handlePerformanceData(JSON.parse(event.data)));
-    eventSource.addEventListener("Party", event => handlePartyChange(JSON.parse(event.data)));
-    eventSource.addEventListener("Opponent", event => handleOpponentChange(JSON.parse(event.data)));
-    eventSource.addEventListener("MapChange", event => handleMapChange(JSON.parse(event.data)));
-    eventSource.addEventListener("MapTileChange", event => handleMapTileChange(JSON.parse(event.data)));
-    eventSource.addEventListener("Message", event => handleMessageChange(JSON.parse(event.data)));
-    eventSource.addEventListener("GameState", event => handleGameStateChange(JSON.parse(event.data)));
-    eventSource.addEventListener("BotMode", event => handleBotModeChange(JSON.parse(event.data)));
-    eventSource.addEventListener("EmulationSpeed", event => handleEmulationSpeedChange(JSON.parse(event.data)));
-    eventSource.addEventListener("AudioEnabled", event => handleAudioEnabledChange(JSON.parse(event.data)));
-    eventSource.addEventListener("VideoEnabled", event => handleVideoEnabledChange(JSON.parse(event.data)));
+    Promise.all(initialDataFetchPromises).then(() => {
+        const eventSource = new EventSource(url);
+        eventSource.addEventListener("PerformanceData", event => handlePerformanceData(JSON.parse(event.data)));
+        eventSource.addEventListener("Player", event => handlePlayerChange(JSON.parse(event.data)));
+        eventSource.addEventListener("Party", event => handlePartyChange(JSON.parse(event.data)));
+        eventSource.addEventListener("Opponent", event => handleOpponentChange(JSON.parse(event.data)));
+        eventSource.addEventListener("MapChange", event => handleMapChange(JSON.parse(event.data)));
+        eventSource.addEventListener("MapTileChange", event => handleMapTileChange(JSON.parse(event.data)));
+        eventSource.addEventListener("Message", event => handleMessageChange(JSON.parse(event.data)));
+        eventSource.addEventListener("GameState", event => handleGameStateChange(JSON.parse(event.data)));
+        eventSource.addEventListener("BotMode", event => handleBotModeChange(JSON.parse(event.data)));
+        eventSource.addEventListener("EmulationSpeed", event => handleEmulationSpeedChange(JSON.parse(event.data)));
+        eventSource.addEventListener("AudioEnabled", event => handleAudioEnabledChange(JSON.parse(event.data)));
+        eventSource.addEventListener("VideoEnabled", event => handleVideoEnabledChange(JSON.parse(event.data)));
+
+        document.getElementById("screen_loading").style.display = "none";
+        eventSource.onerror = () => {
+            document.getElementById("screen_connection_lost").style.display = "flex";
+        };
+        eventSource.onopen = () => {
+            document.getElementById("screen_connection_lost").style.display = "none";
+            document.getElementById("gba_video").src = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+            document.getElementById("gba_video").src = "/stream_video?fps=30&cache_buster=" + (new Date).toString();
+        };
+    });
 
     function log(html)
     {
@@ -188,6 +241,31 @@
         document.getElementById("bot_percentage").innerText = (data.current_time_spent_in_bot_fraction * 100).toLocaleString("en-GB", {maximumFractionDigits: 1}) + "%";
         if (data.encounter_rate > 0) {
             document.getElementById("encounter_rate").innerText = data.encounter_rate.toLocaleString("en-GB") + "/hr";
+        }
+    }
+
+    /**
+     * @param {StreamEvents.Player} data
+     */
+    function handlePlayerChange(data)
+    {
+        document.getElementById("player_name").innerText = data.name;
+        document.getElementById("player_gender").innerText = data.gender;
+        if (data.gender === "male") {
+            document.getElementById("player_gender").style.color = "#058";
+        } else {
+            document.getElementById("player_gender").style.color = "#909";
+        }
+        document.getElementById("trainer_id").innerText = data.trainer_id.toString();
+        document.getElementById("secret_id").innerText = data.secret_id.toString();
+        document.getElementById("player_money").innerText = "$" + data.money.toLocaleString("en-GB");
+        document.getElementById("player_coins").innerText = data.coins.toLocaleString("en-GB");
+        if (data.registered_item) {
+            document.getElementById("registered_item").innerText = data.registered_item;
+            document.getElementById("registered_item").classList.remove("none");
+        } else {
+            document.getElementById("registered_item").innerText = "none";
+            document.getElementById("registered_item").classList.add("none");
         }
     }
 
@@ -310,6 +388,9 @@
 `;
     }
 
+    /**
+     * @param {StreamEvents.MapChange} data
+     */
     function handleMapChange(data)
     {
         mapData = data;
@@ -340,7 +421,7 @@
     }
 
     /**
-     * @param {StreamEvents.MapChange} data
+     * @param {StreamEvents.MapTileChange} data
      */
     function handleMapTileChange(data)
     {
@@ -369,11 +450,17 @@
     }
 
     /**
-     * @param {StreamEvents.MapTileChange} data
+     * @param {StreamEvents.Message} data
      */
     function handleMessageChange(data)
     {
-        document.getElementById("message").innerText = data ?? "";
+        if (data !== null && data !== "") {
+            document.getElementById("message").innerText = data;
+            document.getElementById("message").classList.remove("none");
+        } else {
+            document.getElementById("message").innerText = "none";
+            document.getElementById("message").classList.add("none");
+        }
     }
 
     /**
@@ -462,15 +549,23 @@
                 } else if (tile.type.includes("Water") || tile.type.includes("Current")) {
                     if (tile.has_encounters) {
                         colour = "#08F";
+                    } else if (tile.type.includes("Deep Water")) {
+                        colour = "#05B";
                     } else {
                         colour = "#0FF";
                     }
-                } else if (tile.collision && tile.type.includes("Warp")) {
+                } else if (tile.type.includes("Warp") || tile.type === "Non-Animated Door") {
                     colour = "#F0F";
+                } else if (tile.type.startsWith("Jump")) {
+                    colour = "#a50";
                 } else if (tile.collision) {
                     colour = "#000";
                 } else if (tile.has_encounters) {
                     colour = "#080";
+                } else if (tile.type === "Sand") {
+                    colour = "#ffd";
+                } else if (tile.type === "Deep Sand") {
+                    colour = "#ffb";
                 }
 
                 if (colour !== null) {
@@ -500,13 +595,51 @@
 </script>
 
 <style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+
+    #first_row > div, #second_row > div {
+        padding: 1rem;
+        box-sizing: border-box;
+    }
+
+    #second_row h2 {
+        margin-top: 0;
+    }
+
+    .none {
+        color: #aaa;
+    }
+
     #gba_video {
-        position: absolute;
-        top: 0;
-        right: 0;
-        border-left: 1px #000 solid;
+        border-right: 1px #000 solid;
         border-bottom: 1px #000 solid;
+        margin-right: 1rem;
         image-rendering: crisp-edges;
+        box-sizing: border-box;
+
+        aspect-ratio: 1.5;
+        width: 100%;
+        max-width: 480px;
+    }
+
+    @media screen and (max-width: 520px) {
+        #gba_video {
+            margin-right: 0;
+        }
+    }
+
+    #emulator_card, #trainer_card, #party_card, #map_card {
+        display: inline-block;
+        vertical-align: top;
+        width: 100%;
+        max-width: 500px;
+    }
+
+    #emulator_card ul, #trainer_card ul, #party_card ol, #map_card ul {
+        padding-left: 1rem;
     }
 
     .party-entry {
@@ -560,11 +693,36 @@
         background-color: rgba(0, 0, 0, 0.2);
     }
 
+    @media screen and (max-width: 479px) {
+        #encounter table {
+            margin-top: .5rem;
+        }
+
+        #encounter th, #encounter td {
+            font-size: 70%;
+        }
+    }
+
     #mini_map {
         border: 1px #000 solid;
-        float: right;
-        margin-right: 1rem;
-        margin-bottom: 1rem;
+        box-sizing: border-box;
+        margin: 1rem 0;
+        max-width: 100%;
+    }
+
+    @media screen and (min-width: 1400px) {
+        #mini_map_headline {
+            display: none;
+        }
+
+        #mini_map {
+            margin: 0;
+            position: absolute;
+            top: 0;
+            right: 0;
+            border-top: 0;
+            border-right: 0;
+        }
     }
 
     #log p {
@@ -575,6 +733,33 @@
         font-size: 75%;
         color: #888;
         margin-right: 10px;
+    }
+
+
+    #screen_loading, #screen_connection_lost {
+        position: fixed;
+        z-index: 1;
+
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        text-align: center;
+
+        font-size: 3rem;
+    }
+
+    #screen_loading {
+        background-color: rgba(255, 240, 80, 0.75);
+    }
+
+    #screen_connection_lost {
+        display: none;
+        background-color: rgba(255, 120, 120, 0.75);
     }
 </style>
 </body>

--- a/modules/web/pokemon.d.ts
+++ b/modules/web/pokemon.d.ts
@@ -424,3 +424,40 @@ export type MapLocation = {
     // Information about _all_ the tiles on that map, indexed by x/y.
     tiles: MapTileData[][];
 };
+
+export type Player = {
+    name: string;
+    gender: "male" | "female";
+
+    trainer_id: number;
+    secret_id: number;
+
+    money: number;
+    coins: number;
+
+    registered_item: string;
+};
+
+export type PlayerAvatar = {
+    map_group_and_number: [number, number];
+
+    // Local coordinates (in tiles) on the current map.
+    local_coordinates: [number, number];
+
+    running_state: "NOT_MOVING" | "TURN_DIRECTION" | "MOVING";
+    tile_transition_state: "NOT_MOVING" | "TRANSITIONING" | "CENTERING";
+    acro_bike_state: "NORMAL" | "TURNING" | "STANDING_WHEELIE" | "HOPPING_WHEELIE" | "MOVING_WHEELIE";
+    on_bike: boolean;
+    facing_direction: "Down" | "Up" | "Left" | "Right";
+
+    flags: {
+        OnFoot: boolean;
+        OnMachBike: boolean;
+        OnAcroBike: boolean;
+        Surfing: boolean;
+        Underwater: boolean;
+        Controllable: boolean;
+        ForciblyMoving: boolean;
+        Dash: boolean;
+    };
+};

--- a/modules/web/routes.d.ts
+++ b/modules/web/routes.d.ts
@@ -1,4 +1,4 @@
-import {MapLocation, Pokemon} from "./pokemon";
+import {MapLocation, Player, PlayerAvatar, Pokemon} from "./pokemon";
 
 declare module PokeBotApi {
     /**
@@ -75,35 +75,19 @@ declare module PokeBotApi {
     export type GetFPSResponse = number[];
 
     /**
+     * Response body for `GET /game_state`
+     */
+    export type GetGameStateResponse = string;
+
+    /**
      * Response body for `GET /player`.
      */
-    export type GetPlayerResponse = null | {
-        name: string;
-        gender: "male" | "female";
+    export type GetPlayerResponse = null | Player;
 
-        // Trainer ID.
-        tid: number;
-
-        // Secret ID.
-        sid: number;
-
-        // Current map group and map number.
-        map: [number, number];
-
-        // Name of the map the player is currently on.
-        map_name: string;
-
-        // Local coordinates (in tiles) on the current map.
-        coords: [number, number];
-
-        running_state: number;
-        tile_transition_state: number;
-        acro_bike_state: number;
-        on_bike: boolean;
-        facing_direction: "Down" | "Up" | "Left" | "Right";
-
-        game_state: string;
-    };
+    /**
+     * Response body for `GET /player_avatar`
+     */
+    export type GetPlayerAvatarResponse = null | PlayerAvatar;
 
     /**
      * Response body for `GET /party`.

--- a/modules/web/stream_events.d.ts
+++ b/modules/web/stream_events.d.ts
@@ -1,4 +1,4 @@
-import {MapLocation, Pokemon} from "./pokemon";
+import {MapLocation, Pokemon, Player as PlayerType} from "./pokemon";
 
 declare module StreamEvents {
     export type PerformanceData = {
@@ -18,6 +18,9 @@ declare module StreamEvents {
         // Last calculated encounter rate.
         encounter_rate: number;
     };
+
+    // Contains some basic data about the player (such as name, IDs, current money, ...)
+    export type Player = PlayerType;
 
     // Lists Pokémon in the current party. May contain between 0 and 6 entries.
     export type Party = Pokemon[];


### PR DESCRIPTION
Since I've completely messed up the HTTP API anyway, I have decided to make a few more changes to the data structures:

I have separated player data into:

1. `Player` structure which contains rarely-changing data such as name, IDs, but now also money, coins and the registered item
2. `PlayerAvatar` which contains the player location and various states of the player on the map such as facing direction, transition state etc. I've also exposed _all_ avatar flags.

The reasoning behind this is that I would like to be able to push changes to player data via the event stream endpoint -- but without this split that would be very noisy; because the player data changes _several times_ for each time you turn or move to another tile due to the tile transition state stuff. And realistically, a web client probably doesn't care about those changes anyway.

The HTTP API as well as streamed events have changed accordingly:

- `/player` only contains that rarely-changing data
- `/player_avatar` contains the on-map character data
- a new `/game_state` endpoint contains the current game state, which was previously included in the `/player` endpoint which seemed a bit arbitrary to me
- a new `Player` event can inform HTTP clients about changes to the player (usually change in money or registered item)

The example HTTP page has been updated accordingly, and slightly restructured visually.

![image](https://github.com/40Cakes/pokebot-gen3/assets/1106400/af47cea9-a34e-4468-8777-3287f3142dc3)