### PR TITLE
Add GitHub configuration for auto-generating release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,12 @@
+changelog:
+  exclude:
+    labels: hide-from-changelog
+  categories:
+    - title: 🎉 New Features
+      labels:
+        - feature
+    - title: 🪲 Fixed Bugs
+      labels:
+        - bug
+    - title: 🧩 Changes
+      labels: "*"


### PR DESCRIPTION
This adds a configuration file for auto-generating release notes as documented here:

https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

I've mostly stuck to the example, and the generator will be looking at the `bug` and `feature` labels to categorise changes (the labels need to be applied to the PR.) Without a label, PRs will be displayed in a fallback category.

I've also added a `hide-from-changelog` label that allow creating PRs that do not show up in the release notes. That makes sense for changes that do not actually impact the bot itself, such as this one.