### PR TITLE
Daycare mode: Use full Mach Bike speed, fix R/S navigation issues

### DIFF
--- a/modules/map.py
+++ b/modules/map.py
@@ -1629,7 +1629,7 @@ def get_map_data(
         map_group_and_number = map_group_and_number.value
 
     if len(_map_header_cache) == 0:
-        from modules.map_data import MapGroupFRLG, MapGroupRSE
+        from modules.map_data import MapGroupFRLG, MapGroupRSE, MapRSE
 
         if context.rom.is_rse:
             number_of_map_groups = len(MapGroupRSE)
@@ -1643,6 +1643,9 @@ def get_map_data(
             number_of_maps = len(map_group_enum(group_index).maps)
             group_pointer = unpack_uint32(map_group_pointers[group_index * 4 : (group_index + 1) * 4])
             for map_index in range(number_of_maps):
+                if context.rom.is_rs and not MapRSE((group_index, map_index)).exists_on_rs:
+                    continue
+
                 map_header_pointer = unpack_uint32(context.emulator.read_bytes(group_pointer + 4 * map_index, 4))
                 map_header = context.emulator.read_bytes(map_header_pointer, 0x1C)
                 _map_header_cache[(group_index, map_index)] = map_header

--- a/modules/map_data.py
+++ b/modules/map_data.py
@@ -626,6 +626,10 @@ class MapFRLG(Enum):
     def __repr__(self) -> str:
         return self.name
 
+    @property
+    def exists_on_rs(self) -> bool:
+        return False
+
 
 class MapGroupRSE(Enum):
     TownsAndRoutes = 0
@@ -1309,6 +1313,11 @@ class MapRSE(Enum):
 
     def __repr__(self) -> str:
         return self.name
+
+    @property
+    def exists_on_rs(self) -> bool:
+        emerald_only_maps = [(0, 54), (0, 55), (0, 56), (5, 7), (6, 8), (9, 13), (15, 13), (15, 14), (16, 14)]
+        return self.value not in emerald_only_maps and (self.value[0] != 26 or self.value[1] <= 11)
 
 
 class PokemonCenter(Enum):

--- a/modules/map_path.py
+++ b/modules/map_path.py
@@ -155,6 +155,9 @@ def _get_all_maps_metadata() -> dict[tuple[int, int], PathMap]:
 
     # Load basic map data
     for map_address in maps_enum:
+        if context.rom.is_rs and not map_address.exists_on_rs:
+            continue
+
         map_data = get_map_data(map_address, (0, 0))
         map_connections = [
             _get_connection_for_direction(map_data, "North"),

--- a/modules/modes/util/walking.py
+++ b/modules/modes/util/walking.py
@@ -22,6 +22,7 @@ from modules.player import (
     player_avatar_is_controllable,
     player_avatar_is_standing_still,
     player_is_at,
+    get_player_location,
 )
 from modules.tasks import get_global_script_context
 from .sleep import wait_for_n_frames
@@ -371,11 +372,10 @@ def navigate_to(
         destination_coordinates = coordinates
 
         while not player_is_at(destination_map, destination_coordinates):
-            current_position = get_map_data_for_current_position()
             try:
                 waypoints = calculate_path(
-                    current_position,
-                    get_map_data(map, coordinates),
+                    get_player_location(),
+                    (map, coordinates),
                     avoid_encounters=avoid_encounters,
                     avoid_scripted_events=avoid_scripted_events,
                 )

--- a/modules/player.py
+++ b/modules/player.py
@@ -9,6 +9,7 @@ from modules.map_data import MapFRLG, MapRSE
 from modules.memory import get_save_block, read_symbol, unpack_uint16, unpack_uint32, get_game_state, GameState
 from modules.pokemon import Item, get_item_by_index
 from modules.state_cache import state_cache
+from modules.tasks import task_is_active
 
 
 # https://github.com/pret/pokeemerald/blob/104e81b359d287668cee613f6604020a6e7228a3/include/global.fieldmap.h
@@ -263,6 +264,11 @@ def player_avatar_is_controllable() -> bool:
         or "frozen" in player_map_object_flags
         or AvatarFlags.ForcedMove in get_player_avatar().flags
     ):
+        return False
+
+    # When exiting a door in RSE, there is a single frame where the game erroneously reports
+    # the player as controllable even though it's still in the exiting animation.
+    if task_is_active("Task_ExitDoor") or task_is_active("sub_8080B9C"):
         return False
 
     return True


### PR DESCRIPTION
### Description

This change updates the Daycare mode to make use of the new navigation functions.

These functions hit the direction buttons at different times, so that the player will actually go at full speed using the Mach Bike instead of looking like a grandpa.

I've also adjusted the path the player takes while waiting for a new egg to be available/to hatch to be a bit more efficient: When turning 180° on the Mach Bike, it will first come to a stop (which takes 3 tiles) and then slowly pick up speed again in the other direction. On the other hand, when turning 90° it does not lose any speed.

So going in a circle rather than back and forth is actually faster. It also means that we can stay closer the daycare man/house, meaning that we likely also reach them more quickly once it's time to pick up a new egg or release Pokémon.

Finally, while working on this I noticed that the code that pre-loads map data (introduced in #287) completely breaks navigation on R/S because some maps from the `MapRSE` enum do not actually exist in these games. I have added a check for that.

### Changes

- `modules/modes/daycare.py` - Using the new navigation functions and new path as explained above,
- `modules/player.py` - Fixing an issue where the game might report the avatar as controllable too early after walking through a door,
- `modules/map.py`, `modules/map_data.py`, `modules/map_path.py` - Fixing map-related functions on Ruby and Sapphire (see above)

### Checklist

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)