### PR TITLE
Allow disabling GUI theme with an environment variable

### DIFF
--- a/modules/gui/__init__.py
+++ b/modules/gui/__init__.py
@@ -1,5 +1,6 @@
 import os
 import platform
+from tkinter import Tk, ttk
 from ttkthemes import ThemedTk
 from typing import TYPE_CHECKING
 
@@ -25,8 +26,12 @@ if TYPE_CHECKING:
 
 class PokebotGui:
     def __init__(self, main_loop: callable, on_exit: callable):
-        theme = "equilux" if darkdetect.isDark() else "clam"
-        self.window = ThemedTk(className="PokeBot", theme=theme)
+        if os.getenv("POKEBOT_UNTHEMED") != "1":
+            theme = "equilux" if darkdetect.isDark() else "clam"
+            self.window = ThemedTk(className="PokeBot", theme=theme)
+        else:
+            self.window = Tk(className="PokeBot")
+            ttk.Style().theme_use("default")
         self._current_screen = None
         self._main_loop = main_loop
         self._on_exit = on_exit

--- a/modules/gui/create_profile_screen.py
+++ b/modules/gui/create_profile_screen.py
@@ -1,6 +1,5 @@
 import re
-from tkinter import ttk, StringVar
-from ttkthemes import ThemedTk
+from tkinter import ttk, Tk, StringVar
 from typing import Union
 
 import plyer
@@ -14,7 +13,7 @@ from modules.version import pokebot_name
 
 
 class CreateProfileScreen:
-    def __init__(self, window: ThemedTk, enable_profile_selection_screen: callable, run_profile: callable):
+    def __init__(self, window: Tk, enable_profile_selection_screen: callable, run_profile: callable):
         self.window = window
         self.enable_profile_selection_screen = enable_profile_selection_screen
         self.run_profile = run_profile

--- a/modules/gui/emulator_controls.py
+++ b/modules/gui/emulator_controls.py
@@ -1,6 +1,5 @@
 import tkinter.font
-from tkinter import ttk
-from ttkthemes import ThemedTk
+from tkinter import ttk, Tk
 from typing import Union
 
 from modules.console import console
@@ -12,7 +11,7 @@ from modules.version import pokebot_name, pokebot_version
 
 
 class EmulatorControls:
-    def __init__(self, window: ThemedTk):
+    def __init__(self, window: Tk):
         self.window = window
         self.last_known_bot_mode = context.bot_mode
 
@@ -243,7 +242,7 @@ class DebugTab:
 
 
 class DebugEmulatorControls(EmulatorControls):
-    def __init__(self, window: ThemedTk):
+    def __init__(self, window: Tk):
         super().__init__(window)
         self.debug_frame: Union[ttk.Frame, None] = None
         self.debug_notebook: ttk.Notebook

--- a/modules/gui/emulator_screen.py
+++ b/modules/gui/emulator_screen.py
@@ -1,5 +1,4 @@
-from tkinter import Button, PhotoImage
-from ttkthemes import ThemedTk
+from tkinter import Tk, Button, PhotoImage
 
 import PIL.Image
 import PIL.ImageTk
@@ -11,7 +10,7 @@ from modules.version import pokebot_name, pokebot_version
 
 
 class EmulatorScreen:
-    def __init__(self, window: ThemedTk):
+    def __init__(self, window: Tk):
         self.window = window
         self.frame: Union[ttk.Frame, None] = None
         self.canvas: Union[Canvas, None] = None

--- a/modules/gui/load_state_window.py
+++ b/modules/gui/load_state_window.py
@@ -2,8 +2,7 @@ import random
 import re
 import time
 from pathlib import Path
-from tkinter import ttk, Toplevel, Canvas, PhotoImage, TclError
-from ttkthemes import ThemedTk
+from tkinter import ttk, Tk, Toplevel, Canvas, PhotoImage, TclError
 
 import PIL.Image
 import PIL.ImageDraw
@@ -14,7 +13,7 @@ from modules.runtime import get_sprites_path
 
 
 class LoadStateWindow:
-    def __init__(self, window: ThemedTk):
+    def __init__(self, window: Tk):
         state_directory = context.profile.path / "states"
         if not state_directory.is_dir():
             return

--- a/modules/gui/select_profile_screen.py
+++ b/modules/gui/select_profile_screen.py
@@ -1,13 +1,12 @@
 from datetime import datetime, date
-from tkinter import ttk
-from ttkthemes import ThemedTk
+from tkinter import ttk, Tk
 from typing import Union
 
 from modules.profiles import Profile, list_available_profiles
 
 
 class SelectProfileScreen:
-    def __init__(self, window: ThemedTk, enable_profile_creation_screen: callable, run_profile: callable):
+    def __init__(self, window: Tk, enable_profile_creation_screen: callable, run_profile: callable):
         self.window = window
         self.enable_profile_creation_screen = enable_profile_creation_screen
         self.run_profile = run_profile


### PR DESCRIPTION
The new theme makes the GUI laggy to the point of being unusable.

This change allows disabling the theme using an environment variable (starting the bot with `POKEBOT_UNTHEMED=1`) so I can more happily work and test on the bot.

This changes some of the type hints back from `ThemedTk` to `Tk`, as the former is a subclass of the latter so it works either way.