### PR TITLE
Pokemon Storage Navigation

### DIFF
--- a/modules/pokemon_storage.py
+++ b/modules/pokemon_storage.py
@@ -48,7 +48,7 @@ class PokemonStorageBox:
                 return potential_empty_slot_index
             else:
                 potential_empty_slot_index += 1
-        if potential_empty_slot_index > 30:
+        if potential_empty_slot_index >= 30:
             return None
         else:
             return potential_empty_slot_index
@@ -175,3 +175,4 @@ def get_pokemon_storage() -> PokemonStorage:
     pokemon_storage = PokemonStorage(offset, context.emulator.read_bytes(offset, length))
     state_cache.pokemon_storage = pokemon_storage
     return pokemon_storage
+

--- a/modules/pokemon_storage.py
+++ b/modules/pokemon_storage.py
@@ -175,4 +175,3 @@ def get_pokemon_storage() -> PokemonStorage:
     pokemon_storage = PokemonStorage(offset, context.emulator.read_bytes(offset, length))
     state_cache.pokemon_storage = pokemon_storage
     return pokemon_storage
-

--- a/modules/pokemon_storage_navigaton.py
+++ b/modules/pokemon_storage_navigaton.py
@@ -122,7 +122,7 @@ class MenuNavigator(BaseMenuNavigator):
                 self.navigator = self.select_yes()
 
     def wait_for_menu(self):
-        while self.cursor.menu_cur_pos is None and self.wait_counter < 20:
+        while self.cursor.menu_cur_pos is None and self.wait_counter < 20 or self.wait_counter <= 4:
             self.wait_counter += 1
             yield
         if self.wait_counter >= 20:

