### PR TITLE
Unown letter logging

### DIFF
--- a/modules/console.py
+++ b/modules/console.py
@@ -61,8 +61,11 @@ def sv_colour(value: int) -> str:
 
 
 def print_stats(total_stats: dict, pokemon: Pokemon, session_pokemon: set, encounter_rate: int) -> None:
+    species_name = pokemon.species.name
+    if pokemon.species.name == "Unown":
+        species_name += f" ({pokemon.unown_letter})"
     type_colour = pokemon.species.types[0].name.lower()
-    rich_name = f"[{type_colour}]{pokemon.species.name}[/]"
+    rich_name = f"[{type_colour}]{species_name}[/]"
 
     match context.config.logging.console.encounter_data:
         case "verbose":
@@ -100,7 +103,7 @@ def print_stats(total_stats: dict, pokemon: Pokemon, session_pokemon: set, encou
 
     match context.config.logging.console.encounter_ivs:
         case "verbose":
-            iv_table = Table(title=f"{pokemon.species.name} IVs")
+            iv_table = Table(title=f"{species_name} IVs")
             iv_table.add_column("HP", justify="center", style=iv_colour(pokemon.ivs.hp))
             iv_table.add_column("ATK", justify="center", style=iv_colour(pokemon.ivs.attack))
             iv_table.add_column("DEF", justify="center", style=iv_colour(pokemon.ivs.defence))
@@ -131,7 +134,7 @@ def print_stats(total_stats: dict, pokemon: Pokemon, session_pokemon: set, encou
 
     match context.config.logging.console.encounter_moves:
         case "verbose":
-            move_table = Table(title=f"{pokemon.species.name} Moves")
+            move_table = Table(title=f"{species_name} Moves")
             move_table.add_column("Name", justify="left", width=20)
             move_table.add_column("Kind", justify="center", width=10)
             move_table.add_column("Type", justify="center", width=10)
@@ -202,14 +205,14 @@ def print_stats(total_stats: dict, pokemon: Pokemon, session_pokemon: set, encou
             console.print(stats_table)
         case "basic":
             console.print(
-                f"{rich_name} Phase Encounters: {total_stats['pokemon'][pokemon.species.name].get('phase_encounters', 0):,} | "
-                f"{rich_name} Total Encounters: {total_stats['pokemon'][pokemon.species.name].get('encounters', 0):,} | "
-                f"{rich_name} Shiny Encounters: {total_stats['pokemon'][pokemon.species.name].get('shiny_encounters', 0):,}"
+                f"{rich_name} Phase Encounters: {total_stats['pokemon'][species_name].get('phase_encounters', 0):,} | "
+                f"{rich_name} Total Encounters: {total_stats['pokemon'][species_name].get('encounters', 0):,} | "
+                f"{rich_name} Shiny Encounters: {total_stats['pokemon'][species_name].get('shiny_encounters', 0):,}"
             )
             console.print(
-                f"{rich_name} Phase IV Records [red]{total_stats['pokemon'][pokemon.species.name].get('phase_lowest_iv_sum', -1)}[/]/[green]{total_stats['pokemon'][pokemon.species.name].get('phase_highest_iv_sum', -1)}[/] | "
-                f"{rich_name} Phase SV Records [green]{total_stats['pokemon'][pokemon.species.name].get('phase_lowest_sv', -1):,}[/]/[{sv_colour(total_stats['pokemon'][pokemon.species.name].get('phase_highest_sv', -1))}]{total_stats['pokemon'][pokemon.species.name].get('phase_highest_sv', -1):,}[/] | "
-                f"{rich_name} Shiny Average: {total_stats['pokemon'][pokemon.species.name].get('shiny_average', 'N/A')}"
+                f"{rich_name} Phase IV Records [red]{total_stats['pokemon'][species_name].get('phase_lowest_iv_sum', -1)}[/]/[green]{total_stats['pokemon'][species_name].get('phase_highest_iv_sum', -1)}[/] | "
+                f"{rich_name} Phase SV Records [green]{total_stats['pokemon'][species_name].get('phase_lowest_sv', -1):,}[/]/[{sv_colour(total_stats['pokemon'][species_name].get('phase_highest_sv', -1))}]{total_stats['pokemon'][species_name].get('phase_highest_sv', -1):,}[/] | "
+                f"{rich_name} Shiny Average: {total_stats['pokemon'][species_name].get('shiny_average', 'N/A')}"
             )
             console.print(
                 f"Phase Encounters: {total_stats['totals'].get('phase_encounters', 0):,} | "

--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -1153,9 +1153,9 @@ class MapTab(DebugTab):
         map_connections = map_data.connections
         connections_list = {"__value": set()}
         for i in range(len(map_connections)):
-            connections_list[map_connections[i].direction] = (
-                f"to {map_connections[i].destination_map.map_name} (offset: {str(map_connections[i].offset)})"
-            )
+            connections_list[
+                map_connections[i].direction
+            ] = f"to {map_connections[i].destination_map.map_name} (offset: {str(map_connections[i].offset)})"
             connections_list["__value"].add(map_connections[i].direction)
         connections_list["__value"] = ", ".join(connections_list["__value"])
 

--- a/modules/modes/daycare.py
+++ b/modules/modes/daycare.py
@@ -218,9 +218,12 @@ class DaycareMode(BotMode):
                     context.emulator.press_button("Down")
                     yield from wait_for_n_frames(20)
                 else:
-                    context.emulator.press_button("A")
-                    yield from wait_for_n_frames(7)
+                    while not task_is_active("Task_OnSelectedMon"):
+                        context.emulator.press_button("A")
+                        yield
+                    yield from wait_until_task_is_active("Task_OnSelectedMon")
                     for _ in range(2):
+                        yield from wait_for_n_frames(10)
                         context.emulator.press_button("Up")
                         yield from wait_for_n_frames(2)
                     context.emulator.press_button("A")

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -353,9 +353,7 @@ class TotalStats:
             "snapshot_stats": {
                 "phase_encounters": self.total_stats["totals"]["phase_encounters"],
                 "species_encounters": self.total_stats["pokemon"][species_name]["encounters"],
-                "species_shiny_encounters": self.total_stats["pokemon"][species_name].get(
-                    "shiny_encounters", 0
-                ),
+                "species_shiny_encounters": self.total_stats["pokemon"][species_name].get("shiny_encounters", 0),
                 "total_encounters": self.total_stats["totals"]["encounters"],
                 "total_shiny_encounters": self.total_stats["totals"].get("shiny_encounters", 0),
             },

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -146,31 +146,41 @@ class TotalStats:
 
     def update_incremental_stats(self, pokemon: Pokemon) -> None:
         self.session_encounters += 1
-        self.session_pokemon.add(pokemon.species.name)
+        species_name = pokemon.species.name
+        if pokemon.species.name == "Unown":
+            species_name += f" ({pokemon.unown_letter})"
+
+        self.session_pokemon.add(species_name)
         self.total_stats["totals"]["encounters"] = self.total_stats["totals"].get("encounters", 0) + 1
         self.total_stats["totals"]["phase_encounters"] = self.total_stats["totals"].get("phase_encounters", 0) + 1
-        self.total_stats["pokemon"][pokemon.species.name]["encounters"] = (
-            self.total_stats["pokemon"][pokemon.species.name].get("encounters", 0) + 1
+        self.total_stats["pokemon"][species_name]["encounters"] = (
+            self.total_stats["pokemon"][species_name].get("encounters", 0) + 1
         )
-        self.total_stats["pokemon"][pokemon.species.name]["phase_encounters"] = (
-            self.total_stats["pokemon"][pokemon.species.name].get("phase_encounters", 0) + 1
+        self.total_stats["pokemon"][species_name]["phase_encounters"] = (
+            self.total_stats["pokemon"][species_name].get("phase_encounters", 0) + 1
         )
-        self.total_stats["pokemon"][pokemon.species.name]["last_encounter_time_unix"] = time.time()
-        self.total_stats["pokemon"][pokemon.species.name]["last_encounter_time_str"] = str(datetime.now())
+        self.total_stats["pokemon"][species_name]["last_encounter_time_unix"] = time.time()
+        self.total_stats["pokemon"][species_name]["last_encounter_time_str"] = str(datetime.now())
 
     def update_shiny_incremental_stats(self, pokemon: Pokemon) -> None:
-        self.total_stats["pokemon"][pokemon.species.name]["shiny_encounters"] = (
-            self.total_stats["pokemon"][pokemon.species.name].get("shiny_encounters", 0) + 1
+        species_name = pokemon.species.name
+        if pokemon.species.name == "Unown":
+            species_name += f" ({pokemon.unown_letter})"
+        self.total_stats["pokemon"][species_name]["shiny_encounters"] = (
+            self.total_stats["pokemon"][species_name].get("shiny_encounters", 0) + 1
         )
         self.total_stats["totals"]["shiny_encounters"] = self.total_stats["totals"].get("shiny_encounters", 0) + 1
 
     def update_phase_records(self, pokemon: Pokemon) -> None:
+        species_name = pokemon.species.name
+        if pokemon.species.name == "Unown":
+            species_name += f" ({pokemon.unown_letter})"
         # Total longest phase
         if self.total_stats["totals"]["phase_encounters"] > self.total_stats["totals"].get(
             "longest_phase_encounters", 0
         ):
             self.total_stats["totals"]["longest_phase_encounters"] = self.total_stats["totals"]["phase_encounters"]
-            self.total_stats["totals"]["longest_phase_pokemon"] = pokemon.species.name
+            self.total_stats["totals"]["longest_phase_pokemon"] = species_name
 
         # Total shortest phase
         if (
@@ -178,7 +188,7 @@ class TotalStats:
             or self.total_stats["totals"]["phase_encounters"] <= self.total_stats["totals"]["shortest_phase_encounters"]
         ):
             self.total_stats["totals"]["shortest_phase_encounters"] = self.total_stats["totals"]["phase_encounters"]
-            self.total_stats["totals"]["shortest_phase_pokemon"] = pokemon.species.name
+            self.total_stats["totals"]["shortest_phase_pokemon"] = species_name
 
     def reset_phase_stats(self) -> None:
         # Reset phase stats
@@ -205,101 +215,110 @@ class TotalStats:
             self.total_stats["pokemon"][n]["phase_lowest_iv_sum"] = None
 
     def update_sv_records(self, pokemon: Pokemon) -> None:
+        species_name = pokemon.species.name
+        if pokemon.species.name == "Unown":
+            species_name += f" ({pokemon.unown_letter})"
         # Pokémon phase highest shiny value
-        if not self.total_stats["pokemon"][pokemon.species.name].get("phase_highest_sv", None):
-            self.total_stats["pokemon"][pokemon.species.name]["phase_highest_sv"] = pokemon.shiny_value
+        if not self.total_stats["pokemon"][species_name].get("phase_highest_sv", None):
+            self.total_stats["pokemon"][species_name]["phase_highest_sv"] = pokemon.shiny_value
         else:
-            self.total_stats["pokemon"][pokemon.species.name]["phase_highest_sv"] = max(
-                pokemon.shiny_value, self.total_stats["pokemon"][pokemon.species.name].get("phase_highest_sv", -1)
+            self.total_stats["pokemon"][species_name]["phase_highest_sv"] = max(
+                pokemon.shiny_value, self.total_stats["pokemon"][species_name].get("phase_highest_sv", -1)
             )
 
         # Pokémon phase lowest shiny value
-        if not self.total_stats["pokemon"][pokemon.species.name].get("phase_lowest_sv", None):
-            self.total_stats["pokemon"][pokemon.species.name]["phase_lowest_sv"] = pokemon.shiny_value
+        if not self.total_stats["pokemon"][species_name].get("phase_lowest_sv", None):
+            self.total_stats["pokemon"][species_name]["phase_lowest_sv"] = pokemon.shiny_value
         else:
-            self.total_stats["pokemon"][pokemon.species.name]["phase_lowest_sv"] = min(
-                pokemon.shiny_value, self.total_stats["pokemon"][pokemon.species.name].get("phase_lowest_sv", 65536)
+            self.total_stats["pokemon"][species_name]["phase_lowest_sv"] = min(
+                pokemon.shiny_value, self.total_stats["pokemon"][species_name].get("phase_lowest_sv", 65536)
             )
 
         # Pokémon total lowest shiny value
-        if not self.total_stats["pokemon"][pokemon.species.name].get("total_lowest_sv", None):
-            self.total_stats["pokemon"][pokemon.species.name]["total_lowest_sv"] = pokemon.shiny_value
+        if not self.total_stats["pokemon"][species_name].get("total_lowest_sv", None):
+            self.total_stats["pokemon"][species_name]["total_lowest_sv"] = pokemon.shiny_value
         else:
-            self.total_stats["pokemon"][pokemon.species.name]["total_lowest_sv"] = min(
-                pokemon.shiny_value, self.total_stats["pokemon"][pokemon.species.name].get("total_lowest_sv", 65536)
+            self.total_stats["pokemon"][species_name]["total_lowest_sv"] = min(
+                pokemon.shiny_value, self.total_stats["pokemon"][species_name].get("total_lowest_sv", 65536)
             )
 
         # Phase highest shiny value
         if not self.total_stats["totals"].get("phase_highest_sv", None):
             self.total_stats["totals"]["phase_highest_sv"] = pokemon.shiny_value
-            self.total_stats["totals"]["phase_highest_sv_pokemon"] = pokemon.species.name
+            self.total_stats["totals"]["phase_highest_sv_pokemon"] = species_name
         elif pokemon.shiny_value >= self.total_stats["totals"].get("phase_highest_sv", -1):
             self.total_stats["totals"]["phase_highest_sv"] = pokemon.shiny_value
-            self.total_stats["totals"]["phase_highest_sv_pokemon"] = pokemon.species.name
+            self.total_stats["totals"]["phase_highest_sv_pokemon"] = species_name
 
         # Phase lowest shiny value
         if not self.total_stats["totals"].get("phase_lowest_sv", None):
             self.total_stats["totals"]["phase_lowest_sv"] = pokemon.shiny_value
-            self.total_stats["totals"]["phase_lowest_sv_pokemon"] = pokemon.species.name
+            self.total_stats["totals"]["phase_lowest_sv_pokemon"] = species_name
         elif pokemon.shiny_value <= self.total_stats["totals"].get("phase_lowest_sv", 65536):
             self.total_stats["totals"]["phase_lowest_sv"] = pokemon.shiny_value
-            self.total_stats["totals"]["phase_lowest_sv_pokemon"] = pokemon.species.name
+            self.total_stats["totals"]["phase_lowest_sv_pokemon"] = species_name
 
     def update_iv_records(self, pokemon: Pokemon) -> None:
+        species_name = pokemon.species.name
+        if pokemon.species.name == "Unown":
+            species_name += f" ({pokemon.unown_letter})"
         # Pokémon highest phase IV record
-        if not self.total_stats["pokemon"][pokemon.species.name].get(
+        if not self.total_stats["pokemon"][species_name].get(
             "phase_highest_iv_sum"
-        ) or pokemon.ivs.sum() >= self.total_stats["pokemon"][pokemon.species.name].get("phase_highest_iv_sum", -1):
-            self.total_stats["pokemon"][pokemon.species.name]["phase_highest_iv_sum"] = pokemon.ivs.sum()
+        ) or pokemon.ivs.sum() >= self.total_stats["pokemon"][species_name].get("phase_highest_iv_sum", -1):
+            self.total_stats["pokemon"][species_name]["phase_highest_iv_sum"] = pokemon.ivs.sum()
 
         # Pokémon highest total IV record
-        if pokemon.ivs.sum() >= self.total_stats["pokemon"][pokemon.species.name].get("total_highest_iv_sum", -1):
-            self.total_stats["pokemon"][pokemon.species.name]["total_highest_iv_sum"] = pokemon.ivs.sum()
+        if pokemon.ivs.sum() >= self.total_stats["pokemon"][species_name].get("total_highest_iv_sum", -1):
+            self.total_stats["pokemon"][species_name]["total_highest_iv_sum"] = pokemon.ivs.sum()
 
         # Pokémon lowest phase IV record
-        if not self.total_stats["pokemon"][pokemon.species.name].get(
+        if not self.total_stats["pokemon"][species_name].get(
             "phase_lowest_iv_sum"
-        ) or pokemon.ivs.sum() <= self.total_stats["pokemon"][pokemon.species.name].get("phase_lowest_iv_sum", 999):
-            self.total_stats["pokemon"][pokemon.species.name]["phase_lowest_iv_sum"] = pokemon.ivs.sum()
+        ) or pokemon.ivs.sum() <= self.total_stats["pokemon"][species_name].get("phase_lowest_iv_sum", 999):
+            self.total_stats["pokemon"][species_name]["phase_lowest_iv_sum"] = pokemon.ivs.sum()
 
         # Pokémon lowest total IV record
-        if pokemon.ivs.sum() <= self.total_stats["pokemon"][pokemon.species.name].get("total_lowest_iv_sum", 999):
-            self.total_stats["pokemon"][pokemon.species.name]["total_lowest_iv_sum"] = pokemon.ivs.sum()
+        if pokemon.ivs.sum() <= self.total_stats["pokemon"][species_name].get("total_lowest_iv_sum", 999):
+            self.total_stats["pokemon"][species_name]["total_lowest_iv_sum"] = pokemon.ivs.sum()
 
         # Phase highest IV sum record
         if not self.total_stats["totals"].get("phase_highest_iv_sum") or pokemon.ivs.sum() >= self.total_stats[
             "totals"
         ].get("phase_highest_iv_sum", -1):
             self.total_stats["totals"]["phase_highest_iv_sum"] = pokemon.ivs.sum()
-            self.total_stats["totals"]["phase_highest_iv_sum_pokemon"] = pokemon.species.name
+            self.total_stats["totals"]["phase_highest_iv_sum_pokemon"] = species_name
 
         # Phase lowest IV sum record
         if not self.total_stats["totals"].get("phase_lowest_iv_sum") or pokemon.ivs.sum() <= self.total_stats[
             "totals"
         ].get("phase_lowest_iv_sum", 999):
             self.total_stats["totals"]["phase_lowest_iv_sum"] = pokemon.ivs.sum()
-            self.total_stats["totals"]["phase_lowest_iv_sum_pokemon"] = pokemon.species.name
+            self.total_stats["totals"]["phase_lowest_iv_sum_pokemon"] = species_name
 
         # Total highest IV sum record
         if pokemon.ivs.sum() >= self.total_stats["totals"].get("highest_iv_sum", -1):
             self.total_stats["totals"]["highest_iv_sum"] = pokemon.ivs.sum()
-            self.total_stats["totals"]["highest_iv_sum_pokemon"] = pokemon.species.name
+            self.total_stats["totals"]["highest_iv_sum_pokemon"] = species_name
 
         # Total lowest IV sum record
         if pokemon.ivs.sum() <= self.total_stats["totals"].get("lowest_iv_sum", 999):
             self.total_stats["totals"]["lowest_iv_sum"] = pokemon.ivs.sum()
-            self.total_stats["totals"]["lowest_iv_sum_pokemon"] = pokemon.species.name
+            self.total_stats["totals"]["lowest_iv_sum_pokemon"] = species_name
 
     def update_shiny_averages(self, pokemon: Pokemon) -> None:
+        species_name = pokemon.species.name
+        if pokemon.species.name == "Unown":
+            species_name += f" ({pokemon.unown_letter})"
         # Pokémon shiny average
-        if self.total_stats["pokemon"][pokemon.species.name].get("shiny_encounters"):
+        if self.total_stats["pokemon"][species_name].get("shiny_encounters"):
             avg = int(
                 math.floor(
-                    self.total_stats["pokemon"][pokemon.species.name]["encounters"]
-                    / self.total_stats["pokemon"][pokemon.species.name]["shiny_encounters"]
+                    self.total_stats["pokemon"][species_name]["encounters"]
+                    / self.total_stats["pokemon"][species_name]["shiny_encounters"]
                 )
             )
-            self.total_stats["pokemon"][pokemon.species.name]["shiny_average"] = f"1/{avg:,}"
+            self.total_stats["pokemon"][species_name]["shiny_average"] = f"1/{avg:,}"
 
         # Total shiny average
         if self.total_stats["totals"].get("shiny_encounters"):
@@ -309,26 +328,32 @@ class TotalStats:
             self.total_stats["totals"]["shiny_average"] = f"1/{avg:,}"
 
     def update_same_pokemon_streak_record(self, pokemon: Pokemon) -> None:
+        species_name = pokemon.species.name
+        if pokemon.species.name == "Unown":
+            species_name += f" ({pokemon.unown_letter})"
         # Same Pokémon encounter streak records
         if (
             state_cache.last_encounter_log.value is not None
-            and state_cache.last_encounter_log.value["pokemon"]["name"] == pokemon.species.name
+            and state_cache.last_encounter_log.value["pokemon"]["name"] == species_name
         ):
             self.total_stats["totals"]["current_streak"] = self.total_stats["totals"].get("current_streak", 0) + 1
         else:
             self.total_stats["totals"]["current_streak"] = 1
         if self.total_stats["totals"].get("current_streak", 0) >= self.total_stats["totals"].get("phase_streak", 0):
             self.total_stats["totals"]["phase_streak"] = self.total_stats["totals"].get("current_streak", 0)
-            self.total_stats["totals"]["phase_streak_pokemon"] = pokemon.species.name
+            self.total_stats["totals"]["phase_streak_pokemon"] = species_name
 
     def get_log_obj(self, pokemon: Pokemon) -> dict:
+        species_name = pokemon.species.name
+        if pokemon.species.name == "Unown":
+            species_name += f" ({pokemon.unown_letter})"
         return {
             "time_encountered": time.time(),
             "pokemon": pokemon.to_legacy_dict(),
             "snapshot_stats": {
                 "phase_encounters": self.total_stats["totals"]["phase_encounters"],
-                "species_encounters": self.total_stats["pokemon"][pokemon.species.name]["encounters"],
-                "species_shiny_encounters": self.total_stats["pokemon"][pokemon.species.name].get(
+                "species_encounters": self.total_stats["pokemon"][species_name]["encounters"],
+                "species_shiny_encounters": self.total_stats["pokemon"][species_name].get(
                     "shiny_encounters", 0
                 ),
                 "total_encounters": self.total_stats["totals"]["encounters"],
@@ -344,8 +369,12 @@ class TotalStats:
         if "totals" not in self.total_stats:
             self.total_stats["totals"] = {}
 
-        if pokemon.species.name not in self.total_stats["pokemon"]:  # Set up a Pokémon stats if first encounter
-            self.total_stats["pokemon"][pokemon.species.name] = {}
+        species_name = pokemon.species.name
+        if pokemon.species.name == "Unown":
+            species_name += f" ({pokemon.unown_letter})"
+
+        if species_name not in self.total_stats["pokemon"]:  # Set up a Pokémon stats if first encounter
+            self.total_stats["pokemon"][species_name] = {}
 
         if self.total_stats["totals"].get("last_encounter_pid") == pokemon.personality_value:
             console.print(

--- a/profiles/battle.yml
+++ b/profiles/battle.yml
@@ -4,19 +4,19 @@
 auto_catch: true
 
 # Pickup
-pickup: true
+pickup: false
 pickup_threshold: 1
 pickup_check_frequency: 5
 
 # Battling
 battle: false
-battle_method: strongest  # `strongest`
+battle_method: strongest # `strongest`
 hp_threshold: 20
-lead_cannot_battle_action: flee  # `stop`, `flee`, `rotate`
-faint_action: flee  # `stop`, `flee`, `rotate`
-new_move: stop  # `stop`, `cancel`, `learn_best`
+lead_cannot_battle_action: flee # `stop`, `flee`, `rotate`
+faint_action: flee # `stop`, `flee`, `rotate`
+new_move: stop # `stop`, `cancel`, `learn_best`
 stop_evolution: true
-switch_strategy: first_available  # `first_available`
+switch_strategy: first_available # `first_available`
 banned_moves:
   - None
   # 2-turn


### PR DESCRIPTION
Logs unown letters correctly, both in console and `totals.json` file.

Allows for correctly tracking how many of the "rare" have been seen (e.g. `!` and `?`)

![image](https://github.com/40Cakes/pokebot-gen3/assets/22874875/01f2799e-1a59-48b9-90c8-f1c42ced552a)

```json
"Unown (Z)": {
    "encounters": 53,
    "last_encounter_time_str": "2024-02-19 13:51:50.626350",
    "last_encounter_time_unix": 1708350710.6263502,
    "phase_encounters": 53,
    "phase_highest_iv_sum": 133,
    "phase_highest_sv": 65535,
    "phase_lowest_iv_sum": 40,
    "phase_lowest_sv": 771,
    "total_highest_iv_sum": 133,
    "total_lowest_iv_sum": 40,
    "total_lowest_sv": 771
    },
    ```

Requires testing with webhooks as may cause issues with the sprite being posted - but would be nice to be able to send the correct sprite - e.g. this was `I` unown but came through as `?`
![image](https://github.com/40Cakes/pokebot-gen3/assets/22874875/3fccdd0b-1475-4f43-89a7-a971a9b57add)
