### PR TITLE
Fix GIF playback speed and some other stuff

### DIFF
--- a/modules/libmgba.py
+++ b/modules/libmgba.py
@@ -6,6 +6,7 @@ import PIL.PngImagePlugin
 import time
 import zlib
 from collections import deque
+from contextlib import contextmanager
 
 import sounddevice
 
@@ -519,7 +520,8 @@ class LibmgbaEmulator:
         with open(png_path, "wb") as file:
             self.get_screenshot().save(file, format="PNG")
 
-    def peek_frame(self, callback: callable, frames_to_advance: int = 1) -> any:
+    @contextmanager
+    def peek_frame(self, frames_to_advance: int = 1) -> any:
         """
         Runs the emulation for a number of frames and then runs {callback()}, after which it restores
         the original emulator state.
@@ -527,16 +529,15 @@ class LibmgbaEmulator:
         This can be used to check the emulator state in a given number of frames without actually
         advancing the emulation.
 
-        :param callback: A function to run after the emulation has progressed
         :param frames_to_advance: Optional number of frames to advance (defaults to 1)
-        :return: The return value of the callback function
         """
         original_emulator_state = self.get_save_state()
         for i in range(frames_to_advance):
             self._core.run_frame()
-        result = callback()
-        self.load_save_state(original_emulator_state)
-        return result
+        try:
+            yield
+        finally:
+            self.load_save_state(original_emulator_state)
 
     def run_single_frame(self) -> None:
         """
@@ -594,25 +595,37 @@ class LibmgbaEmulator:
         taking a screenshot and stitching them together into an animated GIF.
         """
 
-        frames = []
+        frames: list[PIL.Image.Image] = []
         current_timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
         gif_dir = self._profile.path / "screenshots" / "gifs"
         gif_filename = gif_dir / f"{current_timestamp}.gif"
         if not gif_dir.exists():
             gif_dir.mkdir(parents=True)
 
-        console.print(f"Generating a {duration:,} frame GIF...")
-        for i in range(start_frame, start_frame + duration):
-            frame = self.peek_frame(self.get_screenshot, i)
-            if frame.getbbox():
-                frames.append(frame)
+        video_was_enabled = self._video_enabled
+        self.set_video_enabled(True)
+
+        with self.peek_frame(start_frame):
+            for i in range(duration):
+                screenshot = self.get_screenshot()
+                if screenshot.getbbox():
+                    frames.append(screenshot)
+                self._core.run_frame()
+
+        self.set_video_enabled(video_was_enabled)
+
+        if len(frames) < 1:
+            raise RuntimeError("GIF generation did not result in any frames.")
+
+        # Closest to 60 fps we can get, as Pillow only seems to support 10ms steps.
+        milliseconds_per_frame = 20
 
         frames[0].save(
             gif_filename,
             format="GIF",
             append_images=frames[1:],
             save_all=True,
-            duration=duration,
+            duration=milliseconds_per_frame,
             loop=0,
         )
         console.print(f"GIF {gif_filename} saved!")

--- a/modules/modes/sudowoodo.py
+++ b/modules/modes/sudowoodo.py
@@ -26,6 +26,8 @@ def _get_targeted_encounter() -> tuple[tuple[int, int], tuple[int, int], str] | 
         encounters = [
             (MapRSE.BATTLE_FRONTIER_E.value, (54, 62), "Sudowoodo"),
         ]
+    else:
+        encounters = []
 
     targeted_tile = get_player_avatar().map_location_in_front
     for entry in encounters:

--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -1474,7 +1474,8 @@ def get_party() -> list[Pokemon]:
         # (1) advancing the emulation by one frame, (2) reading the memory, (3) restoring the previous
         # frame's state so we don't mess with frame accuracy.
         if mon is None:
-            mon = context.emulator.peek_frame(lambda: parse_pokemon(read_symbol("gPlayerParty", o, 100)))
+            with context.emulator.peek_frame():
+                mon = parse_pokemon(read_symbol("gPlayerParty", o, 100))
             if mon is None:
                 raise RuntimeError(f"Party Pokemon #{p + 1} was invalid for two frames in a row.")
 
@@ -1498,7 +1499,8 @@ def get_opponent() -> Pokemon:
 
     # See comment in `GetParty()`
     if mon is None:
-        mon = context.emulator.peek_frame(lambda: parse_pokemon(read_symbol("gEnemyParty")[:100]))
+        with context.emulator.peek_frame():
+            mon = parse_pokemon(read_symbol("gEnemyParty")[:100])
         if mon is None:
             return None
 


### PR DESCRIPTION
This sets the GIF 'frame rate' to a static 20ms/frame instead of using the number of frames as the number of milliseconds per frame.

The GIF generation is a bit faster now by not using `peek_frame()` for every single frame-to-render but rather using one peek pass for all of them.

It also changes `peek_frame()` to create a context so it can be used by invoking the `with` keyword which might make the code a bit more readable.

This also fixes a bug in the Sudowoodo mode that caused an error message whenever you open the bot mode menu on FR/LG. That doesn't have anything to do with GIFs, but I thought I'd sneak it in anyway.