### PR TITLE
Fix item stack sizes for 'bag full' calculation

### DIFF
--- a/modules/items.py
+++ b/modules/items.py
@@ -171,8 +171,14 @@ class ItemBag:
         if len(pocket) < pocket_size:
             return True
 
+        # In FireRed/LeafGreen, you can always put 999 items in a stack. In RSE, this only works for berries.
+        if context.rom.game_title in ["POKEMON FIRE", "POKEMON LEAF"] or item.pocket == ItemPocket.Berries:
+            stack_size = 999
+        else:
+            stack_size = 99
+
         for slot in pocket:
-            if slot.item == item and slot.quantity < 99:
+            if slot.item == item and slot.quantity < stack_size:
                 return True
 
         return False
@@ -243,7 +249,7 @@ class ItemStorage:
             return True
 
         for slot in self.items:
-            if slot.item == item and slot.quantity < 99:
+            if slot.item == item and slot.quantity < 999:
                 return True
 
         return False


### PR DESCRIPTION
It turns out, my assumption that items can always stack up to 99 is not quite correct: Berries and items in PC storage can stack up to 999, and on FR/LG items from other bags as well.