--- a/modules/pokemon_storage_navigaton.py
+++ b/modules/pokemon_storage_navigaton.py
@@ -1,0 +1,284 @@
+from modules.context import context
+from modules.memory import read_symbol, unpack_uint32
+from modules.tasks import get_task, task_is_active
+from modules.menuing import BaseMenuNavigator
+
+PokeInBoxOptions = [
+    "MOVE",
+    "SUMMARY",
+    "WITHDRAW",
+    "MARK",
+    "RELEASE",
+    "CANCEL"
+]
+
+#Not implemented yet
+PCPokeOptions = [
+    "WITHDRAW_POKEMON",
+    "DEPOSIT_POKEMON",
+    "MOVE_POKEMON",
+    "MOVE_ITEMS",
+    "EXIT"
+]
+
+#Not implemented yet
+PCOptions = [
+    "POKE_PC",
+    "ITEM_PC",
+    "HALL_OF_FAME_PC",
+    "EXIT"
+]
+
+BoxOptions = [
+    "JUMP",
+    "WALLPAPER",
+    "NAME",
+    "CANCEL"
+]
+
+def pc_slot_from_number(slot: int) -> tuple[int, int]:
+    """
+    Returns the x and y for a given slot in the PC.
+    Slot number must be between 0 and 29.
+    """
+    if slot > 29:
+        raise ValueError("Slot must be between 0 and 29")
+    return [slot % 6, slot // 6]
+
+class MenuNavigator(BaseMenuNavigator):
+    def __init__(self, desired_option: str, menu: list):
+        super().__init__()
+        if desired_option in menu:
+            self.desired_option = desired_option
+            self.menu = menu
+            self.cursor = StorageCursor()
+            self.wait_counter = 0
+        else:
+            raise ValueError("Option not in given menu")
+        self.current_step = None
+        
+    def get_next_func(self):
+        match self.current_step:
+            case None:
+                self.current_step = "wait_for_menu"
+            case "wait_for_menu":
+                self.current_step = "navigate_to_option"
+            case "navigate_to_option":
+                self.current_step = "confirm_option"
+            case "confirm_option":
+                self.current_step = "exit"
+            
+    def update_navigator(self):
+        match self.current_step:
+            case "wait_for_menu":
+                self.navigator = self.wait_for_menu()
+            case "navigate_to_option":
+                self.navigator = self.navigate_to_option()
+            case "confirm_option":
+                self.navigator = self.confirm_option()
+            
+    def wait_for_menu(self):
+        while self.cursor.menu_cur_pos is None and self.wait_counter < 20:
+            self.wait_counter += 1
+            yield
+        if self.wait_counter >= 20:
+            raise ValueError("Menu did not open")
+        self.wait_counter = 0
+    
+    def navigate_to_option(self):
+        while not self.cursor.menu_cur_pos == self.menu.index(self.desired_option):
+            context.emulator.press_button("Down")
+            yield
+            
+    def confirm_option(self):
+        while self.wait_counter < 10:
+            if self.wait_counter == 5:
+                context.emulator.press_button("A")
+            self.wait_counter += 1
+            yield
+
+class BoxNavigator(BaseMenuNavigator):
+    """
+    This class is for navigating the box menu.
+    goto_pos can be either a tuple [x,y] or int 0-29
+    goto_box is the box number 0-13
+    desired_option is the option to select in the menu
+    """
+    def __init__(self, goto_pos: tuple[int,int], goto_box: int, desired_option: str):
+        super().__init__()
+        if isinstance(goto_pos,int):
+            goto_pos = pc_slot_from_number(goto_pos)
+        if goto_pos[0] > 7:
+            raise ValueError("Not implemented yet")
+        else:
+            self.goto_pos = goto_pos
+            self.desired_option = desired_option.upper()
+            self.cursor = StorageCursor()
+            self.wait_counter = 0
+            self.goto_box = goto_box
+        self.subnavigator = None
+        self.current_step = None
+        
+    def get_next_func(self):
+        match self.current_step:
+            case None:
+                self.current_step = "wait_for_box"
+            case "wait_for_box":
+                self.current_step = "navigate_to_pos"
+            case "navigate_to_pos":
+                self.current_step = "confirm_option"
+            case "confirm_option":
+                self.current_step = "select_sub_option"
+    
+    def update_navigator(self):
+        match self.current_step:
+            case "wait_for_box":
+                self.navigator = self.wait_for_box()
+            case "navigate_to_pos":
+                self.navigator = self.navigate_to_pos()
+            case "confirm_option":
+                self.navigator = self.confirm_option()
+            case "select_sub_option":
+                self.navigator = self.select_sub_option()
+                
+    def wait_for_box(self):
+        while not self.cursor.box_mode_enabled and self.wait_counter < 20:
+            self.wait_counter += 1
+            yield
+        if self.wait_counter >= 20:
+            raise ValueError("Box did not open")
+        self.wait_counter = 0
+        
+    def navigate_to_pos(self):
+        while self.cursor.box_cur_pos != self.goto_pos or self.goto_box != self.cursor.current_box:
+            if self.cursor.box_cur_pos is not None:
+                if self.cursor.current_box != self.goto_box:
+                    if self.cursor.box_cur_pos[0] != 7:
+                        context.emulator.press_button("Start")
+                    elif (self.goto_box - self.cursor.current_box + 13) % 13 > (self.cursor.current_box - self.goto_box + 13) % 13:
+                        context.emulator.press_button("Left")
+                    else:
+                        context.emulator.press_button("Right")
+                elif self.cursor.box_cur_pos[0] > 6 and self.goto_pos[0] < 7:
+                    context.emulator.press_button("Down")
+                elif self.goto_pos[1] != -1:
+                    if self.cursor.box_cur_pos[0] > self.goto_pos[0]:
+                        context.emulator.press_button("Left")
+                    elif self.cursor.box_cur_pos[0] < self.goto_pos[0]:
+                        context.emulator.press_button("Right")
+                    elif self.cursor.box_cur_pos[1] > self.goto_pos[1]:
+                        context.emulator.press_button("Up")
+                    elif self.cursor.box_cur_pos[1] < self.goto_pos[1]:
+                        context.emulator.press_button("Down")
+                else:
+                    if self.cursor.box_cur_pos[0] == 8 and self.goto_pos[0] == 9:
+                        context.emulator.press_button("Right")
+                    if self.cursor.box_cur_pos[0] < self.goto_pos[0]:
+                        context.emulator.press_button("Up")
+                    elif self.cursor.box_cur_pos[0] > self.goto_pos[0]:
+                        context.emulator.press_button("Down")
+                yield
+            yield
+    
+    def confirm_option(self):
+        while self.wait_counter < 10:
+            if self.wait_counter == 5:
+                context.emulator.press_button("A")
+            self.wait_counter += 1
+            yield
+        self.wait_counter = 0
+            
+    def select_sub_option(self):
+        if not self.subnavigator:
+            if self.goto_pos[1] != -1 and self.goto_pos[0] < 6:
+                self.subnavigator = MenuNavigator(self.desired_option, PokeInBoxOptions)
+            elif self.goto_pos[0] == 7:
+                self.subnavigator = MenuNavigator(self.desired_option, BoxOptions)
+            elif self.goto_pos[0] == 8:
+                raise ValueError("Not implemented yet")
+            yield
+        else:
+            yield from self.subnavigator.step()
+            match self.subnavigator.current_step:
+                case "exit":
+                    self.subnavigator = None
+                    self.current_step = "exit"
+
+class StorageCursor:
+    @property
+    def box_mode_enabled(self) -> bool:
+        if self.box_cur_pos:
+            return True
+        else:
+            return False
+    
+    @property
+    def current_box(self) -> int:
+        if context.rom.game_title in ["POKEMON EMER", "POKEMON FIRE", "POKEMON LEAF"]:
+            return int(context.emulator.read_bytes(unpack_uint32(read_symbol("gPokemonStoragePtr")), 1)[0])
+        else:
+            return int(context.emulator.read_bytes(unpack_uint32(read_symbol("gPokemonStorageSystemPtr")) + 0x117D, 1)[0])
+    
+    @property
+    def menu_cur_pos(self) -> int:
+        try:
+            match context.rom.game_title:
+                case "POKEMON EMER" | "POKEMON FIRE" | "POKEMON LEAF":
+                    if task_is_active("Task_PCMainMenu"):
+                        cur_pos = get_task("Task_PCMainMenu").data[2]
+                    else:
+                        if context.rom.game_title == "POKEMON EMER":
+                            start_cur = 236
+                            offset = 0x03007CE8
+                        else:
+                            start_cur = 67
+                            offset = 0x03007CFC
+                        cur_pos = int(context.emulator.read_bytes(offset, 1)[0])
+                        if cur_pos == start_cur:
+                            cur_pos = 0
+                        else:
+                            cur_pos = cur_pos // 16 - 1
+                case "POKEMON RUBY" | "POKEMON SAPP":
+                    cur_pos = int(context.emulator.read_bytes(0x030006B2, 1)[0])
+            return cur_pos
+        except:
+            return None
+    
+    @property
+    def box_cur_pos(self) -> tuple[int, int]:
+        """
+        x position greater than 6 means either box, party, or close in that order
+        y position is -1 if x position is greater than 6
+        """
+        try:
+            x_pos_bytes = [0x54,0x6C,0x84,0x9C,0xB4,0xCC,0x3F,0x92,0x68,0xC0]
+            y_pos_bytes = [0x10,0x28,0x40,0x58,0x70,0xFC,0xF8]
+            match context.rom.game_title:
+                case "POKEMON EMER":
+                    x_without_offset = 0x0300230A
+                    x_with_offset = 0x0300231A
+                    y_without_offset = 0x03002308
+                    y_with_offset = 0x03002318
+                case "POKEMON FIRE" | "POKEMON LEAF":
+                    x_without_offset = 0x0300313A
+                    x_with_offset = 0x0300314A
+                    y_without_offset = 0x03003138
+                    y_with_offset = 0x03003148
+                case "POKEMON RUBY" | "POKEMON SAPP":
+                    x_pos_bytes = [0x54,0x6C,0x84,0x9C,0xB4,0xCC,0x00,0x92,0x68,0xC0]
+                    x_without_offset = 0x030017BE
+                    x_with_offset = 0x030017CE
+                    y_without_offset = 0x030017BC
+                    y_with_offset = 0x030017CC      
+            x_pos = x_pos_bytes.index(context.emulator.read_bytes(x_without_offset, 1)[0])
+            if x_pos == 6:
+                #This means the box slot has a pokemon in it
+                x_pos = x_pos_bytes.index(context.emulator.read_bytes(x_with_offset, 1)[0])
+                y_pos = y_pos_bytes.index(context.emulator.read_bytes(y_with_offset, 1)[0])
+            elif x_pos < 6:
+                y_pos = y_pos_bytes.index(context.emulator.read_bytes(y_without_offset, 1)[0])
+            else:
+                y_pos = -1
+            return [x_pos, y_pos]
+        except:
+            return None

--- a/modules/pokemon_storage_navigaton.py
+++ b/modules/pokemon_storage_navigaton.py
@@ -3,36 +3,15 @@ from modules.memory import read_symbol, unpack_uint32
 from modules.tasks import get_task, task_is_active
 from modules.menuing import BaseMenuNavigator
 
-PokeInBoxOptions = [
-    "MOVE",
-    "SUMMARY",
-    "WITHDRAW",
-    "MARK",
-    "RELEASE",
-    "CANCEL"
-]
+PokeInBoxOptions = ["MOVE", "SUMMARY", "WITHDRAW", "MARK", "RELEASE", "CANCEL"]
 
-PCPokeOptions = [
-    "WITHDRAW_POKEMON",
-    "DEPOSIT_POKEMON",
-    "MOVE_POKEMON",
-    "MOVE_ITEMS"
-]
+PCPokeOptions = ["WITHDRAW_POKEMON", "DEPOSIT_POKEMON", "MOVE_POKEMON", "MOVE_ITEMS"]
 
-#Not implemented yet
-PCOptions = [
-    "POKE_PC",
-    "ITEM_PC",
-    "HALL_OF_FAME_PC",
-    "EXIT"
-]
+# Not implemented yet
+PCOptions = ["POKE_PC", "ITEM_PC", "HALL_OF_FAME_PC", "EXIT"]
 
-BoxOptions = [
-    "JUMP",
-    "WALLPAPER",
-    "NAME",
-    "CANCEL"
-]
+BoxOptions = ["JUMP", "WALLPAPER", "NAME", "CANCEL"]
+
 
 def pc_slot_from_number(slot: int) -> tuple[int, int]:
     """
@@ -42,6 +21,7 @@ def pc_slot_from_number(slot: int) -> tuple[int, int]:
     if slot > 29:
         raise ValueError("Slot must be between 0 and 29")
     return [slot % 6, slot // 6]
+
 
 class PCMainMenuNavigator(BaseMenuNavigator):
     def __init__(self, desired_option: str):
@@ -60,7 +40,7 @@ class PCMainMenuNavigator(BaseMenuNavigator):
         else:
             raise ValueError(f"Option not in PC Main Menu, options are {PCPokeOptions}")
         self.current_step = None
-        
+
     def get_next_func(self):
         match self.current_step:
             case None:
@@ -71,7 +51,7 @@ class PCMainMenuNavigator(BaseMenuNavigator):
                 self.current_step = "confirm_option"
             case "confirm_option":
                 self.current_step = "exit"
-                
+
     def update_navigator(self):
         match self.current_step:
             case "wait_for_pc":
@@ -88,16 +68,17 @@ class PCMainMenuNavigator(BaseMenuNavigator):
         if self.wait_counter >= 20:
             raise ValueError("PC did not open")
         self.wait_counter = 0
-    
+
     def navigate_to_option(self):
         while get_task(self.pc_task).data[2] != PCPokeOptions.index(self.desired_option):
             context.emulator.press_button("Down")
             yield
-            
+
     def confirm_option(self):
         while task_is_active(self.pc_task):
             context.emulator.press_button("A")
             yield
+
 
 class MenuNavigator(BaseMenuNavigator):
     def __init__(self, desired_option: str, menu: list):
@@ -110,7 +91,7 @@ class MenuNavigator(BaseMenuNavigator):
         else:
             raise ValueError("Option not in given menu")
         self.current_step = None
-        
+
     def get_next_func(self):
         match self.current_step, self.desired_option:
             case None, _:
@@ -128,7 +109,7 @@ class MenuNavigator(BaseMenuNavigator):
                 self.desired_option = "YES"
             case "confirm_option", _:
                 self.current_step = "exit"
-            
+
     def update_navigator(self):
         match self.current_step:
             case "wait_for_menu":
@@ -139,7 +120,7 @@ class MenuNavigator(BaseMenuNavigator):
                 self.navigator = self.confirm_option()
             case "select_yes":
                 self.navigator = self.select_yes()
-            
+
     def wait_for_menu(self):
         while self.cursor.menu_cur_pos is None and self.wait_counter < 20:
             self.wait_counter += 1
@@ -147,7 +128,7 @@ class MenuNavigator(BaseMenuNavigator):
         if self.wait_counter >= 20:
             raise ValueError("Menu did not open")
         self.wait_counter = 0
-    
+
     def select_yes(self):
         while self.wait_counter < 6:
             context.emulator.press_button("Up")
@@ -157,12 +138,12 @@ class MenuNavigator(BaseMenuNavigator):
             context.emulator.press_button("A")
             yield
         self.wait_counter = 0
-    
+
     def navigate_to_option(self):
         while not self.cursor.menu_cur_pos == self.menu.index(self.desired_option):
             context.emulator.press_button("Down")
             yield
-            
+
     def confirm_option(self):
         while self.wait_counter < 10:
             if self.wait_counter == 5:
@@ -171,6 +152,7 @@ class MenuNavigator(BaseMenuNavigator):
             yield
         self.wait_counter = 0
 
+
 class BoxNavigator(BaseMenuNavigator):
     """
     This class is for navigating the box menu.
@@ -178,9 +160,10 @@ class BoxNavigator(BaseMenuNavigator):
     goto_box is the box number 0-13
     desired_option is the option to select in the menu
     """
-    def __init__(self, goto_pos: tuple[int,int], goto_box: int, desired_option: str):
+
+    def __init__(self, goto_pos: tuple[int, int], goto_box: int, desired_option: str):
         super().__init__()
-        if isinstance(goto_pos,int):
+        if isinstance(goto_pos, int):
             goto_pos = pc_slot_from_number(goto_pos)
         if goto_pos[0] > 7:
             raise ValueError("Not implemented yet")
@@ -192,7 +175,7 @@ class BoxNavigator(BaseMenuNavigator):
             self.goto_box = goto_box
         self.subnavigator = None
         self.current_step = None
-        
+
     def get_next_func(self):
         match self.current_step:
             case None:
@@ -203,7 +186,7 @@ class BoxNavigator(BaseMenuNavigator):
                 self.current_step = "confirm_option"
             case "confirm_option":
                 self.current_step = "select_sub_option"
-    
+
     def update_navigator(self):
         match self.current_step:
             case "wait_for_box":
@@ -214,7 +197,7 @@ class BoxNavigator(BaseMenuNavigator):
                 self.navigator = self.confirm_option()
             case "select_sub_option":
                 self.navigator = self.select_sub_option()
-                
+
     def wait_for_box(self):
         while not self.cursor.box_mode_enabled and self.wait_counter < 20:
             self.wait_counter += 1
@@ -222,14 +205,16 @@ class BoxNavigator(BaseMenuNavigator):
         if self.wait_counter >= 20:
             raise ValueError("Box did not open")
         self.wait_counter = 0
-        
+
     def navigate_to_pos(self):
         while self.cursor.box_cur_pos != self.goto_pos or self.goto_box != self.cursor.current_box:
             if self.cursor.box_cur_pos is not None:
                 if self.cursor.current_box != self.goto_box:
                     if self.cursor.box_cur_pos[0] != 7:
                         context.emulator.press_button("Start")
-                    elif (self.goto_box - self.cursor.current_box + 13) % 13 > (self.cursor.current_box - self.goto_box + 13) % 13:
+                    elif (self.goto_box - self.cursor.current_box + 13) % 13 > (
+                        self.cursor.current_box - self.goto_box + 13
+                    ) % 13:
                         context.emulator.press_button("Left")
                     else:
                         context.emulator.press_button("Right")
@@ -253,7 +238,7 @@ class BoxNavigator(BaseMenuNavigator):
                         context.emulator.press_button("Down")
                 yield
             yield
-    
+
     def confirm_option(self):
         while self.wait_counter < 10:
             if self.wait_counter == 5:
@@ -261,7 +246,7 @@ class BoxNavigator(BaseMenuNavigator):
             self.wait_counter += 1
             yield
         self.wait_counter = 0
-            
+
     def select_sub_option(self):
         if not self.subnavigator:
             if self.goto_pos[1] != -1 and self.goto_pos[0] < 6:
@@ -278,6 +263,7 @@ class BoxNavigator(BaseMenuNavigator):
                     self.subnavigator = None
                     self.current_step = "exit"
 
+
 class StorageCursor:
     @property
     def box_mode_enabled(self) -> bool:
@@ -285,14 +271,16 @@ class StorageCursor:
             return True
         else:
             return False
-    
+
     @property
     def current_box(self) -> int:
         if context.rom.game_title in ["POKEMON EMER", "POKEMON FIRE", "POKEMON LEAF"]:
             return int(context.emulator.read_bytes(unpack_uint32(read_symbol("gPokemonStoragePtr")), 1)[0])
         else:
-            return int(context.emulator.read_bytes(unpack_uint32(read_symbol("gPokemonStorageSystemPtr")) + 0x117D, 1)[0])
-    
+            return int(
+                context.emulator.read_bytes(unpack_uint32(read_symbol("gPokemonStorageSystemPtr")) + 0x117D, 1)[0]
+            )
+
     @property
     def menu_cur_pos(self) -> int:
         try:
@@ -317,7 +305,7 @@ class StorageCursor:
             return cur_pos
         except:
             return None
-    
+
     @property
     def box_cur_pos(self) -> tuple[int, int]:
         """
@@ -325,8 +313,8 @@ class StorageCursor:
         y position is -1 if x position is greater than 6
         """
         try:
-            x_pos_bytes = [0x54,0x6C,0x84,0x9C,0xB4,0xCC,0x3F,0x92,0x68,0xC0]
-            y_pos_bytes = [0x10,0x28,0x40,0x58,0x70,0xFC,0xF8]
+            x_pos_bytes = [0x54, 0x6C, 0x84, 0x9C, 0xB4, 0xCC, 0x3F, 0x92, 0x68, 0xC0]
+            y_pos_bytes = [0x10, 0x28, 0x40, 0x58, 0x70, 0xFC, 0xF8]
             match context.rom.game_title:
                 case "POKEMON EMER":
                     x_without_offset = 0x0300230A
@@ -339,14 +327,14 @@ class StorageCursor:
                     y_without_offset = 0x03003138
                     y_with_offset = 0x03003148
                 case "POKEMON RUBY" | "POKEMON SAPP":
-                    x_pos_bytes = [0x54,0x6C,0x84,0x9C,0xB4,0xCC,0x00,0x92,0x68,0xC0]
+                    x_pos_bytes = [0x54, 0x6C, 0x84, 0x9C, 0xB4, 0xCC, 0x00, 0x92, 0x68, 0xC0]
                     x_without_offset = 0x030017BE
                     x_with_offset = 0x030017CE
                     y_without_offset = 0x030017BC
-                    y_with_offset = 0x030017CC      
+                    y_with_offset = 0x030017CC
             x_pos = x_pos_bytes.index(context.emulator.read_bytes(x_without_offset, 1)[0])
             if x_pos == 6:
-                #This means the box slot has a pokemon in it
+                # This means the box slot has a pokemon in it
                 x_pos = x_pos_bytes.index(context.emulator.read_bytes(x_with_offset, 1)[0])
                 y_pos = y_pos_bytes.index(context.emulator.read_bytes(y_with_offset, 1)[0])
             elif x_pos < 6:


### PR DESCRIPTION
![python_bIdnPvA3b0](https://github.com/40Cakes/pokebot-gen3/assets/78496235/236d3831-b759-4377-a246-0708fc47010e)

Adds the ability to navigate the Pokemon Storage. Not every menu option is added yet, but currently you can use it to move pokemon that are already in the pc around and you can use it in combination with the Keyboard PR to rename boxes.

Example I used in the gif was this, replacing the spin mode in the general modes
```
class ModeSpin:
    def __init__(self):
        self.navigator = None
        self.current_step = 0

    def step(self):
        if self.navigator is None and self.current_step == 0:
            self.navigator = BoxNavigator([1,0],2,"move")
        elif self.navigator is None and self.current_step == 1:
            for box in get_pokemon_storage().boxes:
                if box.first_empty_slot_index is not None:
                    self.navigator = BoxNavigator(box.first_empty_slot_index,box.number,"move")
                    break
        else:
            yield from self.navigator.step()
            match self.navigator.current_step:
                case "exit":
                    if self.current_step == 1:
                        context.bot_mode = "Manual"
                        yield
                    self.navigator = None
                    self.current_step += 1
        yield
```
