### PR TITLE
Add information about how many EXP are needed to level up to Pokémon data structure

### DIFF
--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -1038,6 +1038,21 @@ class Pokemon:
         return self.data[84]
 
     @property
+    def exp_needed_until_next_level(self) -> int:
+        if self.level >= 100:
+            return 0
+        total_exp_for_next_level = self.species.level_up_type.get_experience_needed_for_level(self.level + 1)
+        return total_exp_for_next_level - self.total_exp
+
+    @property
+    def exp_fraction_to_next_level(self) -> float:
+        if self.level >= 100:
+            return 1
+        total_exp_for_this_level = self.species.level_up_type.get_experience_needed_for_level(self.level)
+        total_exp_for_next_level = self.species.level_up_type.get_experience_needed_for_level(self.level + 1)
+        return (self.total_exp - total_exp_for_this_level) / (total_exp_for_next_level - total_exp_for_this_level)
+
+    @property
     def sleep_duration(self) -> int:
         """Returns the remaining turns on the sleep condition."""
         turns = self.data[80] & 0b0111 if len(self.data) > 80 else 0

--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -1238,6 +1238,7 @@ class Pokemon:
                     result[k] = prepare(getattr(value, k))
 
             return result
+
         result = prepare(self)
         return result
 

--- a/modules/web/pokemon.d.ts
+++ b/modules/web/pokemon.d.ts
@@ -255,6 +255,15 @@ export type Pokemon = {
     // Current level of this Pokémon.
     level: number;
 
+    // Number of EXP the Pokémon still needs to collect until the next level-up.
+    // For level-100 Pokémon, this is always 0.
+    exp_needed_until_next_level: number;
+
+    // Number between 0 and 1, indicating how many EXP towards the next level have
+    // already been collected.
+    // For level-100 Pokémon, this is always 1.
+    exp_fraction_to_next_level: number;
+
     // Current status condition of this Pokémon.
     status_condition: StatusCondition;
 


### PR DESCRIPTION
This adds the number for EXP needed to level up, as well as the percentage of EXP towards the next level already collected (the latter would allow creating an EXP progress bar like in the games.)