### PR TITLE
Error message due to Nugget Bridge mode in RSE

### DIFF
--- a/modules/modes/nugget_bridge.py
+++ b/modules/modes/nugget_bridge.py
@@ -19,12 +19,13 @@ class NuggetBridgeMode(BotMode):
     @staticmethod
     def is_selectable() -> bool:
         if context.rom.is_frlg:
-            allowed_maps = [
+            return get_player_avatar().map_group_and_number in [
                 MapFRLG.ROUTE_24.value,
                 MapFRLG.CERULEAN_CITY.value,
                 MapFRLG.CERULEAN_CITY_D.value,
             ]
-        return get_player_avatar().map_group_and_number in allowed_maps
+        else:
+            return False
 
     def run(self) -> Generator:
         if get_event_flag("HIDE_NUGGET_BRIDGE_ROCKET"):


### PR DESCRIPTION
The Nugget Bridge mode's `is_selectable()` method does not define the `allowed_maps` on RSE, but it _does_ try to compare the current map to it.

This leads to an error being thrown each time the bot mode menu is opened.

The error is suppressed in non-debug runs so that is not a huge issue for most users, but still.