### PR TITLE
Create a unified check whether player avatar is controllable

### DIFF
--- a/modules/map.py
+++ b/modules/map.py
@@ -1619,6 +1619,14 @@ def get_map_objects() -> list[ObjectEvent]:
     return objects
 
 
+def get_player_map_object() -> ObjectEvent | None:
+    data = read_symbol("gObjectEvents", 0, 0x24)
+    if data[0] & 0x01:
+        return ObjectEvent(data)
+    else:
+        return None
+
+
 def get_map_all_tiles() -> list[MapLocation]:
     current_map_data = get_map_data_for_current_position()
     map_group, map_number = current_map_data.map_group, current_map_data.map_number

--- a/modules/modes/_listeners.py
+++ b/modules/modes/_listeners.py
@@ -7,7 +7,7 @@ from modules.map import get_map_objects, get_map_data_for_current_position
 from modules.map_data import MapFRLG, MapRSE
 from modules.memory import GameState, get_game_state, get_game_state_symbol, read_symbol, unpack_uint32
 from modules.menuing import CheckForPickup, MenuWrapper, should_check_for_pickup
-from modules.player import TileTransitionState, get_player_avatar
+from modules.player import TileTransitionState, get_player_avatar, player_avatar_is_standing_still
 from modules.pokemon import (
     BattleTypeFlag,
     StatusCondition,
@@ -89,7 +89,7 @@ class BattleListener(BotListener):
                 and "Task_ReturnToFieldContinueScriptPlayMapMusic" not in frame.active_tasks
                 and "task_mpl_807E3C8" not in frame.active_tasks
                 and len(get_map_objects()) > 0
-                and "heldMovementFinished" in get_map_objects()[0].flags
+                and player_avatar_is_standing_still()
             ):
                 self._in_battle = False
                 if outcome == BattleOutcome.NoSafariBallsLeft:
@@ -112,10 +112,7 @@ class BattleListener(BotListener):
         if (
             get_game_state() != GameState.BATTLE
             and not get_global_script_context().is_active
-            and len(map_objects) > 0
-            and "heldMovementActive" in map_objects[0].flags
-            and "heldMovementFinished" in map_objects[0].flags
-            and "frozen" not in get_map_objects()[0].flags
+            and player_avatar_is_standing_still()
         ):
             if context.config.battle.pickup and should_check_for_pickup():
                 yield from MenuWrapper(CheckForPickup()).step()
@@ -319,9 +316,7 @@ class WhiteoutListener(BotListener):
         while "EventScript_AfterWhiteOutHeal" in get_global_script_context().stack:
             context.emulator.press_button("B")
             yield
-        while len(get_map_objects()) < 1:
-            yield
-        while "heldMovementFinished" not in get_map_objects()[0].flags:
+        while not player_avatar_is_standing_still():
             yield
 
         custom_handling = bot_mode.on_whiteout()
@@ -388,7 +383,7 @@ class SafariZoneListener(BotListener):
         ):
             context.emulator.press_button("B")
             yield
-        while "heldMovementFinished" not in get_map_objects()[0].flags:
+        while not player_avatar_is_standing_still():
             yield
 
         custom_handling = bot_mode.on_safari_zone_timeout()

