### PR TITLE
Additional coordinates for Castform mode

### DIFF
--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -31,6 +31,7 @@ def _get_targeted_encounter() -> tuple[tuple[int, int], tuple[int, int], str] | 
     if context.rom.is_rse:
         encounters = [
             (MapRSE.ROUTE_119_B.value, (2, 2), "Castform"),
+            (MapRSE.ROUTE_119_B.value, (18, 6), "Castform"),
             (MapRSE.RUSTBORO_CITY_B.value, (14, 8), "Hoenn Fossils"),
             (MapRSE.MOSSDEEP_CITY_H.value, (4, 3), "Beldum"),
         ]


### PR DESCRIPTION
Castform NPC can be in two different locations, adding this to allow Castform gift mode to work when he is in either location.
![image](https://github.com/40Cakes/pokebot-gen3/assets/22874875/6724be67-b44e-478d-b6d6-3abfbbd7d676)
