### PR TITLE
[MODE] Pokecenter Loop Mode

### DIFF
--- a/modules/modes/__init__.py
+++ b/modules/modes/__init__.py
@@ -31,6 +31,7 @@ def get_bot_modes() -> list[Type[BotMode]]:
         from .static_gift_resets import StaticGiftResetsMode
         from .static_soft_resets import StaticSoftResetsMode
         from .random import RandomMode
+        from .pokecenterloop import PokecenterLoopMode
 
         _bot_modes = [
             BunnyHopMode,
@@ -50,6 +51,7 @@ def get_bot_modes() -> list[Type[BotMode]]:
             StaticGiftResetsMode,
             StaticSoftResetsMode,
             SudowoodoMode,
+            PokecenterLoopMode,
         ]
 
     return _bot_modes

--- a/modules/modes/_asserts.py
+++ b/modules/modes/_asserts.py
@@ -12,11 +12,21 @@ from ._interface import BotModeError
 
 def assert_no_auto_battle(error_message: str) -> None:
     """
-    Raises an exception if auto battling enabled, i.e. ensures that the bot is configured
+    Raises an exception if auto battling is enabled, i.e. ensures that the bot is configured
     to run away from any battle instead of fighting the opponent.
     :param error_message: Error message to display if the assertion fails.
     """
     if context.config.battle.battle:
+        raise BotModeError(error_message)
+
+
+def assert_auto_battle(error_message: str) -> None:
+    """
+    Raises an exception if auto battling is not enabled, i.e. ensures that the bot is configured
+    to fight any battle instead of running away.
+    :param error_message: Error message to display if the assertion fails.
+    """
+    if not context.config.battle.battle:
         raise BotModeError(error_message)
 
 

--- a/modules/modes/pokecenterloop.py
+++ b/modules/modes/pokecenterloop.py
@@ -1,0 +1,109 @@
+from typing import Generator
+
+from modules.context import context
+from modules.map_data import MapFRLG, MapRSE
+from modules.modes import get_bot_mode_by_name
+from modules.player import get_player_avatar
+from modules.tasks import get_global_script_context
+from ._interface import BotMode, BotModeError
+from ._asserts import assert_auto_battle
+from ._util import (
+    navigate_to,
+    wait_for_task_to_start_and_finish,
+    walk_one_tile,
+)
+from ..battle import BattleOutcome
+
+
+class PokecenterLoopMode(BotMode):
+    @staticmethod
+    def name() -> str:
+        return "Pokecenter Loop"
+
+    @staticmethod
+    def is_selectable() -> bool:
+        if context.rom.is_frlg:
+            allowed_maps = [MapFRLG.ROUTE2]
+        elif context.rom.is_emerald:
+            allowed_maps = [MapRSE.ROUTE102]
+        else:
+            allowed_maps = []
+        return get_player_avatar().map_group_and_number in allowed_maps
+
+    def __init__(self):
+        super().__init__()
+        assert_auto_battle("AutoBattle needs to be enabled for this mode to work")
+        self._use_bike = False
+        self._go_healing = False
+        self._controller = get_bot_mode_by_name("Spin")().run()
+
+    def on_battle_ended(self, outcome: "BattleOutcome") -> None:
+        if outcome == BattleOutcome.RanAway:
+            self._go_healing = True
+        else:
+            self._go_healing = False
+
+    def run(self) -> Generator:
+        if context.rom.is_frlg:
+            match get_player_avatar().map_group_and_number:
+                case MapFRLG.ROUTE2:
+
+                    def path():
+                        # navigate to Pokecenter
+                        yield from navigate_to(8, 0)
+                        yield from walk_one_tile("Up")
+                        yield from navigate_to(17, 26)
+                        yield from walk_one_tile("Up")
+                        yield from navigate_to(7, 4)
+                        # Healing
+                        yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessageBox", "A")
+                        yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessageBox", "A")
+                        while get_global_script_context().is_active:
+                            context.emulator.press_button("B")
+                            yield
+                        yield
+                        # navigate back to route
+                        yield from navigate_to(7, 8)
+                        yield from walk_one_tile("Down")
+                        yield from navigate_to(20, 39)
+                        yield from walk_one_tile("Down")
+                        yield from navigate_to(8, 2)
+
+                case _:
+                    raise BotModeError("You are not on the right map.")
+        elif context.rom.is_emerald:
+            match get_player_avatar().map_group_and_number:
+                case MapRSE.ROUTE102:
+
+                    def path():
+                        # navigate to Pokecenter
+                        yield from navigate_to(0, 7)
+                        yield from walk_one_tile("Left")
+                        yield from navigate_to(20, 17)
+                        yield from walk_one_tile("Up")
+                        yield from navigate_to(7, 4)
+                        # healing
+                        yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessage", "A")
+                        yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessage", "A")
+                        while get_global_script_context().is_active:
+                            context.emulator.press_button("B")
+                            yield
+                        yield
+                        # navigate back to route
+                        yield from navigate_to(7, 8)
+                        yield from walk_one_tile("Down")
+                        yield from navigate_to(29, 17)
+                        yield from walk_one_tile("Right")
+                        yield from navigate_to(4, 7)
+
+                case _:
+                    raise BotModeError("You are not on the right map.")
+
+        while True:
+            # path to pokecenter, heal and back
+            yield from path()
+            self._go_healing = False
+            # spin untill RanAway from battle
+            while not self._go_healing:
+                next(self._controller)
+                yield

