### PR TITLE
Add sorting and filtering functionality to profile selection screen

### DIFF
--- a/modules/gui/select_profile_screen.py
+++ b/modules/gui/select_profile_screen.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from tkinter import Tk, ttk
+from tkinter import Tk, ttk, StringVar
 from typing import Union
 
 from modules.profiles import Profile, list_available_profiles
@@ -11,6 +11,10 @@ class SelectProfileScreen:
         self.enable_profile_creation_screen = enable_profile_creation_screen
         self.run_profile = run_profile
         self.frame: Union[ttk.Frame, None] = None
+
+        self._filter_term = ""
+        self._order_by = "last_played"
+        self._order_descending = True
 
     def enable(self) -> None:
         available_profiles = list_available_profiles()
@@ -66,16 +70,19 @@ class SelectProfileScreen:
             container, columns=("profile_name", "game", "last_played"), show="headings", selectmode="browse"
         )
         treeview.column("profile_name", width=200)
-        treeview.heading("profile_name", text="Profile Name")
+        treeview.heading("profile_name", text="Profile Name", command=lambda: sort_by("profile_name"))
         treeview.column("game", width=150)
-        treeview.heading("game", text="Game")
+        treeview.heading("game", text="Game", command=lambda: sort_by("game"))
         treeview.column("last_played", width=170)
-        treeview.heading("last_played", text="Last Played")
+        treeview.heading("last_played", text="Last Played ↑", command=lambda: sort_by("last_played"))
 
         scrollbar = ttk.Scrollbar(container, orient="vertical", command=treeview.yview)
         scrollbar.grid(row=0, column=1, sticky="NWS")
         treeview.configure(yscrollcommand=scrollbar.set)
         treeview.grid(row=0, column=0, sticky="NSE")
+
+        entry_map: dict[str, str] = {}
+        detached_entries: dict[str, str] = {}
 
         available_profiles.sort(reverse=True, key=lambda p: p.last_played or datetime(1, 1, 1, 0, 0, 0))
         for profile in available_profiles:
@@ -88,7 +95,7 @@ class SelectProfileScreen:
                 last_played = "never"
 
             data = (profile.path.name, profile.rom.short_game_name, last_played)
-            treeview.insert("", "end", text=profile.path.name, values=data)
+            entry_map[profile.path.name] = treeview.insert("", "end", text=profile.path.name, values=data)
 
         def on_double_click(event):
             item = treeview.identify("item", event.x, event.y)
@@ -96,5 +103,80 @@ class SelectProfileScreen:
             for profile in available_profiles:
                 if profile.path.name == selected_name:
                     self.run_profile(profile)
+
+        search_field: ttk.Entry | None = None
+
+        def on_ctrl_f(event):
+            nonlocal search_field
+            if search_field is None:
+                search_term = StringVar()
+                search_field = ttk.Entry(self.frame, textvariable=search_term)
+                search_field.place(x=0, y=0)
+                search_field.focus_set()
+
+                def select_all():
+                    search_field.select_range(0, "end")
+                    search_field.icursor("end")
+
+                def on_change(event):
+                    new_filter_term = search_term.get().lower()
+                    if self._filter_term != new_filter_term:
+                        self._filter_term = new_filter_term
+                        update_list()
+
+                def remove_field():
+                    nonlocal search_field
+                    search_field.destroy()
+                    search_field = None
+                    if self._filter_term != "":
+                        self._filter_term = ""
+                        update_list()
+
+                search_field.bind("<Control-a>", lambda _: self.window.after(50, select_all))
+                search_field.bind("<KeyRelease>", on_change)
+                search_field.bind("<Escape>", lambda _: self.window.after(50, remove_field))
+            else:
+                search_field.destroy()
+
+        self.window.bind("<Control-f>", on_ctrl_f)
+
+        def sort_by(column_name: str):
+            if column_name == self._order_by:
+                self._order_descending = not self._order_descending
+            else:
+                self._order_by = column_name
+                self._order_descending = column_name == "last_played"
+            update_list()
+
+        def update_list():
+            arrow = "↑" if self._order_descending else "↓"
+            treeview.heading("profile_name", text="Profile Name")
+            treeview.heading("game", text="Game")
+            treeview.heading("last_played", text="Last Played")
+
+            if self._order_by == "profile_name":
+                available_profiles.sort(reverse=self._order_descending, key=lambda p: p.path.name)
+                treeview.heading("profile_name", text=f"Profile Name {arrow}")
+            elif self._order_by == "game":
+                available_profiles.sort(reverse=self._order_descending, key=lambda p: p.rom.short_game_name)
+                treeview.heading("game", text=f"Game {arrow}")
+            else:
+                available_profiles.sort(
+                    reverse=self._order_descending, key=lambda p: p.last_played or datetime(1, 1, 1, 0, 0, 0)
+                )
+                treeview.heading("last_played", text=f"Last Played {arrow}")
+
+            index = 1
+            for profile in available_profiles:
+                if self._filter_term == "" or self._filter_term in profile.path.name.lower():
+                    if profile.path.name in detached_entries:
+                        treeview.reattach(entry_map[profile.path.name], "", index)
+                        del detached_entries[profile.path.name]
+                    else:
+                        treeview.move(entry_map[profile.path.name], "", index)
+                    index += 1
+                elif profile.path.name not in detached_entries:
+                    detached_entries[profile.path.name] = entry_map[profile.path.name]
+                    treeview.detach(entry_map[profile.path.name])
 
         treeview.bind("<Double-1>", on_double_click)


### PR DESCRIPTION
### Description

Since my list of profiles has gotten rather long due to all the different test scenario profiles, it has become a bit tricky to find the one I'm trying to test.

So in order to make finding the right profile a bit easier, I have added those two things:

- Clicking on one of the column headings ('Profile Name', 'Game', 'Last Played') will sort the list by that column.
- A second click on the same column will reverse the order.
- Pressing **Ctrl+F** adds a text entry field for a search term that the profiles get filtered by (the profile name needs to contain the search term.)
- When the search field is active, **Esc** will close it again and cancel the filtering.

### Notes

I do not intend to document these features.

Sorting by clicking on the column heading is something that users should already be familiar with in these types of lists. 

And filtering by Ctrl+F is not that uncommon either -- but also, I just assume that this feature will only be necessary for a handful of people that do frequent testing on the bot.

### Video or it didn't happen

[profile-selection.webm](https://github.com/40Cakes/pokebot-gen3/assets/1106400/45c84cd7-0ba2-4dd6-95ae-9207a9c3c406)

### Checklist

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
