### PR TITLE
Add lookup functions for map encounters

### DIFF
--- a/modules/modes/_util.py
+++ b/modules/modes/_util.py
@@ -25,7 +25,7 @@ from modules.memory import (
     get_event_flag,
     get_event_flag_by_number,
 )
-from modules.player import get_player, get_player_avatar, TileTransitionState, RunningState
+from modules.player import get_player_avatar, TileTransitionState, RunningState
 from modules.tasks import task_is_active
 from ._interface import BotModeError
 
@@ -391,31 +391,3 @@ def wait_until_event_flag_is_false(flag_name: str, button_to_press: str | None =
         if button_to_press is not None:
             context.emulator.press_button(button_to_press)
         yield
-
-
-_guaranteed_shiny_rng_seed: str | None = None
-
-
-def set_guaranteed_shiny_rng_seed() -> None:
-    """
-    This can be used for testing purposes, and if used in the frame before an encounter
-    it will seed the RNG in a way that guarantees a shiny for the current player.
-    """
-
-    global _guaranteed_shiny_rng_seed
-    if _guaranteed_shiny_rng_seed is None:
-        player = get_player()
-        while _guaranteed_shiny_rng_seed is None:
-            seed = random.randint(0, 0xFFFF_FFFF)
-
-            rng_value = seed
-            rng_value = (1103515245 * rng_value + 24691) & 0xFFFF_FFFF
-            rng_value = (1103515245 * rng_value + 24691) & 0xFFFF_FFFF
-            personality_value_upper = rng_value >> 16
-            rng_value = (1103515245 * rng_value + 24691) & 0xFFFF_FFFF
-            personality_value_lower = rng_value >> 16
-
-            if player.trainer_id ^ player.secret_id ^ personality_value_upper ^ personality_value_lower < 8:
-                _guaranteed_shiny_rng_seed = pack_uint32(seed)
-
-    write_symbol("gRngValue", _guaranteed_shiny_rng_seed)

--- a/modules/roamer.py
+++ b/modules/roamer.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from modules.context import context
 from modules.map import get_map_data
-from modules.memory import unpack_uint16, unpack_uint32, get_save_block, read_symbol, write_symbol
+from modules.memory import unpack_uint16, unpack_uint32, get_save_block, read_symbol
 from modules.pokemon import (
     StatsValues,
     ContestConditions,
@@ -172,29 +172,3 @@ def get_roamer_location_history() -> list[str]:
         if data[index * 2] != 0 or data[index * 2 + 1] != 0:
             result.append(get_map_data(data[index * 2], data[index * 2 + 1], (0, 0)).map_name)
     return result
-
-
-def dangerous_set_roamer_location(location: tuple[int, int]) -> None:
-    write_symbol("sRoamerLocation", bytes([location[0], location[1]]))
-
-
-def dangerous_make_roamer_shiny() -> None:
-    import random
-    from modules.memory import write_to_save_block, pack_uint32
-
-    data = get_save_block(2, offset=0xA, size=4)
-    trainer_id, secret_trainer_id = unpack_uint16(data[0:2]), unpack_uint16(data[2:4])
-
-    while True:
-        pv = random.randint(0, 0xFFFF_FFFF)
-        upper = pv >> 16
-        lower = pv & 0xFFFF
-        if upper ^ lower ^ trainer_id ^ secret_trainer_id < 8:
-            if context.rom.is_frlg:
-                offset = 0x30D0
-            elif context.rom.is_emerald:
-                offset = 0x31DC
-            else:
-                offset = 0x3144
-            write_to_save_block(pack_uint32(pv), 1, offset + 4)
-            break


### PR DESCRIPTION
This adds a `get_wild_encounters_for_map()` function that, as the name implies, will return the list of encounters (grouped by categories such as land, surfing, fishing) for a given map.

That information is displayed in the `Map` debug tab and not used anywhere else so far, but might prove useful eventually.

This commit also removes some 'cheaty' functions that I have used for testing in the past and forgot to remove after they were no longer needed.

![image](https://github.com/40Cakes/pokebot-gen3/assets/1106400/b804c99d-9aed-4a79-929c-538c7bf427e7)
