### PR TITLE
Include encounter GIF in the original Discord notification

### DIFF
--- a/modules/discord.py
+++ b/modules/discord.py
@@ -14,9 +14,9 @@ def discord_message(
     embed: bool = False,
     embed_title: str = None,
     embed_description: str = None,
-    embed_fields: object = None,
+    embed_fields: dict = None,
     embed_thumbnail: str | Path = None,
-    embed_image: str | Path = None,
+    embed_image: Path = None,
     embed_footer: str = None,
     embed_color: str = "FFFFFF",
 ) -> None:
@@ -39,14 +39,16 @@ def discord_message(
                     embed_obj.add_embed_field(name=key, value=value, inline=False)
 
             if embed_thumbnail:
+                filename = "thumb.gif" if embed_image.name.endswith(".gif") else "thumb.png"
                 with open(embed_thumbnail, "rb") as f:
-                    webhook.add_file(file=f.read(), filename="thumb.png")
-                embed_obj.set_thumbnail(url="attachment://thumb.png")
+                    webhook.add_file(file=f.read(), filename=filename)
+                embed_obj.set_thumbnail(url="attachment://" + filename)
 
             if embed_image:
+                filename = "embed.gif" if embed_image.name.endswith(".gif") else "embed.png"
                 with open(embed_image, "rb") as f:
-                    webhook.add_file(file=f.read(), filename="embed.png")
-                embed_obj.set_image(url="attachment://embed.png")
+                    webhook.add_file(file=f.read(), filename=filename)
+                embed_obj.set_image(url="attachment://" + filename)
 
             if embed_footer:
                 embed_obj.set_footer(text=embed_footer)
@@ -82,6 +84,8 @@ def discord_rich_presence() -> None:
             large_image = "charizard"
         case "POKEMON LEAF":
             large_image = "venusaur"
+        case _:
+            large_image = None
 
     while True:
         encounter_log = total_stats.get_encounter_log()
@@ -97,7 +101,7 @@ def discord_rich_presence() -> None:
                 f"{current_fps:,}fps ({current_fps / 59.727500569606:0.2f}x)"
             ),
             large_image=large_image,
-            start=start,
+            start=int(start),
             buttons=[{"label": "⏬ Download PokéBot", "url": "https://github.com/40Cakes/pokebot-gen3"}],
         )
 

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -1,14 +1,15 @@
 import copy
+import importlib
 import json
 import math
+import random
 import sys
 import time
-import random
-import importlib
-from collections import deque
-from threading import Thread
-from datetime import datetime
 from collections import Counter
+from collections import deque
+from datetime import datetime
+from pathlib import Path
+from threading import Thread
 
 from modules.console import console, print_stats
 from modules.context import context
@@ -328,7 +329,9 @@ class TotalStats:
             },
         }
 
-    def log_encounter(self, pokemon: Pokemon, block_list: list, custom_filter_result: str | bool) -> None:
+    def log_encounter(
+        self, pokemon: Pokemon, block_list: list, custom_filter_result: str | bool, gif_path: Path | None = None
+    ) -> None:
         if "pokemon" not in self.total_stats:
             self.total_stats["pokemon"] = {}
         if "totals" not in self.total_stats:
@@ -382,6 +385,7 @@ class TotalStats:
                 copy.deepcopy(self.total_stats),
                 copy.deepcopy(block_list),
                 copy.deepcopy(custom_filter_result),
+                copy.deepcopy(gif_path),
             )
             Thread(target=self.custom_hooks, args=(hook,)).start()
 

--- a/profiles/customhooks.py
+++ b/profiles/customhooks.py
@@ -1,8 +1,10 @@
-import os
 import glob
-import time
+import os
 import random
+import time
+from pathlib import Path
 from threading import Thread
+
 from modules.console import console
 from modules.context import context
 from modules.discord import discord_message
@@ -17,13 +19,14 @@ def custom_hooks(hook) -> None:
 
     Note: this function runs in a thread and will not hold up the bot if you need to run any slow hooks
     """
-    try:
-        # Deep copy of Pokémon and stats dictionaries when the thread was called to avoid main thread overwriting vars
-        pokemon: Pokemon = hook[0]
-        stats = hook[1]
-        block_list = hook[2]
-        custom_filter_result = hook[3]
+    # Deep copy of Pokémon and stats dictionaries when the thread was called to avoid main thread overwriting vars
+    pokemon: Pokemon = hook[0]
+    stats = hook[1]
+    block_list = hook[2]
+    custom_filter_result = hook[3]
+    gif_path = hook[4]
 
+    try:
         ### Your custom code goes here ###
 
         # Discord messages
@@ -111,6 +114,7 @@ def custom_hooks(hook) -> None:
                     | PhaseSummary(),
                     embed_thumbnail=get_sprites_path() / "pokemon" / "shiny" / f"{pokemon.species.safe_name}.png",
                     embed_color="ffd242",
+                    embed_image=gif_path,
                 )
         except:
             console.print_exception(show_locals=True)
@@ -303,6 +307,7 @@ def custom_hooks(hook) -> None:
                     | PhaseSummary(),
                     embed_thumbnail=get_sprites_path() / "pokemon" / "normal" / f"{pokemon.species.safe_name}.png",
                     embed_color="6a89cc",
+                    embed_image=gif_path,
                 )
         except:
             console.print_exception(show_locals=True)
@@ -319,7 +324,7 @@ def custom_hooks(hook) -> None:
                 time.sleep(3)  # Give the screenshot some time to save to disk
                 images = glob.glob(f"{context.config.obs.replay_dir}*.png")
                 image = max(images, key=os.path.getctime)
-                discord_message(webhook_url=context.config.obs.discord_webhook_url, image=image)
+                discord_message(webhook_url=context.config.obs.discord_webhook_url, image=Path(image))
 
             # Run in a thread to not hold up other hooks
             Thread(target=OBSDiscordScreenshot).start()


### PR DESCRIPTION
(This is based on #239 which should probably be merged first.)

The new encounter-handling code is doing things in a different order, which makes it much easier to include the encounter GIF in the regular Discord notification message.

[discord-embedded-image.webm](https://github.com/40Cakes/pokebot-gen3/assets/1106400/c1d12842-1cb7-48c0-abec-98e8d623a343)
