### PR TITLE
Fix southern isle/mew

### DIFF
--- a/modules/modes/static_run_away.py
+++ b/modules/modes/static_run_away.py
@@ -15,6 +15,7 @@ from ._util import (
     wait_until_script_is_no_longer_active,
     wait_until_script_is_active,
     follow_path,
+    wait_for_script_to_start_and_finish,
 )
 
 
@@ -139,7 +140,7 @@ class StaticRunAway(BotMode):
                     yield from walk_one_tile("Up")
                     yield from navigate_to(13, 12)
                     context.emulator.press_button("A")
-                    yield from wait_until_script_is_no_longer_active("Common_EventScript_LegendaryFlewAway", "B")
+                    yield from wait_for_script_to_start_and_finish("Common_EventScript_LegendaryFlewAway", "B")
 
             # Kyorge in Emerald
             case MapRSE.MARINE_CAVE_A.value:

--- a/modules/modes/static_run_away.py
+++ b/modules/modes/static_run_away.py
@@ -12,8 +12,6 @@ from ._util import (
     wait_for_task_to_start_and_finish,
     navigate_to,
     walk_one_tile,
-    wait_until_script_is_no_longer_active,
-    wait_until_script_is_active,
     follow_path,
     wait_for_script_to_start_and_finish,
 )
@@ -185,8 +183,7 @@ class StaticRunAway(BotMode):
                     yield from follow_path([(12, 16), (16, 16), (16, 13)])
                     context.emulator.press_button("A")
                     yield from wait_for_task_to_start_and_finish("Task_WaitForFadeAndEnableScriptCtx", "B")
-                    yield from wait_until_script_is_active("Common_EventScript_LegendaryFlewAway", "B")
-                    yield from wait_until_script_is_no_longer_active("Common_EventScript_LegendaryFlewAway", "B")
+                    yield from wait_for_script_to_start_and_finish("Common_EventScript_LegendaryFlewAway", "B")
                     yield from walk_one_tile("Down")
                     yield from follow_path([(16, 16), (12, 16), (12, 19)])
                     yield from walk_one_tile("Down")


### PR DESCRIPTION
Southern Isle would get stuck on "Lati@s flew away!" - this fixes that.

I also swapped the Mew code for a single line function which has the exact same behaviour, seedled moment, not sure why I did that.