### PR TITLE
align starter messaging

### DIFF
--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -46,7 +46,7 @@ def run_frlg() -> Generator:
         # Spam 'A' until we see the summary screen
         yield from wait_until_task_is_active("Task_DuckBGMForPokemonCry", button_to_press="A")
 
-        handle_encounter(get_party()[0], disable_auto_catch=True)
+        handle_encounter(get_party()[0], disable_auto_catch=True, do_not_log_battle_action=True)
 
 
 def run_rse_hoenn() -> Generator:
@@ -132,7 +132,7 @@ def run_rse_johto():
         yield from StartMenuNavigator("POKEMON").step()
         yield from PokemonPartyMenuNavigator(len(get_party()) - 1, "summary").step()
 
-        handle_encounter(get_party()[len(get_party()) - 1], disable_auto_catch=True)
+        handle_encounter(get_party()[len(get_party()) - 1], disable_auto_catch=True, do_not_log_battle_action=True)
 
 
 class StartersMode(BotMode):


### PR DESCRIPTION
### Description

Stops the bot from telling you to catch the starters once a shiny starter is found for both of the modes where it checks the summary page.

### Changes

[modules/modes/starters.py](https://github.com/40Cakes/pokebot-gen3/compare/main...Terasol:pokebot-gen3:startermesagesfix#diff-50080c0eaf5ab69bff601f3de4033e480614e36a6af6fe5f2811aa62339daf9c) -> stop `handle_encounter` from adding "switched to manual mode so you can catch it." to the end of the message in the message box

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [ ] Wiki has been updated (if relevant)
