### PR TITLE
Add Sweet Scent method

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -99,6 +99,11 @@ def main_loop() -> None:
                         from modules.modes.soft_resets import ModeStaticSoftResets
 
                         mode = ModeStaticSoftResets()
+                        
+                    case "Sweet Scent":
+                        from modules.modes.sweet_scent import ModeSweetScent
+
+                        mode = ModeSweetScent()
 
                     case "Tower Duo":
                         from modules.modes.tower_duo import ModeTowerDuo

--- a/modules/memory.py
+++ b/modules/memory.py
@@ -153,8 +153,6 @@ def get_game_state() -> GameState:
         return state_cache.game_state.value
 
     match get_game_state_symbol():
-        case "CB2_SETUPOVERWORLDFORQLPLAYBACKWITHWARPEXIT" | "CB2_SETUPOVERWORLDFORQLPLAYBACK" | "CB2_LOADMAPFORQLPLAYBACK" | "CB2_ENTERFIELDFROMQUESTLOG":
-            return GameState.QUEST_LOG
         case "CB2_OVERWORLD":
             result = GameState.OVERWORLD
         case "BATTLEMAINCB2":

--- a/modules/menu_parsers.py
+++ b/modules/menu_parsers.py
@@ -7,7 +7,7 @@ from modules.pokemon import get_party, parse_pokemon, Pokemon, get_move_by_index
 from modules.tasks import get_task, task_is_active
 
 
-class CursorOptionEFRLG(IntEnum):
+class CursorOptionE(IntEnum):
     SUMMARY = 0
     SWITCH = 1
     CANCEL_1 = 2
@@ -42,6 +42,41 @@ class CursorOptionEFRLG(IntEnum):
     SOFTBOILED = 31
     SWEET_SCENT = 32
 
+class CursorOptionFRLG(IntEnum):
+    SUMMARY = 0
+    SWITCH = 1
+    CANCEL_1 = 2
+    ITEM = 3
+    GIVE_ITEM = 4
+    TAKE_ITEM = 5
+    MAIL = 6
+    TAKE_MAIL = 7
+    READ = 8
+    CANCEL_2 = 9
+    SHIFT = 10
+    SEND_OUT = 11
+    ENTER = 12
+    NO_ENTRY = 13
+    STORE = 14
+    REGISTER = 15
+    TRADE_1 = 16
+    TRADE_2 = 17
+    TOSS = 18
+    CUT = 19
+    FLASH = 20
+    ROCK_SMASH = 21
+    STRENGTH = 22
+    SURF = 23
+    FLY = 24
+    DIVE = 25
+    WATERFALL = 26
+    TELEPORT = 27
+    DIG = 28
+    SWEET_SCENT = 29
+    MILK_DRINK = 30
+    SOFTBOILED = 31
+    SECRET_POWER = 32
+    
 
 class CursorOptionRS(IntEnum):
     SUMMARY = 0
@@ -312,7 +347,9 @@ def switch_requested() -> bool:
 
 def get_cursor_options(idx: int) -> str:
     match context.rom.game_title:
-        case "POKEMON FIRE" | "POKEMON LEAF" | "POKEMON EMER":
-            return CursorOptionEFRLG(idx).name
+        case "POKEMON EMER":
+            return CursorOptionE(idx).name
+        case "POKEMON FIRE" | "POKEMON LEAF":
+            return CursorOptionFRLG(idx).name
         case _:
             return CursorOptionRS(idx).name

--- a/modules/menuing.py
+++ b/modules/menuing.py
@@ -307,13 +307,12 @@ class PokemonPartyMenuNavigator(BaseMenuNavigator):
         if self.game in ["POKEMON EMER", "POKEMON FIRE", "POKEMON LEAF"]:
             while task_is_active("TASK_HANDLECHOOSEMONINPUT"):
                 context.emulator.press_button("A")
-                print(":(")
-                yield
+                # yield
+                context.emulator.run_single_frame()
         else:
             while not task_is_active("SUB_8089D94"):
                 context.emulator.press_button("A")
                 yield
-        print("no?")
 
     @staticmethod
     def switch_mon():

