### PR TITLE
Do not go into an infinite loop when trying to rotate the lead in a trainer battle

### DIFF
--- a/modules/battle.py
+++ b/modules/battle.py
@@ -581,9 +581,12 @@ class BattleOpponent:
                     self.idx = -1
                 case "rotate":
                     mon_to_switch = self.get_mon_to_switch()
-                    if mon_to_switch is None and not is_trainer_battle:
+                    if mon_to_switch is None:
                         self.choice = "flee"
                         self.idx = -1
+                        if is_trainer_battle:
+                            context.message = "The lead Pokémon is too weak to fight and there is no suitable replacement in your party. Since this is a trainer battle, we also cannot flee. Switching to manual mode."
+                            context.set_manual_mode()
                     else:
                         self.choice = "switch"
                         self.idx = mon_to_switch


### PR DESCRIPTION
### Description

If the bot is configured to rotate the lead Pokémon when it gets below a certain HP threshold (the `hp_threshold` setting in `battle.yml` with `lead_cannot_battle_action` set to `rotate`), the game goes into an infinite loop and appears to crash.

This only happens in trainer battles because in wild encounters it would just try to flee.

But in trainer battles, it will set the action to `switch` and the Pokémon to switch to as `None` -- which in some part of the code is supposed to trigger an error that puts the bot back into manual mode, but it never reaches the code because before that, this loop is running:

```python
while self.choice is None or self.idx is None:
    self.determine_battle_menu_action()
```

Since `self.idx` (the Pokémon to switch to) will always be set for `None` in the aforementioned case, the bot can never break out of this loop.

### Checklist

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)