### PR TITLE
Make `handle_encounter()` function a bit safer to use

### DIFF
--- a/modules/modes/game_corner.py
+++ b/modules/modes/game_corner.py
@@ -46,16 +46,16 @@ class GameCornerMode(BotMode):
         else:
             raise BotModeError("This mode is not supported on RSE.")
 
-        coin_case = get_save_data().get_player().coins
-        if coin_case < choices[0][1]:
+        coins_owned = get_save_data().get_player().coins
+        if coins_owned < choices[0][1]:
             raise BotModeError("In your saved game, you don't have enough coins to buy anything.")
 
         available_options = []
-        for pokemon, coins in choices:
+        for pokemon, price_in_coins in choices:
             selection = Selection(
                 pokemon,
                 get_sprites_path() / "pokemon" / "normal" / f"{pokemon}.png",
-                coin_case >= coins,
+                coins_owned >= price_in_coins,
             )
             available_options.append(selection)
         game_corner_choice = ask_for_choice(

--- a/modules/save_data.py
+++ b/modules/save_data.py
@@ -29,9 +29,9 @@ class SaveData:
             save_block_1_offset = 0x290
             encryption_key_offset = 0xF20
 
-        save_block_1 = get_save_block(1, offset=save_block_1_offset, size=0x08)
-        save_block_2 = get_save_block(2, size=0x0E)
-        encryption_key = get_save_block(2, encryption_key_offset, 4)
+        save_block_1 = self.get_save_block(1, offset=save_block_1_offset, size=0x08)
+        save_block_2 = self.get_save_block(2, size=0x0E)
+        encryption_key = self.get_save_block(2, encryption_key_offset, 4)
 
         return Player(save_block_1, save_block_2, encryption_key)
 


### PR DESCRIPTION
### Description

This adds a check to `handle_encounter()` whether the game is actually in a battle.

Before, using `handle_encounter()` without setting `disable_auto_catch=True` could lead to accidentally skipping a Shiny/CCF encounter in soft-resetting modes.

While all modes should currently set the parameter correctly, this change will make it less likely for a future mode to have the same issue again.

Apart from that, this fixes the save data class' `get_player()` method, which previously would return the _active_ player data rather than the one from the saved game.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
