### PR TITLE
Add Menu Bar

### DIFF
--- a/modules/context.py
+++ b/modules/context.py
@@ -25,25 +25,26 @@ class BotContext:
         self._current_bot_mode: str = initial_bot_mode
         self._previous_bot_mode: str = "Manual"
 
-    def reload_config(self) -> str:
-        """Triggers a config reload, reload the global config then specific profile config.
-
-        :return: A user-facing message
+    def reload_config(self) -> None:
         """
+        Triggers a config reload, reload the global config then specific profile config.
+        """
+        from modules.console import console
+
         try:
             new_config = Config()
             new_config.load(self.config.config_dir, strict=False)
             self.config = new_config
-            message = "[cyan]Profile settings loaded.[/]"
+            console.print("[cyan]Profile settings loaded.[/]")
         except Exception as error:
             if self.debug:
                 raise error
-            message = (
+            console.print(
                 "[bold red]The configuration could not be loaded, no changes have been made.[/]\n"
                 "[bold yellow]This is probably due to a malformed file."
                 "For more information run the bot with the --debug flag.[/]"
             )
-        return message
+        return
 
     @property
     def message(self) -> str:

--- a/modules/gui/__init__.py
+++ b/modules/gui/__init__.py
@@ -179,9 +179,8 @@ class PokebotGui:
                         console.print(f"Now in [cyan]{context.bot_mode}[/] mode")
                         context.emulator.set_inputs(0)
                     case "reload_config":
-                        message = context.reload_config()
+                        context.reload_config()
                         self._apply_key_config()
-                        console.print(message)
                     case "toggle_video":
                         context.toggle_video()
                     case "toggle_audio":
@@ -197,7 +196,7 @@ class PokebotGui:
                     case "set_speed_unthrottled":
                         context.emulation_speed = 0
                     case "screenshot":
-                        context.emulator.take_screenshot(suffix="manual")
+                        context.emulator.take_screenshot("manual")
 
         # This prevents the default action for that key to be executed, which is important for
         # the Tab key (which normally moves focus to the next GUI element.)

--- a/modules/gui/emulator_controls.py
+++ b/modules/gui/emulator_controls.py
@@ -44,28 +44,24 @@ class EmulatorControls:
         self.menu_bar = Menu(self.window)
 
         emulator_menu = Menu(self.window, tearoff=0)
-        emulator_menu.add_command(label="Load save state...", command=lambda: LoadStateWindow(self.window))
-        emulator_menu.add_command(
-            label="New save state...", command=lambda: context.emulator.create_save_state("Manual")
-        )
-        emulator_menu.add_command(
-            label="Take screenshot...", command=lambda: context.emulator.take_screenshot("manual")
-        )
+        emulator_menu.add_command(label="Load Save State", command=lambda: LoadStateWindow(self.window))
+        emulator_menu.add_command(label="New Save State", command=lambda: context.emulator.create_save_state("Manual"))
+        emulator_menu.add_command(label="Take Screenshot", command=lambda: context.emulator.take_screenshot("manual"))
         emulator_menu.add_separator()
-        emulator_menu.add_command(label="Reset...", command=context.emulator.reset)
+        emulator_menu.add_command(label="Reset", command=context.emulator.reset)
 
         profile_menu = Menu(self.window, tearoff=0)
         profile_menu.add_command(
-            label="Open profile folder...", command=lambda: show_in_file_manager(str(context.profile.path))
+            label="Open Profile Folder", command=lambda: show_in_file_manager(str(context.profile.path))
         )
 
         help_menu = Menu(self.window, tearoff=0)
         help_menu.add_command(
-            label="Open wiki...",
+            label=f"{pokebot_name} Wiki",
             command=lambda: webbrowser.open_new_tab("https://github.com/40Cakes/pokebot-gen3/tree/main/wiki"),
         )
         help_menu.add_command(
-            label="Support Discord...",
+            label="Discord #pokebot-gen3-support",
             command=lambda: webbrowser.open_new_tab(
                 "https://discord.com/channels/1057088810950860850/1139190426834833528"
             ),

--- a/modules/gui/emulator_controls.py
+++ b/modules/gui/emulator_controls.py
@@ -1,6 +1,9 @@
 import tkinter.font
-from tkinter import Tk, ttk
+import webbrowser
+from tkinter import Menu, Tk, ttk
 from typing import Union
+
+from showinfm import show_in_file_manager
 
 from modules.console import console
 from modules.context import context
@@ -16,6 +19,7 @@ class EmulatorControls:
         self.last_known_bot_mode = context.bot_mode
 
         self.frame: Union[ttk.Frame, None] = None
+        self.menu_bar: Union[Menu, None] = None
         self.bot_mode_button: ttk.Button
         self.bot_mode_menu: tkinter.Menu | None
         self.speed_1x_button: ttk.Button
@@ -35,6 +39,43 @@ class EmulatorControls:
         return 200
 
     def add_to_window(self) -> None:
+        from modules.gui import LoadStateWindow
+
+        self.menu_bar = Menu(self.window)
+
+        emulator_menu = Menu(self.window, tearoff=0)
+        emulator_menu.add_command(label="Load save state...", command=lambda: LoadStateWindow(self.window))
+        emulator_menu.add_command(
+            label="New save state...", command=lambda: context.emulator.create_save_state("Manual")
+        )
+        emulator_menu.add_command(
+            label="Take screenshot...", command=lambda: context.emulator.take_screenshot("manual")
+        )
+        emulator_menu.add_separator()
+        emulator_menu.add_command(label="Reset...", command=context.emulator.reset)
+
+        profile_menu = Menu(self.window, tearoff=0)
+        profile_menu.add_command(
+            label="Open profile folder...", command=lambda: show_in_file_manager(str(context.profile.path))
+        )
+
+        help_menu = Menu(self.window, tearoff=0)
+        help_menu.add_command(
+            label="Open wiki...",
+            command=lambda: webbrowser.open_new_tab("https://github.com/40Cakes/pokebot-gen3/tree/main/wiki"),
+        )
+        help_menu.add_command(
+            label="Support Discord...",
+            command=lambda: webbrowser.open_new_tab(
+                "https://discord.com/channels/1057088810950860850/1139190426834833528"
+            ),
+        )
+
+        self.menu_bar.add_cascade(label="Emulator", menu=emulator_menu)
+        self.menu_bar.add_cascade(label="Profile", menu=profile_menu)
+        self.menu_bar.add_cascade(label="Help", menu=help_menu)
+        self.window.config(menu=self.menu_bar)
+
         self.frame = ttk.Frame(self.window, padding=5)
         self.frame.grid(row=1, sticky="NSWE")
         self.frame.columnconfigure(1, weight=1)
@@ -222,7 +263,7 @@ class EmulatorControls:
         if current_fps:
             stats.append(f"{current_fps:,}fps ({current_fps / 59.727500569606:0.2f}x)")
         if context.profile:
-            from modules.stats import total_stats  # TODO prevent instantiating TotalStats class before profile selected
+            from modules.stats import total_stats
 
             stats.append(f"{total_stats.get_encounter_rate():,}/h")
         if context.debug:

--- a/requirements.py
+++ b/requirements.py
@@ -35,6 +35,7 @@ required_modules = [
     "flask-swagger-ui~=4.11.1",
     "ttkthemes~=3.2.2",
     "darkdetect~=0.8.0",
+    "show-in-file-manager~=1.1.4",
 ]
 
 if platform.system() == "Windows":


### PR DESCRIPTION
Add a basic drop-down menu bar to emulator screen for quick access to some common functions, can be expanded in the future.

![image](https://github.com/40Cakes/pokebot-gen3/assets/16377135/7e306cc8-ebd4-413f-b5a3-72aee7ced71f)
