### PR TITLE
[BUG] Fix Daycare on Fire Red (and would apply to RSE too)

### DIFF
--- a/modules/modes/daycare.py
+++ b/modules/modes/daycare.py
@@ -218,9 +218,12 @@ class DaycareMode(BotMode):
                     context.emulator.press_button("Down")
                     yield from wait_for_n_frames(20)
                 else:
-                    context.emulator.press_button("A")
-                    yield from wait_for_n_frames(7)
+                    while not task_is_active("Task_OnSelectedMon"):
+                        context.emulator.press_button("A")
+                        yield
+                    yield from wait_until_task_is_active("Task_OnSelectedMon")
                     for _ in range(2):
+                        yield from wait_for_n_frames(10)
                         context.emulator.press_button("Up")
                         yield from wait_for_n_frames(2)
                     context.emulator.press_button("A")

--- a/modules/modes/game_corner.py
+++ b/modules/modes/game_corner.py
@@ -40,10 +40,10 @@ class GameCornerMode(BotMode):
         coincase = get_player().coins
         if coincase < 180:
             raise BotModeError("You don't have enough coins to buy anything.")
-
+        
         if context.rom.is_fr:
             choices = [("Abra", 180), ("Clefairy", 500), ("Dratini", 2800), ("Scyther", 5500), ("Porygon", 9999)]
-        if context.rom.is_lg:
+        elif context.rom.is_lg:
             choices = [("Abra", 120), ("Clefairy", 750), ("Pinsir", 2500), ("Dratini", 4600), ("Porygon", 6500)]
         else:
             raise BotModeError("This mode is not supported on RSE.")

--- a/modules/modes/game_corner.py
+++ b/modules/modes/game_corner.py
@@ -40,7 +40,7 @@ class GameCornerMode(BotMode):
         coincase = get_player().coins
         if coincase < 180:
             raise BotModeError("You don't have enough coins to buy anything.")
-        
+
         if context.rom.is_fr:
             choices = [("Abra", 180), ("Clefairy", 500), ("Dratini", 2800), ("Scyther", 5500), ("Porygon", 9999)]
         elif context.rom.is_lg:

--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -23,7 +23,7 @@ from ._util import (
     wait_until_event_flag_is_true,
     wait_for_script_to_start_and_finish,
     navigate_to,
-    wait_for_n_frames,
+    follow_path,
 )
 
 
@@ -151,8 +151,8 @@ class StaticGiftResetsMode(BotMode):
                 if not get_player_avatar().is_on_bike:
                     context.emulator.press_button("Select")
                 if encounter[2] == "Wynaut":
-                    yield from navigate_to(3, 10, False)
-                    yield from navigate_to(16, 10, False)
+                    yield from navigate_to(3, 10)
+                    yield from follow_path([(3, 10), (16, 10)])
                 elif encounter[2] == "Togepi":
                     yield from navigate_to(17, 9, False)
                     yield from navigate_to(8, 9, False)
@@ -163,15 +163,7 @@ class StaticGiftResetsMode(BotMode):
                     context.emulator.press_button("B")
                     yield
                 while egg_in_party() > 0:
-                    yield from wait_for_n_frames(20)
-                    for _ in hatch_egg():
-                        script_ctx = get_global_script_context()
-                        if "EventScript_EggHatch" in script_ctx.stack:
-                            if context.rom.is_rse and not task_is_active("Task_WaitForFadeAndEnableScriptCtx"):
-                                yield from wait_for_task_to_start_and_finish("Task_WaitForFadeAndEnableScriptCtx", "B")
-                            elif context.rom.is_frlg and not task_is_active("Task_ContinueScript"):
-                                yield from wait_for_task_to_start_and_finish("Task_ContinueScript", "B")
-                        yield
+                    yield from hatch_egg()
 
             # Navigate to the summary screen to check for shininess
             yield from StartMenuNavigator("POKEMON").step()


### PR DESCRIPTION
Adds in a bit of a safetynet around the release pokemon menu, as on FR for some peoples saves (not others), it was pressing Up early, causing it to navigate to the lead pokemon which got stuck. 