### PR TITLE
Add Magikarp to Gift Reset mode for FRLG

### DIFF
--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -27,6 +27,7 @@ def _get_targeted_encounter() -> tuple[tuple[int, int], tuple[int, int], str] | 
             (MapFRLG.CINNABAR_ISLAND_E.value, (11, 2), "Kanto Fossils"),
             (MapFRLG.CINNABAR_ISLAND_E.value, (13, 4), "Kanto Fossils"),
             (MapFRLG.CELADON_CITY_L.value, (7, 3), "Eevee"),
+            (MapFRLG.ROUTE_4_A.value, (1, 3), "Magikarp"),
         ]
     if context.rom.is_rse:
         encounters = [
@@ -78,7 +79,7 @@ class StaticGiftResetsMode(BotMode):
                 yield from wait_until_task_is_not_active("Task_DrawFieldMessage", "B")
 
             # accept the pokemon
-            if encounter[2] in ["Beldum", "Hitmonchan", "Hitmonlee"]:
+            if encounter[2] in ["Beldum", "Hitmonchan", "Hitmonlee", "Magikarp"]:
                 if context.rom.is_rse:
                     yield from wait_for_task_to_start_and_finish("Task_HandleYesNoInput", "A")
                     yield from wait_for_task_to_start_and_finish("Task_Fanfare", "B")


### PR DESCRIPTION
Added Magikarp as an option for Soft Gift Resetting in FRLG. 
I will update the Wiki post-merge

Even though they're encountered millions of times while fishing, as a part of Professor Oak's Challenge for FRLG you should buy the gift Magikarp.

![Kapture 2024-01-22 at 09 57 36](https://github.com/40Cakes/pokebot-gen3/assets/22874875/1ea4ab84-d773-4802-b553-3bcb013c83dd)
