### PR TITLE
Fix Spin mode on underwater maps

### DIFF
--- a/modules/modes/_listeners.py
+++ b/modules/modes/_listeners.py
@@ -3,7 +3,7 @@ import signal
 from modules.battle import BattleHandler, BattleOutcome, RotatePokemon, check_lead_can_battle, flee_battle
 from modules.context import context
 from modules.encounter import handle_encounter
-from modules.map import get_map_objects
+from modules.map import get_map_objects, get_map_data_for_current_position
 from modules.map_data import MapFRLG, MapRSE
 from modules.memory import GameState, get_game_state, get_game_state_symbol, read_symbol, unpack_uint32
 from modules.menuing import CheckForPickup, MenuWrapper, should_check_for_pickup
@@ -99,7 +99,8 @@ class BattleListener(BotListener):
 
     def _wait_until_battle_is_over(self):
         while self._in_battle:
-            context.emulator.press_button("B")
+            if get_game_state() != GameState.OVERWORLD or get_map_data_for_current_position().map_type != "Underwater":
+                context.emulator.press_button("B")
             yield
 
     @isolate_inputs


### PR DESCRIPTION
### Description

The battle listener will, at the end of a battle, spam the `B` button until the player is controllable again.

Pressing a button continuously means that it will be pressed in one frame, then not pressed in the next, then again etc.

So there is a 50/50 chance that during the frame where the player avatar becomes controllable again, the button is being held down.

This appears to happen regularly after a battle, so on Underwater maps this triggers the surfacing dialogue.

### Changes

I have added an exception for this very case. We stop pressing `B` once the battle scene transitions into the overworld when the player is on maps of type `Underwater`.

### Notes

The map type check is required because the listener is _also_ supposed to skip through any post-battle dialogue (which some trainer battles feature.) As far as I know, there are no scripted underwater battles.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] ~Wiki has been updated (if relevant)~ not relevant

<!-- Any further information can be added below here such as images/videos -->
