### PR TITLE
Remove bot percentage for non-debug users

### DIFF
--- a/modules/gui/emulator_controls.py
+++ b/modules/gui/emulator_controls.py
@@ -219,7 +219,8 @@ class EmulatorControls:
             from modules.stats import total_stats  # TODO prevent instantiating TotalStats class before profile selected
 
             stats.append(f"{total_stats.get_encounter_rate():,}/h")
-        stats.append(f"{round(current_load * 100, 1)}%")
+        if context.debug:
+            stats.append(f"{round(current_load * 100, 1)}%")
         self.stats_label.config(text=" | ".join(stats))
 
 


### PR DESCRIPTION
This removes the 'time spent in bot fraction' percentage shown in the bottom left corner if the emulator is not run in debug mode.

That number seems to occasionally confuse people and to be honest, for non-developers this is not a particularly useful metric anyway.