### PR TITLE
Re-add Unown letter to dumped PK3 file names

### DIFF
--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from modules.console import console
 from modules.context import context
-from modules.files import save_pk3
+from modules.files import save_pk3, make_string_safe_for_file_name
 from modules.gui.desktop_notification import desktop_notification
 from modules.modes import BattleAction
 from modules.pokedex import get_pokedex
@@ -195,7 +195,7 @@ def handle_encounter(
         desktop_notification(title=alert[0], message=alert[1], icon=alert_icon)
 
     if is_of_interest:
-        filename_suffix = f"{encounter_value.name}_{pokemon.species.safe_name}"
+        filename_suffix = f"{encounter_value.name}_{make_string_safe_for_file_name(pokemon.species_name_for_stats)}"
         context.emulator.create_save_state(suffix=filename_suffix)
 
         if context.config.battle.auto_catch and not disable_auto_catch:

--- a/modules/files.py
+++ b/modules/files.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import os
+import string
 from pathlib import Path
 
 from modules.context import context
@@ -56,6 +57,27 @@ def write_file(file: Path, value: str, mode: str = "w") -> bool:
         return True
 
 
+def make_string_safe_for_file_name(base_string: str) -> str:
+    """
+    :return: The string name with any characters that might be problematic in file names replaced.
+    """
+    result = ""
+    for i in range(len(base_string)):
+        if base_string[i] in f"-_.()' {string.ascii_letters}{string.digits}":
+            result += base_string[i]
+        elif base_string[i] == "♂":
+            result += "_m"
+        elif base_string[i] == "♀":
+            result += "_f"
+        elif base_string[i] == "!":
+            result += "em"
+        elif base_string[i] == "?":
+            result += "qm"
+        else:
+            result += "_"
+    return result
+
+
 def save_pk3(pokemon: Pokemon) -> None:
     """
     Takes the byte data of [obj]Pokémon.data and outputs it in a pkX format in the /profiles/[PROFILE]/pokemon dir.
@@ -69,7 +91,7 @@ def save_pk3(pokemon: Pokemon) -> None:
         pk3_file = f"{pk3_file} ★"
 
     pk3_file = pokemon_dir_path / (
-        f"{pk3_file} - {pokemon.species.safe_name} - {pokemon.nature} "
+        f"{pk3_file} - {make_string_safe_for_file_name(pokemon.species_name_for_stats)} - {pokemon.nature} "
         f"[{pokemon.ivs.sum()}] - {hex(pokemon.personality_value)[2:].upper()}.pk3"
     )
 

--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -1,6 +1,5 @@
 import contextlib
 import json
-import string
 import struct
 from dataclasses import dataclass
 from enum import Enum, Flag, KEEP
@@ -592,27 +591,6 @@ class Species:
     egg_groups: list[str]
     base_experience_yield: int
     ev_yield: StatsValues
-
-    @property
-    def safe_name(self) -> str:
-        """
-        :return: The species name with any characters that might be problematic in file names replaced.
-        """
-        result = ""
-        for i in range(len(self.name)):
-            if self.name[i] in f"-_.()' {string.ascii_letters}{string.digits}":
-                result += self.name[i]
-            elif self.name[i] == "♂":
-                result += "_m"
-            elif self.name[i] == "♀":
-                result += "_f"
-            elif self.name[i] == "!":
-                result += "em"
-            elif self.name[i] == "?":
-                result += "qm"
-            else:
-                result += "_"
-        return result
 
     def has_type(self, type_to_find: Type) -> bool:
         return any(t.index == type_to_find.index for t in self.types)

--- a/modules/web/pokemon.d.ts
+++ b/modules/web/pokemon.d.ts
@@ -162,10 +162,6 @@ export type Species = {
     // English name of this species.
     name: string;
 
-    // The species name with any characters that might be problematic in file names
-    // replaced.
-    safe_name: string;
-
     types: Type[];
 
     // List of abilities that this species can have.


### PR DESCRIPTION
### Description

When changing how Unown names are handled in the stats system in #260 I missed the PK3 file names, so those would now only say 'Unown' again.

### Changes

- `modules/files.py` -- extracted the 'string cleaning' function from the Species' `safe_name()` method into a dedicated function so it can be used with any string; also made `save_pk3()` use the Pokemon's `species_name_for_stats` property rather than the raw species name.
- `modules/encounter.py` -- updated that code to use the new function, and also use `species_name_for_stats` for the save states it creates
- other files: associated clean-up

### Checklist

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)