### PR TITLE
Allow Pokecenter Loop mode to be used without enabling auto-battle mode

### DIFF
--- a/wiki/pages/Mode - Pokecenter Loop.md
+++ b/wiki/pages/Mode - Pokecenter Loop.md
@@ -2,10 +2,6 @@
 
 # 🔄️ Pokécenter Loop Mode
 
-## Requirements
-
-- Set battle to True in the ⚔ [Battling and Pickup](Configuration%20-%20Battling%20and%20Pickup.md) config
-
 ## Instructions
 
 Start this mode while standing somewhere in tall grass. If the mode is not available


### PR DESCRIPTION
### Description

This changes the Pokecenter Loop mode so that the auto-battle feature does not have to be enabled in `battle.yml`. It will fight regardless of that setting.

The rationale being that it would avoid having to restart the bot just to use that mode (and then possibly forgetting to set the `battle` config value back to `false` later)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