--- a/modules/modes/__init__.py
+++ b/modules/modes/__init__.py
@@ -7,6 +7,7 @@ available_bot_modes = [
     "Fishing",
     "Bunny Hop",
     "Static Soft Resets",
+    "Sweet Scent",
     "Tower Duo",
     "Ancient Legendaries",
 ]

--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -335,15 +335,16 @@ class ModeStarters:
                             self.update_state(ModeStarterStates.TITLE)
 
                         case ModeStarterStates.TITLE:
-                            match get_game_state():
-                                case GameState.TITLE_SCREEN:
+                            match get_game_state(), read_symbol("gQuestLogState"):
+                                case GameState.TITLE_SCREEN, _:
                                     context.emulator.press_button(random.choice(["A", "Start", "Left", "Right", "Up"]))
-                                case GameState.MAIN_MENU:
+                                case GameState.MAIN_MENU, _:
                                     context.emulator.press_button("A")
-                                case GameState.QUEST_LOG:
-                                    context.emulator.press_button("B")
-                                case GameState.OVERWORLD:
+                                case GameState.OVERWORLD, bytearray(b"\x00"):
                                     self.update_state(ModeStarterStates.OVERWORLD)
+                                case GameState.OVERWORLD, _:
+                                    context.emulator.press_button("B")
+                                
 
                         case ModeStarterStates.OVERWORLD:
                             context.message = "Pathing to starter..."

