### PR TITLE
[BUG] Fix daycare on Fire Red

### DIFF
--- a/modules/modes/daycare.py
+++ b/modules/modes/daycare.py
@@ -218,9 +218,12 @@ class DaycareMode(BotMode):
                     context.emulator.press_button("Down")
                     yield from wait_for_n_frames(20)
                 else:
-                    context.emulator.press_button("A")
-                    yield from wait_for_n_frames(7)
+                    while not task_is_active("Task_OnSelectedMon"):
+                        context.emulator.press_button("A")
+                        yield
+                    yield from wait_until_task_is_active("Task_OnSelectedMon")
                     for _ in range(2):
+                        yield from wait_for_n_frames(10)
                         context.emulator.press_button("Up")
                         yield from wait_for_n_frames(2)
                     context.emulator.press_button("A")


### PR DESCRIPTION
Fixes the daycare on fire red, ensures that the task Task_OnSelectedMon is active before trying to navigate to "Release"
Prior line is also required to ensure it hits the task at all to prevent getting stuck in limbo