### PR TITLE
Fix how ROMs are looked up for profiles

### DIFF
--- a/modules/profiles.py
+++ b/modules/profiles.py
@@ -72,7 +72,7 @@ def load_profile(path: Path) -> Profile:
                 [
                     rom.game_code == metadata.rom.game_code,
                     rom.revision == metadata.rom.revision,
-                    rom.language == metadata.rom.language,
+                    rom.language.value == metadata.rom.language,
                 ]
             ):
                 return Profile(rom, path, last_played)


### PR DESCRIPTION
When loading a profile, the bot has two approaches to find the correct ROM:

1. Find a ROM with the exact name stated in the profile's `metadata.yml`
2. If that fails, find a ROM that matches in game title, version number and language code.

Unfortunately, there was a bug with the second approach because the bot compared a string (from `metadata.yml`) with an Enum (from `load_rom_data()`) which caused that check to always fail.

So effectively, unless the ROM file name matched the bot would always complain about the ROM missing.

This makes sharing profiles for debugging/testing purposes harder.