--- a/modules/modes/sweet_scent.py
+++ b/modules/modes/sweet_scent.py
@@ -1,0 +1,179 @@
+import random
+from enum import Enum, auto
+
+from modules.context import context
+from modules.encounter import encounter_pokemon
+from modules.files import get_rng_state_history, save_rng_state_history
+from modules.memory import (
+    read_symbol,
+    get_game_state,
+    GameState,
+    write_symbol,
+    unpack_uint32,
+    pack_uint32,
+)
+from modules.pokemon import get_opponent, opponent_changed
+from modules.tasks import task_is_active
+from modules.menuing import StartMenuNavigator, PokemonPartyMenuNavigator
+from modules.menu_parsers import parse_party_menu
+from modules.pokemon import get_party
+
+
+class ModeSweetScentStates(Enum):
+    RESET = auto()
+    TITLE = auto()
+    SELECT_SCENT = auto()
+    WAIT_FRAMES = auto()
+    OVERWORLD = auto()
+    INJECT_RNG = auto()
+    RNG_CHECK = auto()
+    BATTLE = auto()
+    OPPONENT_CRY_START = auto()
+    OPPONENT_CRY_END = auto()
+    LOG_OPPONENT = auto()
+
+
+class ModeSweetScent:
+    def __init__(self) -> None:
+        if not context.config.cheats.random_soft_reset_rng:
+            self.rng_history: list = get_rng_state_history()
+
+        self.frame_count = None
+        self.navigator = None
+        self.state: ModeSweetScentStates = ModeSweetScentStates.RESET
+
+    def update_state(self, state: ModeSweetScentStates) -> None:
+        self.state: ModeSweetScentStates = state
+
+    def wait_frames(self, frames: int) -> bool:
+        if not self.frame_count:
+            self.frame_count = context.emulator.get_frame_count()
+        elif context.emulator.get_frame_count() < self.frame_count + frames:
+            return False
+        else:
+            self.frame_count = 0
+            return True
+
+    def step(self):
+        while True:
+            match self.state:
+                case ModeSweetScentStates.RESET:
+                    match context.rom.game_title:
+                        case "POKEMON FIRE" | "POKEMON LEAF":
+                            context.emulator.reset()
+                            self.update_state(ModeSweetScentStates.TITLE)
+                        case "POKEMON RUBY" | "POKEMON SAPP" | "POKEMON EMER":
+                            if task_is_active("Task_HandleChooseMonInput"):
+                                self.update_state(ModeSweetScentStates.SELECT_SCENT)
+                            else:
+                                self.update_state(ModeSweetScentStates.OVERWORLD)
+                    continue
+
+                case ModeSweetScentStates.TITLE:
+                    match get_game_state():
+                        case GameState.TITLE_SCREEN:
+                            context.emulator.press_button(random.choice(["A", "Start", "Left", "Right", "Up"]))
+                        case GameState.MAIN_MENU:
+                            context.emulator.press_button("A")
+                        case GameState.QUEST_LOG:
+                            context.emulator.press_button("B")
+                        case GameState.OVERWORLD:
+                            self.update_state(ModeSweetScentStates.OVERWORLD)
+                    continue
+
+                case ModeSweetScentStates.OVERWORLD:
+                    if self.navigator is None:
+                        self.navigator = StartMenuNavigator("POKEMON")
+                    else:
+                        yield from self.navigator.step()
+                        match self.navigator.current_step:
+                            case "exit":
+                                self.navigator = None
+                                self.update_state(ModeSweetScentStates.SELECT_SCENT)
+                                continue
+                    continue
+                
+                case ModeSweetScentStates.WAIT_FRAMES:
+                    if self.wait_frames(60):
+                        self.update_state(ModeSweetScentStates.SELECT_SCENT)
+                    else:
+                        pass
+                
+                case ModeSweetScentStates.SELECT_SCENT:
+                    scent_poke = None
+                    for num, poke in enumerate(get_party()):
+                        if "Sweet Scent" in str(poke.moves):
+                            scent_poke = num
+                            break
+                    if scent_poke is None:
+                        raise Exception("No Pokemon with Sweet Scent in party")
+                        context.set_manual_mode()
+                        break
+                    else:
+                        if self.navigator is None:
+                            self.navigator = PokemonPartyMenuNavigator(scent_poke, "hover_scent")
+                        else:
+                            yield from self.navigator.step()
+                            match self.navigator.current_step:
+                                case "exit":
+                                    self.navigator = None
+                                    print("exit")
+                                    # self.update_state(ModeStarterStates.LOG_STARTER)
+                                    # continue
+                                    context.set_manual_mode()
+                                    break
+                        continue
+                
+                case ModeSweetScentStates.RNG_CHECK:
+                    if context.config.cheats.random_soft_reset_rng:
+                        self.update_state(ModeSweetScentStates.WAIT_FRAMES)
+                    else:
+                        rng = unpack_uint32(read_symbol("gRngValue"))
+                        if rng in self.rng_history or (
+                            task_is_active("Task_ExitNonDoor")
+                            or task_is_active("task_map_chg_seq_0807E20C")
+                            or task_is_active("task_map_chg_seq_0807E2CC")
+                        ):
+                            pass
+                        else:
+                            self.rng_history.append(rng)
+                            save_rng_state_history(self.rng_history)
+                            self.update_state(ModeSweetScentStates.WAIT_FRAMES)
+                            continue
+
+                
+
+                case ModeSweetScentStates.INJECT_RNG:
+                    if context.config.cheats.random_soft_reset_rng:
+                        write_symbol("gRngValue", pack_uint32(random.randint(0, 2**32 - 1)))
+                    self.update_state(ModeSweetScentStates.OVERWORLD)
+
+                
+
+                case ModeSweetScentStates.BATTLE:
+                    if get_game_state() != GameState.BATTLE:
+                        context.emulator.press_button("A")
+                    else:
+                        self.update_state(ModeSweetScentStates.OPPONENT_CRY_START)
+                        continue
+
+                case ModeSweetScentStates.OPPONENT_CRY_START:
+                    if not task_is_active("Task_DuckBGMForPokemonCry"):
+                        context.emulator.press_button("B")
+                    else:
+                        self.update_state(ModeSweetScentStates.OPPONENT_CRY_END)
+                        continue
+
+                # Ensure opponent sprite is fully visible before resetting
+                case ModeSweetScentStates.OPPONENT_CRY_END:
+                    if task_is_active("Task_DuckBGMForPokemonCry"):
+                        pass
+                    else:
+                        self.update_state(ModeSweetScentStates.LOG_OPPONENT)
+                        continue
+
+                case ModeSweetScentStates.LOG_OPPONENT:
+                    encounter_pokemon(get_opponent())
+                    return
+
+            yield


### PR DESCRIPTION
Adds a method for using Sweet Scent to hunt for shinies. Runs from battles in RSE and resets for FRLG.

Had to change a yield to a run_single_frame() to fix random behavior where a yield would cause you to enter manual mode. We're looking into fixing that.

The move list in menu_parsers.py was also incorrect for FRLG. I copied the list and changed the number for Sweet Scent, but once I'm able to understand the numbers, they can be fixed.