### PR TITLE
Fix daycare (R) and rock smash (E)

### DIFF
--- a/modules/modes/daycare.py
+++ b/modules/modes/daycare.py
@@ -235,10 +235,9 @@ class DaycareMode(BotMode):
                     context.emulator.press_button("Down")
                     yield from wait_for_n_frames(20)
                 else:
-                    while not task_is_active("Task_OnSelectedMon"):
-                        context.emulator.press_button("A")
-                        yield
-                    yield from wait_until_task_is_active("Task_OnSelectedMon")
+                    yield from wait_for_n_frames(5)
+                    context.emulator.press_button("A")
+                    yield from wait_for_n_frames(5)
                     for _ in range(2):
                         yield from wait_for_n_frames(10)
                         context.emulator.press_button("Up")

--- a/modules/modes/rock_smash.py
+++ b/modules/modes/rock_smash.py
@@ -222,7 +222,7 @@ class RockSmashMode(BotMode):
         yield from walk_one_tile("Up")
         yield from walk_one_tile("Up")
         yield from walk_one_tile("Down")
-        yield from navigate_to(7, 13)
+        yield from follow_path([(29, 14), (7, 13)])
         yield from ensure_facing_direction("Up")
         if self._using_repel:
             yield from apply_white_flute_if_available()


### PR DESCRIPTION
### Description
<!-- A brief overview of what the PR achieves -->
Rock Smash (E) and Daycare (R) reported as having issues in Discord. this fixes both.

### Changes
<!-- In depth changes per file, if feasible -->
- `modules/modes/daycare.py` - removed check for `Task_OnSelectedMon` as doesn't exist in Ruby
- `modules/modes/rock_smash.py` - Swapped a `navigate_to()` for `follow_path()` forcing walking one tile down initially and issue appears to be resolved.

### Checklist
<!-- Pre-merge checks that should be completed -->
- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->