### PR TITLE
Check mode requirements in the saved game where appropriate

### DIFF
--- a/modules/modes/_asserts.py
+++ b/modules/modes/_asserts.py
@@ -99,28 +99,36 @@ def assert_saved_on_map(expected_locations: SavedMapLocation | list[SavedMapLoca
     raise BotModeError(error_message)
 
 
-def assert_registered_item(expected_items: str | list[str], error_message: str) -> None:
+def assert_registered_item(
+    expected_items: str | list[str], error_message: str, check_in_saved_game: bool = False
+) -> None:
     """
     Raises an exception if the given item is not registered (for the Select button.)
     :param expected_items: Item name, or list of item names, that should be registered.
     :param error_message: Error message to display if the assertion fails.
+    :param check_in_saved_game: Whether to check for the registered item in the saved game, rather than the
+                                currently active one.
     """
     if not isinstance(expected_items, list):
         expected_items = [expected_items]
 
-    registered_item = get_player().registered_item
+    player = get_player() if not check_in_saved_game else get_save_data().get_player()
+    registered_item = player.registered_item
     if registered_item is None or registered_item.name not in expected_items:
         raise BotModeError(error_message)
 
 
-def assert_has_pokemon_with_move(move: str, error_message: str) -> None:
+def assert_has_pokemon_with_move(move: str, error_message: str, check_in_saved_game: bool = False) -> None:
     """
     Raises an exception if the player has no Pokémon that knows a given move in their
     party.
     :param move: Name of the move to look for.
     :param error_message: Error message to display if the assertion fails.
+    :param check_in_saved_game: Whether to get the party in the saved game, rather than the
+                                currently active one.
     """
-    for pokemon in get_party():
+    party = get_party() if not check_in_saved_game else get_save_data().get_party()
+    for pokemon in party:
         if not pokemon.is_egg and not pokemon.is_empty:
             for learned_move in pokemon.moves:
                 if learned_move is not None and learned_move.move.name == move:

--- a/modules/modes/game_corner.py
+++ b/modules/modes/game_corner.py
@@ -10,7 +10,7 @@ from modules.pokemon import get_party
 from modules.runtime import get_sprites_path
 from modules.save_data import get_save_data
 from modules.tasks import task_is_active
-from ._asserts import SavedMapLocation, assert_save_game_exists, assert_saved_on_map
+from ._asserts import SavedMapLocation, assert_save_game_exists, assert_saved_on_map, assert_empty_slot_in_party
 from ._interface import BotMode, BotModeError
 from .util import (
     soft_reset,
@@ -41,7 +41,7 @@ class GameCornerMode(BotMode):
 
         coin_case = get_save_data().get_player().coins
         if coin_case < 180:
-            raise BotModeError("You don't have enough coins to buy anything.")
+            raise BotModeError("In your saved game, you don't have enough coins to buy anything.")
 
         if context.rom.is_fr:
             choices = [("Abra", 180), ("Clefairy", 500), ("Dratini", 2800), ("Scyther", 5500), ("Porygon", 9999)]
@@ -70,8 +70,7 @@ class GameCornerMode(BotMode):
             "Please save in-game, facing the counter before starting this mode.",
         )
 
-        if len(get_save_data().get_party()) >= 6:
-            raise BotModeError("This mode requires at least one empty party slot, but your party is full.")
+        assert_empty_slot_in_party("This mode requires at least one empty party slot, but your party is full.")
 
         while context.bot_mode != "Manual":
             yield from soft_reset(mash_random_keys=True)

--- a/modules/modes/game_corner.py
+++ b/modules/modes/game_corner.py
@@ -5,9 +5,10 @@ from modules.encounter import handle_encounter
 from modules.gui.multi_select_window import Selection, ask_for_choice
 from modules.map_data import MapFRLG
 from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
-from modules.player import get_player, get_player_avatar
+from modules.player import get_player_avatar
 from modules.pokemon import get_party
 from modules.runtime import get_sprites_path
+from modules.save_data import get_save_data
 from modules.tasks import task_is_active
 from ._asserts import SavedMapLocation, assert_save_game_exists, assert_saved_on_map
 from ._interface import BotMode, BotModeError
@@ -36,7 +37,9 @@ class GameCornerMode(BotMode):
         )
 
     def run(self) -> Generator:
-        coin_case = get_player().coins
+        assert_save_game_exists("There is no saved game. Cannot soft reset.")
+
+        coin_case = get_save_data().get_player().coins
         if coin_case < 180:
             raise BotModeError("You don't have enough coins to buy anything.")
 
@@ -62,18 +65,17 @@ class GameCornerMode(BotMode):
         if game_corner_choice is None:
             return
 
-        assert_save_game_exists("There is no saved game. Cannot soft reset.")
         assert_saved_on_map(
             SavedMapLocation(MapFRLG.CELADON_CITY_GAME_CORNER_PRIZE_ROOM, (4, 3), facing=True),
             "Please save in-game, facing the counter before starting this mode.",
         )
 
+        if len(get_save_data().get_party()) >= 6:
+            raise BotModeError("This mode requires at least one empty party slot, but your party is full.")
+
         while context.bot_mode != "Manual":
             yield from soft_reset(mash_random_keys=True)
             yield from wait_for_unique_rng_value()
-
-            if len(get_party()) >= 6:
-                raise BotModeError("This mode requires at least one empty party slot, but your party is full.")
 
             # Spam A until choice appears
             if not task_is_active("Task_MultichoiceMenu_HandleInput"):

--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -13,6 +13,7 @@ from modules.save_data import get_save_data
 from ._asserts import (
     assert_save_game_exists,
     assert_registered_item,
+    assert_empty_slot_in_party,
 )
 from ._interface import BotMode, BotModeError
 from .util import (
@@ -73,6 +74,9 @@ class StaticGiftResetsMode(BotMode):
 
     def run(self) -> Generator:
         encounter = _get_targeted_encounter()
+        if encounter is None:
+            raise BotModeError("You are not facing the NPC or tile that gives you the gift encounter.")
+
         assert_save_game_exists("There is no saved game. Cannot soft reset.")
 
         save_data = get_save_data()
@@ -86,29 +90,35 @@ class StaticGiftResetsMode(BotMode):
                 check_in_saved_game=True,
             )
             if save_data.get_event_flag("RECEIVED_LAVARIDGE_EGG"):
-                raise BotModeError("You have already received the Wynaut egg.")
-        if encounter[2] in ["Wynaut", "Togepi"] and get_party()[0].ability.name not in ["Flame Body", "Magma Armor"]:
+                raise BotModeError("You have already received the Wynaut egg in your saved game.")
+        if encounter[2] in ["Wynaut", "Togepi"] and save_data.get_party()[0].ability.name not in [
+            "Flame Body",
+            "Magma Armor",
+        ]:
             console.print(
                 "[bold yellow]WARNING: First Pokemon in party does not have Flame Body / Magma Armor ability."
             )
             console.print("[bold yellow]This will slow down the egg hatching process.")
         if encounter[2] == "Togepi":
+            if save_data.get_event_flag("GOT_TOGEPI_EGG"):
+                raise BotModeError("You have already received the Togepi egg in your saved game.")
             assert_registered_item(
                 ["Bicycle"],
                 "You need to register the Bicycle for the Select button, then save again.",
                 check_in_saved_game=True,
             )
             if save_data.get_party()[0].friendship < 255:
-                raise BotModeError("The first Pokemon in your party must have max friendship (255) to receive the egg.")
+                raise BotModeError(
+                    "The first Pokémon in your party in the saved game must have max friendship (255) to receive the egg."
+                )
 
-        if save_data.get_event_flag("GOT_TOGEPI_EGG"):
-            raise BotModeError("You have already received the Togepi egg.")
+        assert_empty_slot_in_party(
+            "This mode requires at least one empty party slot, but your party is full.", check_in_saved_game=True
+        )
+
         while context.bot_mode != "Manual":
             yield from soft_reset(mash_random_keys=True)
             yield from wait_for_unique_rng_value()
-
-            if len(get_party()) >= 6:
-                raise BotModeError("This mode requires at least one empty party slot, but your party is full.")
 
             # Spam A through chat boxes
             if context.rom.is_frlg:

--- a/modules/modes/sudowoodo.py
+++ b/modules/modes/sudowoodo.py
@@ -38,6 +38,7 @@ class SudowoodoMode(BotMode):
         assert_registered_item(
             ["Wailmer Pail"],
             "You need to register the Wailmer Pail for the Select button.",
+            check_in_saved_game=True,
         )
 
         while context.bot_mode != "Manual":

--- a/modules/save_data.py
+++ b/modules/save_data.py
@@ -5,6 +5,7 @@ from modules.context import context
 from modules.game import get_event_flag_offset, get_event_var_offset
 from modules.items import ItemBag
 from modules.memory import get_save_block, unpack_uint16, unpack_uint32
+from modules.player import Player
 from modules.pokemon import Pokemon, parse_pokemon
 
 
@@ -18,6 +19,20 @@ class SaveData:
     save_index: int
     block_index: int
     sections: list[bytes]
+
+    def get_player(self):
+        if context.rom.is_rse:
+            save_block_1_offset = 0x490
+            encryption_key_offset = 0xAC
+        else:
+            save_block_1_offset = 0x290
+            encryption_key_offset = 0xF20
+
+        save_block_1 = get_save_block(1, offset=save_block_1_offset, size=0x08)
+        save_block_2 = get_save_block(2, size=0x0E)
+        encryption_key = get_save_block(2, encryption_key_offset, 4)
+
+        return Player(save_block_1, save_block_2, encryption_key)
 
     def get_map_group_and_number(self) -> tuple[int, int]:
         return self.sections[1][4], self.sections[1][5]


### PR DESCRIPTION
### Description

This changes a few more modes so they check their conditions in the saved game, rather than in the active ones (which makes more sense for soft-resetting modes, because the active game's state is mostly meaningless in that gase.)

In order to -- hopefully -- somewhat limit confusion about what the error messages are actually complaining about, I have tried to update the error message to specify that it is related to the saved game where appropriate.

### Checklist

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)
