### PR TITLE
Fix pokecenter loop link

### DIFF
--- a/wiki/Readme.md
+++ b/wiki/Readme.md
@@ -22,7 +22,7 @@ For quick help and support, reach out in Discord [#pokebot-gen3-support❔](http
 - 🎰 [Game Corner](pages/Mode%20-%20Game%20Corner.md)
 - 🎨 [Kecleon](pages/Mode%20-%20Kecleon.md)
 - 🟡 [Nugget Bridge](pages/Mode%20-%20Nugget%20Bridge.md)
-- 🔄️ [Pokécenter Loop](pages/Mode%20-%Pokecenter%20Loop.md)
+- 🔄️ [Pokécenter Loop](pages/Mode%20-%20Pokecenter%20Loop.md)
 - 🧩 [Puzzle Solver](pages/Mode%20-%20Puzzle%20Solver.md)
 - 🎲 [Random Inputs](pages/Mode%20-%20Random%20Inputs.md)
 - 🏃 [Roamer Resets](pages/Mode%20-%20Roamer%20Resets.md)


### PR DESCRIPTION
### Description
Fixes link in readme of wiki to correctly point to the Pokebot loop page

### Changes
Added in the `20` after `%`

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
