### PR TITLE
Fix battle on nugget bridge mode... again

### DIFF
--- a/modules/battle.py
+++ b/modules/battle.py
@@ -23,7 +23,7 @@ from modules.menuing import (
     party_menu_is_open,
 )
 from modules.modes import BotModeError
-from modules.modes._util import scroll_to_item_in_bag
+from modules.modes.util import scroll_to_item_in_bag
 from modules.player import get_player_avatar
 from modules.pokedex import get_pokedex
 from modules.pokemon import (
@@ -581,7 +581,7 @@ class BattleOpponent:
                     self.idx = -1
                 case "rotate":
                     mon_to_switch = self.get_mon_to_switch()
-                    if mon_to_switch is None and not is_trainer_battle:
+                    if mon_to_switch is None:
                         self.choice = "flee"
                         self.idx = -1
                     else:

--- a/modules/battle.py
+++ b/modules/battle.py
@@ -1373,7 +1373,7 @@ def check_mon_can_battle(mon: Pokemon) -> bool:
     """
     if context.bot_mode == "Nugget Bridge":
         return True
-    
+
     if mon.is_egg or not mon_has_enough_hp(mon):
         return False
 

--- a/modules/battle.py
+++ b/modules/battle.py
@@ -584,6 +584,9 @@ class BattleOpponent:
                     if mon_to_switch is None:
                         self.choice = "flee"
                         self.idx = -1
+                        if is_trainer_battle:
+                            context.message = "The lead Pokémon is too weak to fight and there is no suitable replacement in your party. Since this is a trainer battle, we also cannot flee. Switching to manual mode."
+                            context.set_manual_mode()
                     else:
                         self.choice = "switch"
                         self.idx = mon_to_switch

--- a/modules/battle.py
+++ b/modules/battle.py
@@ -23,7 +23,7 @@ from modules.menuing import (
     party_menu_is_open,
 )
 from modules.modes import BotModeError
-from modules.modes.util import scroll_to_item_in_bag
+from modules.modes._util import scroll_to_item_in_bag
 from modules.player import get_player_avatar
 from modules.pokedex import get_pokedex
 from modules.pokemon import (
@@ -581,12 +581,9 @@ class BattleOpponent:
                     self.idx = -1
                 case "rotate":
                     mon_to_switch = self.get_mon_to_switch()
-                    if mon_to_switch is None:
+                    if mon_to_switch is None and not is_trainer_battle:
                         self.choice = "flee"
                         self.idx = -1
-                        if is_trainer_battle:
-                            context.message = "The lead Pokémon is too weak to fight and there is no suitable replacement in your party. Since this is a trainer battle, we also cannot flee. Switching to manual mode."
-                            context.set_manual_mode()
                     else:
                         self.choice = "switch"
                         self.idx = mon_to_switch
@@ -821,6 +818,8 @@ class BattleOpponent:
         else:
             current_opponent = get_opponent()
             move = self.find_effective_move(self.current_battler, current_opponent)
+            if context.bot_mode == "Nugget Bridge":
+                return move["index"]
             if move["power"] == 0:
                 context.message = "Lead Pokémon has no effective moves to battle the foe!"
                 return -1
@@ -1369,6 +1368,9 @@ def check_mon_can_battle(mon: Pokemon) -> bool:
     """
     Determines whether a Pokémon is fit to fight
     """
+    if context.bot_mode == "Nugget Bridge":
+        return True
+    
     if mon.is_egg or not mon_has_enough_hp(mon):
         return False
 


### PR DESCRIPTION
### Description
Amends `battle.py` to add some specific handling that will only trigger on Nugget Bridge mode. 

User reported issue with Nugget Bridge mode saying their pokemon was too weak - now tested with a level 1 pokemon it handles correctly and attempts to battle until whiteout.

### Changes
`battle.py`
- added handling for nugget bridge to use the first move if the bot mode is "Nugget Bridge"
- always return `True` that lead mon is able to fight only for Nugget Bridge mode

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
