### PR TITLE
Extract more map data

### DIFF
--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -883,7 +883,7 @@ class MapTab(DebugTab):
             event = map_bg_events[i]
             kind = event.kind
             key = format_coordinates(event.local_coordinates)
-            if kind.startswith("Script"):
+            if kind == "Script":
                 bg_events_list[key] = {
                     "__value": f"Script/Sign ({event.script_symbol})",
                     "Script": event.script_symbol,

--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -31,14 +31,14 @@ if TYPE_CHECKING:
 
 class FancyTreeview:
     def __init__(
-            self,
-            root: ttk.Widget,
-            height=22,
-            row=0,
-            column=0,
-            columnspan=1,
-            additional_context_actions: Optional[dict[str, callable]] = None,
-            on_highlight: Optional[callable] = None,
+        self,
+        root: ttk.Widget,
+        height=22,
+        row=0,
+        column=0,
+        columnspan=1,
+        additional_context_actions: Optional[dict[str, callable]] = None,
+        on_highlight: Optional[callable] = None,
     ):
         if additional_context_actions is None:
             additional_context_actions = {}
@@ -76,6 +76,7 @@ class FancyTreeview:
         self._tv.bind("<Right>", lambda _: root.focus_set())
 
         if on_highlight is not None:
+
             def handle_selection(e):
                 selected_item = self._tv.focus()
                 on_highlight(self._tv.item(selected_item)["text"])
@@ -515,7 +516,7 @@ class SymbolsTab(DebugTab):
                 n = int.from_bytes(value, byteorder="little")
                 binary_string = bin(n).removeprefix("0b").rjust(length * 8, "0")
                 chunk_size = 4
-                chunks = [binary_string[i: i + chunk_size] for i in range(0, len(binary_string), chunk_size)]
+                chunks = [binary_string[i : i + chunk_size] for i in range(0, len(binary_string), chunk_size)]
                 data[symbol] = " ".join(chunks)
             else:
                 data[symbol] = value.hex(" ", 1)
@@ -777,11 +778,11 @@ class MapTab(DebugTab):
         actual_x = current_map_data.local_position[0] + (tile_x - 7)
         actual_y = current_map_data.local_position[1] + (tile_y - 5)
         if (
-                self._selected_tile == (actual_x, actual_y)
-                or actual_x < 0
-                or actual_x >= current_map_data.map_size[0]
-                or actual_y < 0
-                or actual_y >= current_map_data.map_size[1]
+            self._selected_tile == (actual_x, actual_y)
+            or actual_x < 0
+            or actual_x >= current_map_data.map_size[0]
+            or actual_y < 0
+            or actual_y >= current_map_data.map_size[1]
         ):
             self._selected_tile = None
             self._selected_map = None
@@ -839,8 +840,9 @@ class MapTab(DebugTab):
         map_connections = map_data.connections
         connections_list = {"__value": set()}
         for i in range(len(map_connections)):
-            connections_list[map_connections[i].direction] = \
-                f"to {map_connections[i].destination_map.map_name} (offset: {str(map_connections[i].offset)})"
+            connections_list[
+                map_connections[i].direction
+            ] = f"to {map_connections[i].destination_map.map_name} (offset: {str(map_connections[i].offset)})"
             connections_list["__value"].add(map_connections[i].direction)
         connections_list["__value"] = ", ".join(connections_list["__value"])
 
@@ -849,8 +851,9 @@ class MapTab(DebugTab):
         for i in range(len(map_warps)):
             warp = map_warps[i]
             d = warp.destination_location
-            warps_list[format_coordinates(warp.local_coordinates)] = \
-                f"to ({format_coordinates(d.local_position)}) on [{d.map_group}, {d.map_number}] ({d.map_name})"
+            warps_list[
+                format_coordinates(warp.local_coordinates)
+            ] = f"to ({format_coordinates(d.local_position)}) on [{d.map_group}, {d.map_number}] ({d.map_name})"
 
         map_object_templates = map_data.objects
         object_templates_list = {"__value": len(map_object_templates)}
@@ -871,8 +874,9 @@ class MapTab(DebugTab):
             else:
                 object_templates_list[key]["target_local_id"] = obj.clone_target_local_id
                 target_map = obj.clone_target_map
-                object_templates_list[key]["target_map"] = \
-                    f"{target_map.map_name} [{target_map.map_group}, {target_map.map_number}]"
+                object_templates_list[key][
+                    "target_map"
+                ] = f"{target_map.map_name} [{target_map.map_group}, {target_map.map_number}]"
 
         map_coord_events = map_data.coord_events
         coord_events_list = {"__value": len(map_coord_events)}

--- a/modules/http.py
+++ b/modules/http.py
@@ -7,10 +7,12 @@ from flask_cors import CORS
 
 from modules.config import available_bot_modes
 from modules.context import context
+from modules.data.map import MapRSE, MapFRLG
 from modules.game import _event_flags
 from modules.http_stream import add_subscriber
 from modules.items import get_items
 from modules.main import work_queue
+from modules.map import get_map_data
 from modules.memory import get_event_flag, get_game_state, GameState
 from modules.pokemon import get_party
 from modules.stats import total_stats
@@ -110,6 +112,24 @@ def http_server() -> None:
             data = None
 
         return jsonify(data)
+
+    @server.route("/map/<int:map_group>/<int:map_number>")
+    def http_get_map_by_group_and_number(map_group: int, map_number: int):
+        if context.rom.game_title in ["POKEMON EMER", "POKEMON RUBY", "POKEMON SAPP"]:
+            maps_enum = MapRSE
+        else:
+            maps_enum = MapFRLG
+
+        try:
+            maps_enum((map_group, map_number))
+        except ValueError:
+            return Response(f"No such map: {str(map_group)}, {str(map_number)}", status=404)
+
+        map_data = get_map_data(map_group, map_number, local_position=(0, 0))
+        return jsonify({
+            "map": map_data.dict_for_map(),
+            "tiles": map_data.dicts_for_all_tiles(),
+        })
 
     @server.route("/party", methods=["GET"])
     def http_get_party():

--- a/modules/http.py
+++ b/modules/http.py
@@ -139,10 +139,12 @@ def http_server() -> None:
             return Response(f"No such map: {str(map_group)}, {str(map_number)}", status=404)
 
         map_data = get_map_data(map_group, map_number, local_position=(0, 0))
-        return jsonify({
-            "map": map_data.dict_for_map(),
-            "tiles": map_data.dicts_for_all_tiles(),
-        })
+        return jsonify(
+            {
+                "map": map_data.dict_for_map(),
+                "tiles": map_data.dicts_for_all_tiles(),
+            }
+        )
 
     @server.route("/party", methods=["GET"])
     def http_get_party():

--- a/modules/map.py
+++ b/modules/map.py
@@ -602,7 +602,7 @@ class MapBgEvent:
 
     @property
     def player_facing_direction(self) -> str:
-        """ This only has meaning if `kind` is 'Script'. """
+        """This only has meaning if `kind` is 'Script'."""
         match self._data[5]:
             case 0:
                 return "Any"
@@ -619,12 +619,12 @@ class MapBgEvent:
 
     @property
     def script_pointer(self) -> int:
-        """ This only has meaning if `kind` is 'Script'. """
+        """This only has meaning if `kind` is 'Script'."""
         return unpack_uint32(self._data[8:12])
 
     @property
     def script_symbol(self) -> str:
-        """ This only has meaning if `kind` is 'Script'. """
+        """This only has meaning if `kind` is 'Script'."""
         symbol = get_symbol_name(self.script_pointer, pretty_name=True)
         if symbol == "":
             return hex(self.script_pointer)
@@ -633,17 +633,17 @@ class MapBgEvent:
 
     @property
     def hidden_item(self) -> Item:
-        """ This only has meaning if `kind` is 'Hidden Item'. """
+        """This only has meaning if `kind` is 'Hidden Item'."""
         return get_item_by_index(unpack_uint16(self._data[8:10]))
 
     @property
     def hidden_item_flag_id(self) -> int:
-        """ This only has meaning if `kind` is 'Hidden Item'. """
+        """This only has meaning if `kind` is 'Hidden Item'."""
         return unpack_uint16(self._data[10:12])
 
     @property
     def secret_base_id(self) -> int:
-        """ This only has meaning if `kind` is 'Secret Base'. """
+        """This only has meaning if `kind` is 'Secret Base'."""
         return unpack_uint32(self._data[8:12])
 
     def to_dict(self) -> dict:
@@ -895,7 +895,7 @@ class MapLocation:
 
         result = []
         for index in range(count):
-            result.append(MapConnection(data[size_of_struct * index:size_of_struct * (index + 1)]))
+            result.append(MapConnection(data[size_of_struct * index : size_of_struct * (index + 1)]))
         return result
 
     @property
@@ -910,7 +910,7 @@ class MapLocation:
 
         result = []
         for index in range(warp_count):
-            result.append(MapWarp(data[size_of_struct * index:size_of_struct * (index + 1)]))
+            result.append(MapWarp(data[size_of_struct * index : size_of_struct * (index + 1)]))
         return result
 
     @property
@@ -925,7 +925,7 @@ class MapLocation:
 
         result = []
         for index in range(object_event_count):
-            result.append(ObjectEventTemplate(data[size_of_struct * index:size_of_struct * (index + 1)]))
+            result.append(ObjectEventTemplate(data[size_of_struct * index : size_of_struct * (index + 1)]))
         return result
 
     @property
@@ -940,7 +940,7 @@ class MapLocation:
 
         result = []
         for index in range(coord_event_count):
-            result.append(MapCoordEvent(data[size_of_struct * index:size_of_struct * (index + 1)]))
+            result.append(MapCoordEvent(data[size_of_struct * index : size_of_struct * (index + 1)]))
         return result
 
     @property
@@ -955,7 +955,7 @@ class MapLocation:
 
         result = []
         for index in range(bg_event_count):
-            result.append(MapBgEvent(data[size_of_struct * index:size_of_struct * (index + 1)]))
+            result.append(MapBgEvent(data[size_of_struct * index : size_of_struct * (index + 1)]))
         return result
 
     def all_tiles(self) -> list[list["MapLocation"]]:
@@ -1536,22 +1536,22 @@ class ObjectEventTemplate:
 
     @property
     def clone_target_local_id(self) -> int:
-        """ This only has meaning if `kind` is 'clone' on FRLG. """
+        """This only has meaning if `kind` is 'clone' on FRLG."""
         return self.elevation
 
     @property
     def clone_target_map_group(self) -> int:
-        """ This only has meaning if `kind` is 'clone' on FRLG. """
+        """This only has meaning if `kind` is 'clone' on FRLG."""
         return unpack_uint16(self._data[12:14])
 
     @property
     def clone_target_map_number(self) -> int:
-        """ This only has meaning if `kind` is 'clone' on FRLG. """
+        """This only has meaning if `kind` is 'clone' on FRLG."""
         return unpack_uint16(self._data[14:16])
 
     @property
     def clone_target_map(self) -> MapLocation:
-        """ This only has meaning if `kind` is 'clone' on FRLG. """
+        """This only has meaning if `kind` is 'clone' on FRLG."""
         return get_map_data(self.clone_target_map_group, self.clone_target_map_number, (0, 0))
 
     def to_dict(self) -> dict:
@@ -1582,7 +1582,7 @@ class ObjectEventTemplate:
                 "map_group": self.clone_target_map_group,
                 "map_number": self.clone_target_map_number,
                 "map_name": self.clone_target_map.map_name,
-                "local_id": self.local_id
+                "local_id": self.local_id,
             }
 
         return data