--- a/wiki/Readme.md
+++ b/wiki/Readme.md
@@ -32,6 +32,7 @@ For quick help and support, reach out in Discord [#pokebot-gen3-support❔](http
 - 🏃🏼 [Static Run Away](pages/Mode%20-%20Static%20Run%20Aways.md)
 - ♻ [Static Soft Resets](pages/Mode%20-%20Static%20Soft%20Resets.md)
 - 🥦 [Sudowoodo](pages/Mode%20-%20Sudowoodo.md)
+- 🔄️ [Pokecenter Loop](pages/Mode%20-%Pokecenter%20Loop.md)
 
 ### Configuration
 

--- a/wiki/Readme.md
+++ b/wiki/Readme.md
@@ -22,6 +22,7 @@ For quick help and support, reach out in Discord [#pokebot-gen3-support❔](http
 - 🎰 [Game Corner](pages/Mode%20-%20Game%20Corner.md)
 - 🎨 [Kecleon](pages/Mode%20-%20Kecleon.md)
 - 🟡 [Nugget Bridge](pages/Mode%20-%20Nugget%20Bridge.md)
+- 🔄️ [Pokécenter Loop](pages/Mode%20-%Pokecenter%20Loop.md)
 - 🧩 [Puzzle Solver](pages/Mode%20-%20Puzzle%20Solver.md)
 - 🎲 [Random Inputs](pages/Mode%20-%20Random%20Inputs.md)
 - 🏃 [Roamer Resets](pages/Mode%20-%20Roamer%20Resets.md)
@@ -32,7 +33,6 @@ For quick help and support, reach out in Discord [#pokebot-gen3-support❔](http
 - 🏃🏼 [Static Run Away](pages/Mode%20-%20Static%20Run%20Aways.md)
 - ♻ [Static Soft Resets](pages/Mode%20-%20Static%20Soft%20Resets.md)
 - 🥦 [Sudowoodo](pages/Mode%20-%20Sudowoodo.md)
-- 🔄️ [Pokecenter Loop](pages/Mode%20-%Pokecenter%20Loop.md)
 
 ### Configuration
 

--- a/wiki/pages/Mode - Pokecenter Loop.md
+++ b/wiki/pages/Mode - Pokecenter Loop.md
@@ -1,0 +1,28 @@
+🏠 [`pokebot-gen3` Wiki Home](../Readme.md)
+
+# 🔄️ Pokecenter Loop Mode
+
+## Requirements
+
+- Set battle to True in the ⚔ [Battling and Pickup](Configuration%20-%20Battling%20and%20Pickup.md) config
+
+## Instructions
+
+Start this mode while being on Route 102 (in E) or Route 2 (FR/LG), the bot will automatically go to the Pokecenter and heal, return to the route untill it runs from battle and then repeat.
+
+## Game Support
+
+|          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
+| :------- | :-----: | :---------: | :--------: | :--------: | :----------: |
+| English  |   ❌    |     ❌      |     ✅     |     ✅     |      ✅      |
+| Japanese |   ❌    |     ❌      |     ❌     |     ❌     |      ❌      |
+| German   |   ❌    |     ❌      |     ❌     |     ❌     |      ❌      |
+| Spanish  |   ❌    |     ❌      |     ❌     |     ❌     |      ❌      |
+| French   |   ❌    |     ❌      |     ❌     |     ❌     |      ❌      |
+| Italian  |   ❌    |     ❌      |     ❌     |     ❌     |      ❌      |
+
+✅ Tested, working
+
+🟨 Untested, may not work
+
+❌ Untested, not working

--- a/wiki/pages/Mode - Pokecenter Loop.md
+++ b/wiki/pages/Mode - Pokecenter Loop.md
@@ -1,6 +1,6 @@
 🏠 [`pokebot-gen3` Wiki Home](../Readme.md)
 
-# 🔄️ Pokecenter Loop Mode
+# 🔄️ Pokécenter Loop Mode
 
 ## Requirements
 
@@ -8,7 +8,7 @@
 
 ## Instructions
 
-Start this mode while being on Route 102 (in E) or Route 2 (FR/LG), the bot will automatically go to the Pokecenter and heal, return to the route untill it runs from battle and then repeat.
+Start this mode while being on Route 102 (in E) or Route 2 (FR/LG), the bot will automatically go to the Pokécenter and heal, return to the route untill it runs from battle and then repeat.
 
 ## Game Support
 


### PR DESCRIPTION
### Description

Adds a generic Pokecenter loop mode that behaves like the old Petalburg loop.
it can be extended to other routs easy if needs be

currently supports the old Route 102 to Petalburg loop and for LGFR a Route 2 to Pewter City loop

### Changes

- [modules/modes/pokecenterloop.py](https://github.com/40Cakes/pokebot-gen3/compare/main...Terasol:pokebot-gen3:LevelLoop?expand=1#diff-f4961241186e27ec406dc2836ed2104b6d048a1c1c1ced1cba1e85074a2683b3) new mode
- [modules/modes/_asserts.py](https://github.com/40Cakes/pokebot-gen3/compare/main...Terasol:pokebot-gen3:LevelLoop?expand=1#diff-3c2a643b71e053eed956d73e00bd42d6caf5067209971b0b99511258e124e4f1) new assert to make sure the battle mode is turned on in the config
- [modules/modes/__init__.py](https://github.com/40Cakes/pokebot-gen3/compare/main...Terasol:pokebot-gen3:LevelLoop?expand=1#diff-2ad0d4717c4651d238c2961265b0367dd007ffa4140410958567558f00803a14) adding the new mode

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
