### PR TITLE
Use species_name_for_stats in customhooks.py

### DIFF
--- a/modules/tcg_card.py
+++ b/modules/tcg_card.py
@@ -204,7 +204,7 @@ def generate_tcg_card(pokemon: Pokemon, location: str = "") -> Path | None:
 
             # Encounter sprite
             sprite_type = "shiny" if pokemon.is_shiny else "normal"
-            species_name_safe = make_string_safe_for_file_name(pokemon.species.name)
+            species_name_safe = make_string_safe_for_file_name(pokemon.species_name_for_stats)
             sprite = Image.open(get_sprites_path() / "pokemon" / sprite_type / f"{species_name_safe}.png")
             card.paste(
                 sprite,

--- a/modules/tcg_card.py
+++ b/modules/tcg_card.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from PIL import Image, ImageDraw, ImageFont
 
 from modules.context import context
+from modules.files import make_string_safe_for_file_name
 from modules.player import get_player, get_player_avatar
 from modules.pokemon import Pokemon
 from modules.runtime import get_sprites_path
@@ -203,13 +204,8 @@ def generate_tcg_card(pokemon: Pokemon, location: str = "") -> Path | None:
 
             # Encounter sprite
             sprite_type = "shiny" if pokemon.is_shiny else "normal"
-            species_name_escaped = (
-                pokemon.species_name_for_stats.replace("♀", "_f")
-                .replace("♂", "_m")
-                .replace("!", "em")
-                .replace("?", "qm")
-            )
-            sprite = Image.open(get_sprites_path() / "pokemon" / sprite_type / f"{species_name_escaped}.png")
+            species_name_safe = make_string_safe_for_file_name(pokemon.species.name)
+            sprite = Image.open(get_sprites_path() / "pokemon" / sprite_type / f"{species_name_safe}.png")
             card.paste(
                 sprite,
                 (int(425 - (sprite.width / 2)), int(250 - (sprite.height - (sprite.height - sprite.getbbox()[3])))),

--- a/modules/tcg_card.py
+++ b/modules/tcg_card.py
@@ -105,7 +105,7 @@ def generate_tcg_card(pokemon: Pokemon, location: str = "") -> Path | None:
                 card.paste(shiny, (567, 55), mask=shiny)
 
             # Name text
-            draw = draw_text(draw, text=pokemon.species.name, coords=(192, 78), size=30, anchor="mm")
+            draw = draw_text(draw, text=pokemon.species_name_for_stats, coords=(192, 78), size=30, anchor="mm")
 
             # Nat dex number
             draw = draw_text(
@@ -203,7 +203,13 @@ def generate_tcg_card(pokemon: Pokemon, location: str = "") -> Path | None:
 
             # Encounter sprite
             sprite_type = "shiny" if pokemon.is_shiny else "normal"
-            sprite = Image.open(get_sprites_path() / "pokemon" / sprite_type / f"{pokemon.species.name}.png")
+            species_name_escaped = (
+                pokemon.species_name_for_stats.replace("♀", "_f")
+                .replace("♂", "_m")
+                .replace("!", "em")
+                .replace("?", "qm")
+            )
+            sprite = Image.open(get_sprites_path() / "pokemon" / sprite_type / f"{species_name_escaped}.png")
             card.paste(
                 sprite,
                 (int(425 - (sprite.width / 2)), int(250 - (sprite.height - (sprite.height - sprite.getbbox()[3])))),

--- a/profiles/customhooks.py
+++ b/profiles/customhooks.py
@@ -95,23 +95,23 @@ def custom_hooks(hook) -> None:
                         discord_ping = f"📢 <@{context.config.discord.shiny_pokemon_encounter.ping_id}>"
 
                 block = (
-                    "\n❌Skipping catching shiny (on catch block list)!" if pokemon.species.name in block_list else ""
+                    "\n❌Skipping catching shiny (on catch block list)!" if pokemon.species_name_for_stats in block_list else ""
                 )
 
                 discord_message(
                     webhook_url=context.config.discord.shiny_pokemon_encounter.webhook_url,
-                    content=f"Encountered a shiny ✨ {pokemon.species.name} ✨! {block}\n{discord_ping}",
+                    content=f"Encountered a shiny ✨ {pokemon.species_name_for_stats} ✨! {block}\n{discord_ping}",
                     embed=True,
                     embed_title="Shiny encountered!",
                     embed_description=(
-                        f"{pokemon.nature.name} {pokemon.species.name} (Lv. {pokemon.level:,}) at {pokemon.location_met}!"
+                        f"{pokemon.nature.name} {pokemon.species_name_for_stats} (Lv. {pokemon.level:,}) at {pokemon.location_met}!"
                     ),
                     embed_fields={
                         "Shiny Value": f"{pokemon.shiny_value:,}",
                         f"IVs ({pokemon.ivs.sum()})": iv_field(),
                         "Held item": pokemon.held_item.name if pokemon.held_item else "None",
-                        f"{pokemon.species.name} Encounters": f"{stats['pokemon'][pokemon.species.name].get('encounters', 0):,} ({stats['pokemon'][pokemon.species.name].get('shiny_encounters', 0):,}✨)",
-                        f"{pokemon.species.name} Phase Encounters": f"{stats['pokemon'][pokemon.species.name].get('phase_encounters', 0):,}",
+                        f"{pokemon.species_name_for_stats} Encounters": f"{stats['pokemon'][pokemon.species_name_for_stats].get('encounters', 0):,} ({stats['pokemon'][pokemon.species_name_for_stats].get('shiny_encounters', 0):,}✨)",
+                        f"{pokemon.species_name_for_stats} Phase Encounters": f"{stats['pokemon'][pokemon.species_name_for_stats].get('phase_encounters', 0):,}",
                     }
                     | phase_summary(),
                     embed_thumbnail=get_sprites_path()
@@ -128,7 +128,7 @@ def custom_hooks(hook) -> None:
             # Discord Pokémon encounter milestones
             if (
                 context.config.discord.pokemon_encounter_milestones.enable
-                and stats["pokemon"][pokemon.species.name].get("encounters", -1)
+                and stats["pokemon"][pokemon.species_name_for_stats].get("encounters", -1)
                 % context.config.discord.pokemon_encounter_milestones.interval
                 == 0
             ):
@@ -143,7 +143,7 @@ def custom_hooks(hook) -> None:
                     webhook_url=context.config.discord.pokemon_encounter_milestones.webhook_url,
                     content=f"🎉 New milestone achieved!\n{discord_ping}",
                     embed=True,
-                    embed_description=f"{stats['pokemon'][pokemon.species.name].get('encounters', 0):,} {pokemon.species.name} encounters!",
+                    embed_description=f"{stats['pokemon'][pokemon.species_name_for_stats].get('encounters', 0):,} {pokemon.species_name_for_stats} encounters!",
                     embed_thumbnail=get_sprites_path()
                     / "pokemon"
                     / "normal"
@@ -158,7 +158,7 @@ def custom_hooks(hook) -> None:
             if (
                 context.config.discord.shiny_pokemon_encounter_milestones.enable
                 and pokemon.is_shiny
-                and stats["pokemon"][pokemon.species.name].get("shiny_encounters", -1)
+                and stats["pokemon"][pokemon.species_name_for_stats].get("shiny_encounters", -1)
                 % context.config.discord.shiny_pokemon_encounter_milestones.interval
                 == 0
             ):
@@ -173,7 +173,7 @@ def custom_hooks(hook) -> None:
                     webhook_url=context.config.discord.shiny_pokemon_encounter_milestones.webhook_url,
                     content=f"🎉 New milestone achieved!\n{discord_ping}",
                     embed=True,
-                    embed_description=f"{stats['pokemon'][pokemon.species.name].get('shiny_encounters', 0):,} shiny ✨ {pokemon.species.name} ✨ encounters!",
+                    embed_description=f"{stats['pokemon'][pokemon.species_name_for_stats].get('shiny_encounters', 0):,} shiny ✨ {pokemon.species_name_for_stats} ✨ encounters!",
                     embed_thumbnail=get_sprites_path()
                     / "pokemon"
                     / "shiny"
@@ -273,16 +273,16 @@ def custom_hooks(hook) -> None:
                         discord_ping = f"📢 <@{context.config.discord.anti_shiny_pokemon_encounter.ping_id}>"
                 discord_message(
                     webhook_url=context.config.discord.anti_shiny_pokemon_encounter.webhook_url,
-                    content=f"Encountered an anti-shiny 💀 {pokemon.species.name} 💀!\n{discord_ping}",
+                    content=f"Encountered an anti-shiny 💀 {pokemon.species_name_for_stats} 💀!\n{discord_ping}",
                     embed=True,
                     embed_title="Anti-Shiny encountered!",
-                    embed_description=f"{pokemon.nature.name} {pokemon.species.name} (Lv. {pokemon.level:,}) at {pokemon.location_met}!",
+                    embed_description=f"{pokemon.nature.name} {pokemon.species_name_for_stats} (Lv. {pokemon.level:,}) at {pokemon.location_met}!",
                     embed_fields={
                         "Shiny Value": f"{pokemon.shiny_value:,}",
                         f"IVs ({pokemon.ivs.sum()})": iv_field(),
                         "Held item": pokemon.held_item.name if pokemon.held_item else "None",
-                        f"{pokemon.species.name} Encounters": f"{stats['pokemon'][pokemon.species.name].get('encounters', 0):,} ({stats['pokemon'][pokemon.species.name].get('shiny_encounters', 0):,}✨)",
-                        f"{pokemon.species.name} Phase Encounters": f"{stats['pokemon'][pokemon.species.name].get('phase_encounters', 0):,}",
+                        f"{pokemon.species_name_for_stats} Encounters": f"{stats['pokemon'][pokemon.species_name_for_stats].get('encounters', 0):,} ({stats['pokemon'][pokemon.species_name_for_stats].get('shiny_encounters', 0):,}✨)",
+                        f"{pokemon.species_name_for_stats} Phase Encounters": f"{stats['pokemon'][pokemon.species_name_for_stats].get('phase_encounters', 0):,}",
                     }
                     | phase_summary(),
                     embed_thumbnail=get_sprites_path()
@@ -307,16 +307,16 @@ def custom_hooks(hook) -> None:
 
                 discord_message(
                     webhook_url=context.config.discord.custom_filter_pokemon_encounter.webhook_url,
-                    content=f"Encountered a {pokemon.species.name} matching custom filter: `{custom_filter_result}`!\n{discord_ping}",
+                    content=f"Encountered a {pokemon.species_name_for_stats} matching custom filter: `{custom_filter_result}`!\n{discord_ping}",
                     embed=True,
                     embed_title="Encountered Pokémon matching custom catch filter!",
-                    embed_description=f"{pokemon.nature.name} {pokemon.species.name} (Lv. {pokemon.level:,}) at {pokemon.location_met}!\nMatching custom filter **{custom_filter_result}**",
+                    embed_description=f"{pokemon.nature.name} {pokemon.species_name_for_stats} (Lv. {pokemon.level:,}) at {pokemon.location_met}!\nMatching custom filter **{custom_filter_result}**",
                     embed_fields={
                         "Shiny Value": f"{pokemon.shiny_value:,}",
                         f"IVs ({pokemon.ivs.sum()})": iv_field(),
                         "Held item": pokemon.held_item.name if pokemon.held_item else "None",
-                        f"{pokemon.species.name} Encounters": f"{stats['pokemon'][pokemon.species.name].get('encounters', 0):,} ({stats['pokemon'][pokemon.species.name].get('shiny_encounters', 0):,}✨)",
-                        f"{pokemon.species.name} Phase Encounters": f"{stats['pokemon'][pokemon.species.name].get('phase_encounters', 0):,}",
+                        f"{pokemon.species_name_for_stats} Encounters": f"{stats['pokemon'][pokemon.species_name_for_stats].get('encounters', 0):,} ({stats['pokemon'][pokemon.species_name_for_stats].get('shiny_encounters', 0):,}✨)",
+                        f"{pokemon.species_name_for_stats} Phase Encounters": f"{stats['pokemon'][pokemon.species_name_for_stats].get('phase_encounters', 0):,}",
                     }
                     | phase_summary(),
                     embed_thumbnail=get_sprites_path()

--- a/profiles/customhooks.py
+++ b/profiles/customhooks.py
@@ -95,7 +95,9 @@ def custom_hooks(hook) -> None:
                         discord_ping = f"📢 <@{context.config.discord.shiny_pokemon_encounter.ping_id}>"
 
                 block = (
-                    "\n❌Skipping catching shiny (on catch block list)!" if pokemon.species_name_for_stats in block_list else ""
+                    "\n❌Skipping catching shiny (on catch block list)!"
+                    if pokemon.species_name_for_stats in block_list
+                    else ""
                 )
 
                 discord_message(


### PR DESCRIPTION
### Description
Fixes webhooks for Unowns / other pokemon with weird names for stats 

### Changes
Replaced `pokemon.species.name` with `pokemon.species_name_for_stats` in `customhooks.py`

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