--- a/modules/modes/daycare.py
+++ b/modules/modes/daycare.py
@@ -17,6 +17,7 @@ from ._util import (
     follow_path,
     navigate_to,
     register_key_item,
+    wait_for_player_avatar_to_be_controllable,
     wait_for_n_frames,
     wait_for_task_to_start_and_finish,
     wait_until_task_is_active,
@@ -256,9 +257,7 @@ class DaycareMode(BotMode):
                     yield from wait_for_n_frames(20)
 
             # Leave daycare
-            while get_game_state() != GameState.OVERWORLD or "heldMovementActive" not in get_map_objects()[0].flags:
-                context.emulator.press_button("B")
-                yield
+            yield from wait_for_player_avatar_to_be_controllable("B")
 
             yield from navigate_to(*daycare_exit)
             yield from walk_one_tile("Down")

--- a/modules/modes/puzzle_solver.py
+++ b/modules/modes/puzzle_solver.py
@@ -14,6 +14,7 @@ from ._interface import BotMode, BotModeError
 from ._util import (
     follow_path,
     navigate_to,
+    wait_for_player_avatar_to_be_controllable,
     wait_for_n_frames,
     wait_for_script_to_start_and_finish,
     wait_for_task_to_start_and_finish,
@@ -450,6 +451,4 @@ class PuzzleSolverMode(BotMode):
                 context.emulator.press_button("A")
                 yield
 
-            while "heldMovementActive" not in get_map_objects()[0].flags:
-                context.emulator.press_button("B")
-                yield
+            yield from wait_for_player_avatar_to_be_controllable("B")

--- a/modules/modes/roamer_reset.py
+++ b/modules/modes/roamer_reset.py
@@ -3,7 +3,6 @@ from typing import Generator
 from modules.context import context
 from modules.encounter import EncounterValue, handle_encounter, judge_encounter, log_encounter
 from modules.gui.multi_select_window import Selection, ask_for_choice
-from modules.map import get_map_objects
 from modules.map_data import MapFRLG, MapRSE
 from modules.memory import GameState, get_event_var, get_game_state
 from modules.player import get_player, get_player_avatar
@@ -23,6 +22,7 @@ from ._util import (
     navigate_to,
     replenish_repel,
     soft_reset,
+    wait_for_player_avatar_to_be_standing_still,
     wait_for_unique_rng_value,
     wait_until_task_is_active,
     walk_one_tile,
@@ -141,8 +141,7 @@ class RoamerResetMode(BotMode):
             yield from soft_reset(mash_random_keys=True)
             yield from wait_for_unique_rng_value()
 
-            while "heldMovementFinished" not in get_map_objects()[0].flags:
-                yield
+            yield from wait_for_player_avatar_to_be_standing_still()
 
             if get_player().gender == "female":
                 yield from navigate_to(1, 2)
@@ -162,8 +161,7 @@ class RoamerResetMode(BotMode):
                 context.emulator.press_button("A")
                 yield
 
-            while "heldMovementFinished" not in get_map_objects()[0].flags or "frozen" in get_map_objects()[0].flags:
-                yield
+            yield from wait_for_player_avatar_to_be_standing_still()
 
             if get_player().gender == "female":
                 yield from navigate_to(2, 8)
@@ -234,8 +232,7 @@ class RoamerResetMode(BotMode):
             yield from soft_reset(mash_random_keys=True)
             yield from wait_for_unique_rng_value()
 
-            while "heldMovementFinished" not in get_map_objects()[0].flags:
-                yield
+            yield from wait_for_player_avatar_to_be_standing_still()
 
             yield from navigate_to(14, 6)
             yield from ensure_facing_direction("Right")

--- a/modules/modes/rock_smash.py
+++ b/modules/modes/rock_smash.py
@@ -5,7 +5,6 @@ from modules.context import context
 from modules.encounter import handle_encounter
 from modules.gui.multi_select_window import Selection, ask_for_choice
 from modules.items import get_item_bag
-from modules.map import get_map_objects
 from modules.map_data import MapRSE
 from modules.memory import get_event_flag, get_event_var
 from modules.player import TileTransitionState, get_player, get_player_avatar
@@ -25,6 +24,7 @@ from ._util import (
     navigate_to,
     replenish_repel,
     soft_reset,
+    wait_for_player_avatar_to_be_standing_still,
     wait_for_script_to_start_and_finish,
     wait_for_unique_rng_value,
     wait_until_task_is_not_active,
@@ -164,12 +164,7 @@ class RockSmashMode(BotMode):
         context.emulator.reset_held_buttons()
         yield from soft_reset()
         yield from wait_for_unique_rng_value()
-        while (
-            get_map_objects() is None
-            or "heldMovementFinished" not in get_map_objects()[0].flags
-            or "heldMovementActive" not in get_map_objects()[0].flags
-        ):
-            yield
+        yield from wait_for_player_avatar_to_be_standing_still()
 
     @staticmethod
     def smash(flag_name):

--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -17,6 +17,7 @@ from ._util import (
     follow_path,
     navigate_to,
     soft_reset,
+    wait_for_player_avatar_to_be_controllable,
     wait_for_script_to_start_and_finish,
     wait_for_task_to_start_and_finish,
     wait_for_unique_rng_value,
@@ -165,6 +166,7 @@ class StaticGiftResetsMode(BotMode):
                     context.emulator.press_button("B")
                     yield
                 while egg_in_party() > 0:
+                    yield from wait_for_player_avatar_to_be_controllable()
                     yield from hatch_egg()
 
             # Navigate to the summary screen to check for shininess

--- a/modules/modes/static_run_away.py
+++ b/modules/modes/static_run_away.py
@@ -11,6 +11,7 @@ from ._interface import BattleAction, BotMode, BotModeError
 from ._util import (
     follow_path,
     navigate_to,
+    wait_for_player_avatar_to_be_controllable,
     wait_for_script_to_start_and_finish,
     wait_for_task_to_start_and_finish,
     walk_one_tile,
@@ -201,6 +202,4 @@ class StaticRunAway(BotMode):
                 context.emulator.press_button("A")
                 yield
 
-            while "heldMovementActive" not in get_map_objects()[0].flags:
-                context.emulator.press_button("B")
-                yield
+            yield from wait_for_player_avatar_to_be_controllable("B")


### PR DESCRIPTION
Currently, there are a lot of places where we are checking for the `heldMovementActive` or `heldMovementFinished` flags, or some other indicators that the player avatar is currently controllable.

I've now migrated that into ~a single function~ two functions that do all the checks in order to make the code a bit easier to understand and also to avoid inconsistencies across modes.

While doing so, I've extracted `get_player_map_object()` into its own function, because that's what _most_ of the calls to `get_map_objects()` actually want to know.

Fixes #249  
Fixes #259