@@ -1619,7 +1619,7 @@ def get_map_objects() -> list[ObjectEvent]:
         offset = i * 0x24
         is_active = bool(data[offset] & 0x01)
         if is_active:
-            map_object = ObjectEvent(data[offset: offset + 0x24])
+            map_object = ObjectEvent(data[offset : offset + 0x24])
             objects.append(map_object)
     return objects
 

--- a/modules/web/pokemon.d.ts
+++ b/modules/web/pokemon.d.ts
@@ -363,6 +363,83 @@ export type Weather =
     | "Route 119 Cycle"
     | "Route 123 Cycle"
 
+type MapConnection = {
+    direction: "South" | "North" | "West" | "East" | "Dive" | "Emerge";
+
+    // Offset of the connecting map compared to this one, i.e. how many tiles
+    // a player needs to be moved up/down/left/right (depending on connection
+    // direction) when transitioning maps.
+    offset: number;
+
+    destination: {
+        map_group: number;
+        map_number: number;
+        map_name: string;
+    }
+};
+
+type MapWarp = {
+    local_coordinates: [number, number];
+    elevation: number;
+    destination: {
+        map_group: number;
+        map_number: number;
+        map_name: string;
+
+        // Index of the warp on the destination map where this warp should
+        // lead to. This is used to figure out the local coordinates at the
+        // destination.
+        warp_id: number;
+    }
+};
+
+type MapTileEnterEvent = {
+    local_coordinates: [number, number];
+    elevation: number;
+
+    // Name of the script symbol in the pret decompilation project.
+    // This is not an official name and only here for easier reading of the list.
+    script: string;
+};
+
+type MapTileInteractEvent =
+    { local_coordinates: [number, number]; elevation: number; } & (
+        | { kind: "Script"; player_facing_direction: "Any" | "Up" | "Down" | "Right" | "Left"; script: string; }
+        | { kind: "Hidden Item"; item: string; }
+        | { kind: "Secret Base"; secret_base_id: number; }
+    );
+
+type MapRegularObjectTemplate = {
+    kind: "normal";
+
+    local_id: number;
+    local_coordinates: [number, number];
+    elevation: number;
+
+    // Name of the script symbol in the pret decompilation project.
+    // This is not an official name and only here for easier reading of the list.
+    script: string;
+
+    trainer: { type: "None" | "Normal" | "See All Directions" | "Buried"; range: number; } | null;
+    movement: { type: string; range: [number, number]; };
+};
+
+type MapCloneObjectTemplate = {
+    kind: "clone";
+
+    local_id: number;
+    local_coordinates: [number, number];
+
+    target: {
+        "map_group": number;
+        "map_number": number;
+        "map_name": string;
+        "local_id": number;
+    }
+};
+
+type MapObjectTemplate = MapRegularObjectTemplate | MapCloneObjectTemplate;
+
 type MapData = {
     map_group: number;
     map_number: number;
@@ -391,6 +468,27 @@ type MapData = {
     // Indicates that this map is 'dark', i.e. HM Flash needs to be used in order
     // to see properly.
     is_dark_cave: boolean;
+
+    // Where this map connects to in the overworld (can be up to one per cardinal
+    // direction, as well as one for diving/surfacing.
+    connections: MapConnection[];
+
+    // Tiles on this map that, when entering, will teleport the player to a
+    // different location on another map. This is used for implementing doors.
+    warps: MapWarp[];
+
+    // Events triggered by walking onto a tile.
+    tile_enter_events: MapTileEnterEvent[];
+
+    // Events triggered by interacting with ('talking to') a tile.
+    tile_interact_events: MapTileInteractEvent[];
+
+    // Objects that should be placed on this map.
+    // Not all of these objects might be present. Some are toggled on/off depending
+    // on some flag's value, and some objects might be NPCs that walk around and so
+    // are in different positions than `local_coordinates` indicates. (The range of
+    // their movement is defined by `movement.range`.)
+    object_templates: MapObjectTemplate[];
 };
 
 type MapTileData = {


### PR DESCRIPTION
This PR extends the `MapLocation` objects so it extracts some more data:

- **Map Connections**: Defines which maps a map connects to in each cardinal direction, as well as when diving/surfacing.
- **Warps**: Defines tiles that teleport the player to a different location, such as doors or those pitfalls.
- **Coord Events** or **Tile Enter Events**: Scripts that are triggered by entering a tile. (Examples for this would be Prof. Oak stopping you from accessing Route 1, or Prof. Birch whining when you try to leave the Route 101 map without helping him.)
- **BG Events** or **Tile Interaction Events**: Scripts that are triggered by interacting with a tile ('talking' to it), which also includes hidden items and secret base locations.
- **Object Event Templates**: A list of all map objects. The game only simulates objects that are within 1 tile of the camera. This list contains _all_ possible objects, even the non-active ones.

For now, this data is only used by the debug view. But it should be useful for pathing.

![image](https://github.com/40Cakes/pokebot-gen3/assets/1106400/a8c4de4f-de8d-4169-823c-dc526dfa7a0c)

![image](https://github.com/40Cakes/pokebot-gen3/assets/1106400/91d880f4-fbf8-4091-a34e-57b505535140)

![image](https://github.com/40Cakes/pokebot-gen3/assets/1106400/9b296967-b034-4c37-883d-8a77995fb8d5)

![image](https://github.com/40Cakes/pokebot-gen3/assets/1106400/b24b766f-46ef-453c-af73-60bd6f2768dd)
