### PR TITLE
Fix Sprite Loading for Discord Webhooks

### DIFF
--- a/profiles/customhooks.py
+++ b/profiles/customhooks.py
@@ -113,7 +113,7 @@ def custom_hooks(hook) -> None:
                         f"{pokemon.species.name} Phase Encounters": f"{stats['pokemon'][pokemon.species.name].get('phase_encounters', 0):,}",
                     }
                     | phase_summary(),
-                    embed_thumbnail=get_sprites_path() / "pokemon" / "shiny" / f"{pokemon.species.safe_name}.png",
+                    embed_thumbnail=get_sprites_path() / "pokemon" / "shiny" / f"{pokemon.species_name_for_stats}.png",
                     embed_color="ffd242",
                     embed_image=gif_path,
                 )
@@ -140,7 +140,7 @@ def custom_hooks(hook) -> None:
                     content=f"🎉 New milestone achieved!\n{discord_ping}",
                     embed=True,
                     embed_description=f"{stats['pokemon'][pokemon.species.name].get('encounters', 0):,} {pokemon.species.name} encounters!",
-                    embed_thumbnail=get_sprites_path() / "pokemon" / "normal" / f"{pokemon.species.safe_name}.png",
+                    embed_thumbnail=get_sprites_path() / "pokemon" / "normal" / f"{pokemon.species_name_for_stats}.png",
                     embed_color="50C878",
                 )
         except Exception:
@@ -167,7 +167,7 @@ def custom_hooks(hook) -> None:
                     content=f"🎉 New milestone achieved!\n{discord_ping}",
                     embed=True,
                     embed_description=f"{stats['pokemon'][pokemon.species.name].get('shiny_encounters', 0):,} shiny ✨ {pokemon.species.name} ✨ encounters!",
-                    embed_thumbnail=get_sprites_path() / "pokemon" / "shiny" / f"{pokemon.species.safe_name}.png",
+                    embed_thumbnail=get_sprites_path() / "pokemon" / "shiny" / f"{pokemon.species_name_for_stats}.png",
                     embed_color="ffd242",
                 )
         except Exception:
@@ -275,7 +275,7 @@ def custom_hooks(hook) -> None:
                         f"{pokemon.species.name} Phase Encounters": f"{stats['pokemon'][pokemon.species.name].get('phase_encounters', 0):,}",
                     }
                     | phase_summary(),
-                    embed_thumbnail=get_sprites_path() / "pokemon" / "anti-shiny" / f"{pokemon.species.safe_name}.png",
+                    embed_thumbnail=get_sprites_path() / "pokemon" / "anti-shiny" / f"{pokemon.species_name_for_stats}.png",
                     embed_color="000000",
                 )
         except Exception:
@@ -306,7 +306,7 @@ def custom_hooks(hook) -> None:
                         f"{pokemon.species.name} Phase Encounters": f"{stats['pokemon'][pokemon.species.name].get('phase_encounters', 0):,}",
                     }
                     | phase_summary(),
-                    embed_thumbnail=get_sprites_path() / "pokemon" / "normal" / f"{pokemon.species.safe_name}.png",
+                    embed_thumbnail=get_sprites_path() / "pokemon" / "normal" / f"{pokemon.species_name_for_stats}.png",
                     embed_color="6a89cc",
                     embed_image=gif_path,
                 )

--- a/profiles/customhooks.py
+++ b/profiles/customhooks.py
@@ -275,7 +275,10 @@ def custom_hooks(hook) -> None:
                         f"{pokemon.species.name} Phase Encounters": f"{stats['pokemon'][pokemon.species.name].get('phase_encounters', 0):,}",
                     }
                     | phase_summary(),
-                    embed_thumbnail=get_sprites_path() / "pokemon" / "anti-shiny" / f"{pokemon.species_name_for_stats}.png",
+                    embed_thumbnail=get_sprites_path()
+                    / "pokemon"
+                    / "anti-shiny"
+                    / f"{pokemon.species_name_for_stats}.png",
                     embed_color="000000",
                 )
         except Exception:


### PR DESCRIPTION
### Description

Discord Webhooks for Shinys coudnt load the Sprite because `species.safe_name` dosnt exist anymore.

### Changes

[profiles/customhooks.py](https://github.com/40Cakes/pokebot-gen3/compare/main...Dukmos:pokebot-gen3:FixCustomCatch?expand=1#diff-14c5cbd885ff1f52edc54b0435555c258c317af622f0757976c26df3e3ffd3d9) -> change `species.safe_name` to `species_name_for_stats`

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [ ] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
