### PR TITLE
[MODES] Sudowoodo, Game Corner, Static Gifts

### DIFF
--- a/modules/modes/__init__.py
+++ b/modules/modes/__init__.py
@@ -13,10 +13,13 @@ def get_bot_modes() -> list[Type[BotMode]]:
         from .ancient_legendaries import AncientLegendariesMode
         from .bunny_hop import BunnyHopMode
         from .fishing import FishingMode
+        from .game_corner import GameCornerMode
         from .roamer_reset import RoamerResetMode
         from .spin import SpinMode
         from .starters import StartersMode
+        from .static_gift_resets import StaticGiftResetsMode
         from .static_soft_resets import StaticSoftResetsMode
+        from .sudowoodo import SudowoodoMode
         from .tower_duo import TowerDuoMode
 
         _bot_modes = [
@@ -25,6 +28,9 @@ def get_bot_modes() -> list[Type[BotMode]]:
             FishingMode,
             BunnyHopMode,
             StaticSoftResetsMode,
+            StaticGiftResetsMode,
+            GameCornerMode,
+            SudowoodoMode,
             TowerDuoMode,
             AncientLegendariesMode,
             RoamerResetMode,

--- a/modules/modes/__init__.py
+++ b/modules/modes/__init__.py
@@ -28,7 +28,7 @@ def get_bot_modes() -> list[Type[BotMode]]:
             StartersMode,
             FishingMode,
             BunnyHopMode,
-            StaticSoftResetsMode
+            StaticSoftResetsMode,
             StaticGiftResetsMode,
             GameCornerMode,
             SudowoodoMode,

--- a/modules/modes/_util.py
+++ b/modules/modes/_util.py
@@ -419,3 +419,11 @@ def set_guaranteed_shiny_rng_seed() -> None:
                 _guaranteed_shiny_rng_seed = pack_uint32(seed)
 
     write_symbol("gRngValue", _guaranteed_shiny_rng_seed)
+
+
+def wait_for_n_frames(number_of_frames: int) -> Generator:
+    """
+    This will wait for a certain number of frames to pass.
+    """
+    for _ in range(number_of_frames):
+        yield

--- a/modules/modes/_util.py
+++ b/modules/modes/_util.py
@@ -25,7 +25,7 @@ from modules.memory import (
     get_event_flag,
     get_event_flag_by_number,
 )
-from modules.player import get_player_avatar, TileTransitionState, RunningState
+from modules.player import get_player, get_player_avatar, TileTransitionState, RunningState
 from modules.tasks import task_is_active
 from ._interface import BotModeError
 
@@ -391,6 +391,7 @@ def wait_until_event_flag_is_false(flag_name: str, button_to_press: str | None =
         if button_to_press is not None:
             context.emulator.press_button(button_to_press)
         yield
+
 
 _guaranteed_shiny_rng_seed: str | None = None
 

--- a/modules/modes/game_corner.py
+++ b/modules/modes/game_corner.py
@@ -1,0 +1,151 @@
+from typing import Generator
+
+from modules.data.map import MapFRLG
+from modules.context import context
+from modules.encounter import encounter_pokemon
+from modules.gui.multi_select_window import Selection, ask_for_choice
+from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
+from modules.runtime import get_sprites_path
+from modules.save_data import get_save_data
+from modules.pokemon import get_party
+from modules.player import get_player, get_player_avatar
+from modules.tasks import task_is_active
+from ._interface import BotMode, BotModeError
+from ._util import (
+    soft_reset,
+    wait_for_unique_rng_value,
+    wait_until_task_is_active,
+    wait_for_task_to_start_and_finish,
+    wait_for_n_frames,
+)
+
+
+def _get_targeted_encounter() -> tuple[tuple[int, int], tuple[int, int], str] | None:
+    encounters = [
+        (MapFRLG.CELADON_CITY_P.value, (4, 3), "Game Corner"),
+    ]
+
+    targeted_tile = get_player_avatar().map_location_in_front
+
+    for entry in encounters:
+        if entry[0] == (targeted_tile.map_group, targeted_tile.map_number) and entry[1] == targeted_tile.local_position:
+            return entry
+
+    return None
+
+
+class GameCornerMode(BotMode):
+    @staticmethod
+    def name() -> str:
+        return "Game Corner"
+
+    @staticmethod
+    def is_selectable() -> bool:
+        return _get_targeted_encounter() is not None
+
+    def run(self) -> Generator:
+        coincase = get_player().coins
+        if coincase < 180:
+            raise BotModeError("You don't have enough coins to buy anything.")
+
+        game_corner_choice = ask_for_choice(
+            [
+                Selection(
+                    "Abra",
+                    get_sprites_path() / "pokemon" / "normal" / "Abra.png",
+                    coincase >= 180,
+                ),
+                Selection(
+                    "Clefairy",
+                    get_sprites_path() / "pokemon" / "normal" / "Clefairy.png",
+                    coincase >= 500,
+                ),
+                Selection(
+                    "Dratini",
+                    get_sprites_path() / "pokemon" / "normal" / "Dratini.png",
+                    coincase >= 2800,
+                ),
+                Selection(
+                    "Scyther",
+                    get_sprites_path() / "pokemon" / "normal" / "Scyther.png",
+                    coincase >= 5500,
+                ),
+                Selection(
+                    "Porygon",
+                    get_sprites_path() / "pokemon" / "normal" / "Porygon.png",
+                    coincase >= 9999,
+                ),
+            ],
+            window_title="Select which one to buy...",
+        )
+        if game_corner_choice is None:
+            return
+
+        encounter = _get_targeted_encounter()
+
+        save_data = get_save_data()
+        if save_data is None:
+            raise BotModeError("There is no saved game. Cannot soft reset.")
+
+        if encounter[0] != (save_data.sections[1][4], save_data.sections[1][5]):
+            raise BotModeError("The targeted encounter is not in the current map. Cannot soft reset.")
+
+        while context.bot_mode != "Manual":
+            yield from soft_reset(mash_random_keys=True)
+            yield from wait_for_unique_rng_value()
+
+            if len(get_party()) >= 6:
+                raise BotModeError("This mode requires at least one empty party slot, but your party is full.")
+
+            # spam A until choice appears
+            if task_is_active("Task_MultichoiceMenu_HandleInput") == False:
+                yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessageBox", "A")
+                yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessageBox", "A")
+                yield from wait_until_task_is_active("Task_MultichoiceMenu_HandleInput")
+                yield from wait_for_n_frames(5)
+
+            match game_corner_choice:
+                case "Abra":
+                    yield from wait_until_task_is_active("Task_DrawFieldMessageBox", "A")
+                case "Clefairy":
+                    context.emulator.press_button("Down")
+                    yield from wait_for_n_frames(2)
+                    yield from wait_until_task_is_active("Task_DrawFieldMessageBox", "A")
+                case "Dratini":
+                    context.emulator.press_button("Down")
+                    yield from wait_for_n_frames(2)
+                    context.emulator.press_button("Down")
+                    yield from wait_for_n_frames(2)
+                    yield from wait_until_task_is_active("Task_DrawFieldMessageBox", "A")
+                case "Scyther":
+                    context.emulator.press_button("Down")
+                    yield from wait_for_n_frames(2)
+                    context.emulator.press_button("Down")
+                    yield from wait_for_n_frames(2)
+                    context.emulator.press_button("Down")
+                    yield from wait_for_n_frames(2)
+                    yield from wait_until_task_is_active("Task_DrawFieldMessageBox", "A")
+                case "Porygon":
+                    context.emulator.press_button("Down")
+                    yield from wait_for_n_frames(2)
+                    context.emulator.press_button("Down")
+                    yield from wait_for_n_frames(2)
+                    context.emulator.press_button("Down")
+                    yield from wait_for_n_frames(2)
+                    context.emulator.press_button("Down")
+                    yield from wait_for_n_frames(2)
+                    yield from wait_until_task_is_active("Task_DrawFieldMessageBox", "A")
+
+            # accept the pokemon
+            yield from wait_for_task_to_start_and_finish("Task_YesNoMenu_HandleInput", "A")
+            # don't rename pokemon
+            yield from wait_for_task_to_start_and_finish("Task_YesNoMenu_HandleInput", "B")
+
+            # log the encounter
+            if context.config.cheats.fast_check_starters:
+                encounter_pokemon(get_party()[len(get_party()) - 1])
+            else:
+                yield from StartMenuNavigator("POKEMON").step()
+                yield from PokemonPartyMenuNavigator(len(get_party()) - 1, "summary").step()
+
+                encounter_pokemon(get_party()[len(get_party()) - 1])

--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -1,0 +1,115 @@
+from typing import Generator
+
+from modules.data.map import MapRSE, MapFRLG
+from modules.context import context
+from modules.encounter import encounter_pokemon
+from modules.save_data import get_save_data
+from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
+from modules.pokemon import get_party
+from modules.player import get_player_avatar
+from ._interface import BotMode, BotModeError
+from ._util import (
+    soft_reset,
+    wait_for_unique_rng_value,
+    wait_until_task_is_active,
+    wait_until_task_is_not_active,
+    wait_for_task_to_start_and_finish,
+    wait_until_event_flag_is_true,
+)
+
+
+def _get_targeted_encounter() -> tuple[tuple[int, int], tuple[int, int], str] | None:
+    if context.rom.is_frlg:
+        encounters = [
+            (MapFRLG.SILPH_CO_F.value, (0, 7), "Lapras"),
+            (MapFRLG.SAFFRON_CITY_D.value, (5, 3), "Hitmonlee"),
+            (MapFRLG.SAFFRON_CITY_D.value, (7, 3), "Hitmonchan"),
+            (MapFRLG.CINNABAR_ISLAND_E.value, (11, 2), "Kanto Fossils"),
+            (MapFRLG.CINNABAR_ISLAND_E.value, (13, 4), "Kanto Fossils"),
+            (MapFRLG.CELADON_CITY_L.value, (7, 3), "Eevee"),
+        ]
+    if context.rom.is_rse:
+        encounters = [
+            (MapRSE.ROUTE_119_B.value, (2, 2), "Castform"),
+            (MapRSE.RUSTBORO_CITY_B.value, (14, 8), "Hoenn Fossils"),
+            (MapRSE.MOSSDEEP_CITY_H.value, (4, 3), "Beldum"),
+        ]
+
+    targeted_tile = get_player_avatar().map_location_in_front
+    for entry in encounters:
+        if entry[0] == (targeted_tile.map_group, targeted_tile.map_number) and entry[1] == targeted_tile.local_position:
+            return entry
+
+    return None
+
+
+class StaticGiftResetsMode(BotMode):
+    @staticmethod
+    def name() -> str:
+        return "Static Gift Resets"
+
+    @staticmethod
+    def is_selectable() -> bool:
+        return _get_targeted_encounter() is not None
+
+    def run(self) -> Generator:
+        encounter = _get_targeted_encounter()
+
+        save_data = get_save_data()
+        if save_data is None:
+            raise BotModeError("There is no saved game. Cannot soft reset.")
+
+        if encounter[0] != (save_data.sections[1][4], save_data.sections[1][5]):
+            raise BotModeError("The targeted encounter is not in the current map. Cannot soft reset.")
+
+        while context.bot_mode != "Manual":
+            yield from soft_reset(mash_random_keys=True)
+            yield from wait_for_unique_rng_value()
+
+            if len(get_party()) >= 6:
+                raise BotModeError("This mode requires at least one empty party slot, but your party is full.")
+
+            # spam A through chat boxes
+            if context.rom.is_frlg:
+                yield from wait_until_task_is_active("Task_DrawFieldMessageBox", "A")
+                yield from wait_until_task_is_not_active("Task_DrawFieldMessageBox", "B")
+            if context.rom.is_emerald:
+                yield from wait_until_task_is_active("Task_DrawFieldMessage", "A")
+                yield from wait_until_task_is_not_active("Task_DrawFieldMessage", "B")
+
+            # accept the pokemon
+            if encounter[2] in ["Beldum", "Hitmonchan", "Hitmonlee"]:
+                if context.rom.is_rse:
+                    yield from wait_for_task_to_start_and_finish("Task_HandleYesNoInput", "A")
+                    yield from wait_for_task_to_start_and_finish("Task_Fanfare", "B")
+                if context.rom.is_frlg:
+                    yield from wait_for_task_to_start_and_finish("Task_YesNoMenu_HandleInput", "A")
+                    yield from wait_for_task_to_start_and_finish("Task_Fanfare", "B")
+                    yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessageBox", "B")
+
+            # don't rename pokemon
+            if context.rom.is_frlg:
+                if encounter[2] in ["Hitmonchan", "Hitmonlee"]:
+                    yield from wait_until_event_flag_is_true("GOT_HITMON_FROM_DOJO", "B")
+                yield from wait_for_task_to_start_and_finish("Task_YesNoMenu_HandleInput", "B")
+            if context.rom.is_emerald:
+                yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessage", "B")
+                yield from wait_for_task_to_start_and_finish("Task_HandleYesNoInput", "B")
+
+            # extra check for lapras and castform and clear extra message boxes
+            if encounter[2] == "Lapras":
+                yield from wait_until_event_flag_is_true("GOT_LAPRAS_FROM_SILPH", "B")
+            if encounter[2] == "Castform":
+                yield from wait_until_event_flag_is_true("RECEIVED_CASTFORM", "B")
+
+            # If the respective 'cheat' is enabled, check the Pokemon immediately
+            # instead of 'genuinely' looking at the summary screen
+            if context.config.cheats.fast_check_starters:
+                encounter_pokemon(get_party()[len(get_party()) - 1])
+                continue
+            else:
+                # Navigate to the summary screen to check for shininess
+                yield from StartMenuNavigator("POKEMON").step()
+                yield from PokemonPartyMenuNavigator(len(get_party()) - 1, "summary").step()
+
+                encounter_pokemon(get_party()[len(get_party()) - 1])

--- a/modules/modes/sudowoodo.py
+++ b/modules/modes/sudowoodo.py
@@ -1,0 +1,76 @@
+from typing import Generator
+
+from modules.data.map import MapRSE
+
+from modules.context import context
+from modules.encounter import encounter_pokemon
+from modules.player import get_player_avatar
+from modules.pokemon import get_opponent
+from ._asserts import (
+    assert_save_game_exists,
+    assert_saved_on_map,
+    assert_registered_item,
+    SavedMapLocation,
+)
+from ._interface import BotMode
+from ._util import (
+    soft_reset,
+    wait_for_unique_rng_value,
+    wait_until_task_is_active,
+    wait_for_task_to_start_and_finish,
+)
+
+
+def _get_targeted_encounter() -> tuple[tuple[int, int], tuple[int, int], str] | None:
+    if context.rom.is_emerald:
+        encounters = [
+            (MapRSE.BATTLE_FRONTIER_E.value, (54, 62), "Sudowoodo"),
+        ]
+
+    targeted_tile = get_player_avatar().map_location_in_front
+    for entry in encounters:
+        if entry[0] == (targeted_tile.map_group, targeted_tile.map_number) and entry[1] == targeted_tile.local_position:
+            return entry
+
+    return None
+
+
+class SudowoodoMode(BotMode):
+    @staticmethod
+    def name() -> str:
+        return "Sudowoodo"
+
+    @staticmethod
+    def is_selectable() -> bool:
+        return _get_targeted_encounter() is not None
+
+    @staticmethod
+    def disable_default_battle_handler() -> bool:
+        return True
+
+    def run(self) -> Generator:
+        encounter = _get_targeted_encounter()
+
+        assert_save_game_exists("This is no saved game. Cannot soft reset.")
+        assert_saved_on_map(
+            SavedMapLocation(encounter[0], encounter[1], facing=True),
+            "The game has not been saved on this tile.",
+        )
+        assert_registered_item(
+            ["Wailmer Pail"],
+            "You need to register the Wailmer Pail for the Select button.",
+        )
+
+        while context.bot_mode != "Manual":
+            yield from soft_reset(mash_random_keys=True)
+            yield from wait_for_unique_rng_value()
+
+            # use registered item
+            yield from wait_for_task_to_start_and_finish(
+                "Task_WateringBerryTreeAnim_Continue", button_to_press="Select"
+            )
+            yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessage", button_to_press="B")
+            yield from wait_for_task_to_start_and_finish("Task_DuckBGMForPokemonCry", button_to_press="A")
+            yield from wait_until_task_is_active("Task_DuckBGMForPokemonCry", button_to_press="A")
+
+            encounter_pokemon(get_opponent())


### PR DESCRIPTION
3 new modes have been implemented. All of them include cheats / no-cheats to check the pokemon.

### Sudowodoo Mode 
**Compatbile With:** `E`
**Tested in:** `E` 
- [x] Sudowoodo `E`

Start with a Wailmer Pail registered stood in front of the Sudowoodo tree.
![sudowoodo](https://github.com/40Cakes/pokebot-gen3/assets/22874875/f2edcf68-0986-4ad1-8790-1d69312b4da5)
Split into its own mode instead of including in #86 as has different behaviour


### Game Corner 
**Compatible With:** `FR` `LG`
**Tested in:** `FR`
- [x] Abra `150 coins`
- [x] Clefairy `500 coins`
- [x] Dratini `2,800 coins`
- [x] Scyther `5,500 coins`
- [x] Porygon `9,999 coins`

Start in the game corner facing the NPC who sells them. Options on the GUI will be disabled depending on which you can currently afford.

Gif shows cheat mode, but non-cheat included too
![gamecorner](https://github.com/40Cakes/pokebot-gen3/assets/22874875/e3e8008e-086b-416a-8f3e-7d3b93bc080d)


### Static Gift Resets
**Compatbile With:** `R` `S` `E` `FR` `LG`
**Tested in:** `E` `FR`
- [x] Castform `E`
- [x] Beldum `RSE`
- [x] Fossils `RSE` `FRLG`
- [x] Eevee `FRLG`
- [x] Hitmonlee/chan `FRLG`
- [x] Lapras `FRLG`

Start this mode facing the NPC/Item that grants the pokemon, cheats are included to fast check them in party but also has the ability to open summary page to confirm.
Did not include Wynaut from #86 - someone can add that in future, that needs a way to hatch the egg and such too
Also did not include Kecleon from #86 as I think that should have its own mode due to differences