### PR TITLE
[Fix] Pokecenter Loop does not heal

### DIFF
--- a/modules/modes/_util.py
+++ b/modules/modes/_util.py
@@ -1065,8 +1065,8 @@ def heal_in_pokemon_center(pokemon_center_door_location: PokemonCenter) -> Gener
 
     # Walk up to the nurse and talk to her
     yield from navigate_to(get_player_avatar().map_group_and_number, (7, 4))
-    context.emulator.press_button("A")
-    yield
+    yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessageBox", "A")
+    yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessageBox", "A")
     yield from wait_for_player_avatar_to_be_standing_still("B")
 
     # Get out

--- a/modules/modes/_util.py
+++ b/modules/modes/_util.py
@@ -1060,13 +1060,18 @@ def get_tile_direction(tile: tuple[int, int]) -> str | None:
 
 
 def heal_in_pokemon_center(pokemon_center_door_location: PokemonCenter) -> Generator:
+    if context.rom.is_frlg:
+        TextBoxTask = "Task_DrawFieldMessageBox"
+    elif context.rom.is_rse:
+        TextBoxTask = "Task_DrawFieldMessage"
+
     # Walk to and enter the Pokémon centre
     yield from navigate_to(pokemon_center_door_location.value[0], pokemon_center_door_location.value[1])
 
     # Walk up to the nurse and talk to her
     yield from navigate_to(get_player_avatar().map_group_and_number, (7, 4))
-    yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessageBox", "A")
-    yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessageBox", "A")
+    yield from wait_for_task_to_start_and_finish(TextBoxTask, "A")
+    yield from wait_for_task_to_start_and_finish(TextBoxTask, "A")
     yield from wait_for_player_avatar_to_be_standing_still("B")
 
     # Get out


### PR DESCRIPTION
### Description

When the loop runs into the pokecenter it does not heal

### Changes

modules/modes/_util.py -> wait for the first two textboxes by mashing A (this confirms the Prompt to heal) , then start mashing B

### Notes

The Function itself should work on Ruby and Saphire, but the Loop Mode silently crashes the bot 

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [ ] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
