### PR TITLE
Emerald Sudowoodo and Rocksmash in all Languages 

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.json
+++ b/modules/data/symbols/patches/language/pokeemerald.json
@@ -263,6 +263,13 @@
       "J":"81b33d0",
       "S":"81b3350"
     },
+    "Task_WateringBerryTreeAnim_Continue":{
+      "D":"80fab88",
+      "F":"80faba8",
+      "I":"80fab74",
+      "J":"80fb7d4",
+      "S":"80fab7c"
+    },
     "AnimTask_ThrowBall_Step":{
       "D":"8170b58",
       "F":"8170c80",

--- a/modules/data/symbols/patches/language/pokeemerald.json
+++ b/modules/data/symbols/patches/language/pokeemerald.json
@@ -270,6 +270,13 @@
       "J":"80fb7d4",
       "S":"80fab7c"
     },
+    "Task_ContinueTaskAfterMessagePrints":{
+      "D":"8121b60",
+      "F":"8121b80",
+      "I":"8121b4c",
+      "J":"8121f2c",
+      "S":"8121b54"
+    },
     "AnimTask_ThrowBall_Step":{
       "D":"8170b58",
       "F":"8170c80",
@@ -305,10 +312,33 @@
       "J":"82424ee",
       "S":"8275258"
     },
+    "EventScript_RockSmash":{
+      "D":"829ef03",
+      "F":"8297028",
+      "I":"829146e",
+      "J":"825667c",
+      "S":"8295638"
+    },
+    "EventScript_SmashRock":{
+      "D":"829ef58",
+      "F":"829707d",
+      "I":"82914c3",
+      "J":"82566d1",
+      "S":"829568d"
+    },
+    "EventScript_RepelWoreOff":{
+      "D":"82b6715",
+      "F":"82ad0f5",
+      "I":"82a5fd3",
+      "J":"826239b",
+      "S":"82aadf3"
+    },
     "HANDLEINPUTCHOOSEACTION":{
-      "D":"805758c",
-      "I":"805758c",
-      "J":"08057198"
+      "D":["805758c","8158f7c"],
+      "F":"81590a4",
+      "I":["805758c","8158f6c"],
+      "J":["8057198","8159314"],
+      "S":"815907c"
     },
     "HANDLEINPUTCHOOSEMOVE":{
       "D":"8057c00",
@@ -404,6 +434,60 @@
     },
     "ITEMSTORAGE_HANDLEREMOVEITEM":{
       "I":"0"
+    },
+    "Route120_Text_RileyIntro":{
+      "D":"0"
+    },
+    "Route104_Text_HaleyIntro":{
+      "S":"0"
+    },
+    "Route104_Text_HaleyDefeat":{
+      "S":"0"
+    },
+    "BattleFrontier_BattleArenaLobby_Text_NotEnoughValidMonsLv50":{
+      "J":"0"
+    },
+    "Route108_Text_CoryRematchDefeated":{
+      "F":"0"
+    },
+    "Route108_Text_CoryRematchPostBattle":{
+      "F":"0"
+    },
+    "VictoryRoad_1F_EventScript_ItemPPUp":{
+      "I":"0"
+    },
+    "VictoryRoad_B1F_EventScript_ItemFullRestore":{
+      "I":"0"
+    },
+    "VictoryRoad_1F_EventScript_ItemMaxElixir":{
+      "I":"0"
+    },
+    "VictoryRoad_B1F_EventScript_ItemTMPsychic":{
+      "I":"0"
+    },
+    "Route110_TrickHousePuzzle8_EventScript_ItemBeadMail":{
+      "I":"0"
+    },
+    "Route121_SafariZoneEntrance_EventScript_EntranceCounterTrigger":{
+      "D": "82326e4",
+      "F": "822fb95",
+      "I": "822ba06",
+      "J": "8212a42",
+      "S": "822de70"
+    },
+    "Route121_SafariZoneEntrance_EventScript_TryEnterSafariZone":{
+      "D": "8232745",
+      "F": "822fbf6",
+      "I": "822ba67",
+      "J": "8212aa3",
+      "S": "822ded1"
+    },
+    "SafariZone_EventScript_TimesUp":{
+      "D": "82b676d",
+      "F": "82ad154",
+      "I": "82a6033",
+      "J": "82623e9",
+      "S": "82aae5a"
     },
     "gItems":{
       "D": "85946dc",

--- a/modules/game.py
+++ b/modules/game.py
@@ -38,14 +38,19 @@ def _load_symbols(symbols_file: str, language: ROMLanguage) -> None:
     if language_code in {"D", "I", "S", "F", "J"} and language_patch_path.is_file():
         with open(language_patch_path, "r") as file:
             language_patches = json.load(file)
-        for item in language_patches:
-            if language_code in language_patches[item]:
-                _symbols[item.upper()] = (int(language_patches[item][language_code], 16), _symbols[item.upper()][1])
-                _reverse_symbols[int(language_patches[item][language_code], 16)] = (
-                    item.upper(),
-                    item,
-                    _symbols[item.upper()][1],
-                )
+        for label in language_patches:
+            if language_code in language_patches[label]:
+                _reverse_symbols.pop(_symbols[label.upper()][0])
+                addresses = language_patches[label][language_code]
+                if type(addresses) is not list:
+                    addresses = [addresses]
+                for addr in addresses:
+                    _symbols[label.upper()] = (int(addr, 16), _symbols[label.upper()][1])
+                    _reverse_symbols[int(addr, 16)] = (
+                        label.upper(),
+                        label,
+                        _symbols[label.upper()][1],
+                    )
 
 
 def _load_event_flags_and_vars(file_name: str) -> None:  # TODO Japanese ROMs not working

--- a/wiki/pages/Mode - Rock Smash.md
+++ b/wiki/pages/Mode - Rock Smash.md
@@ -54,11 +54,11 @@ The mode will continuously try to enter the Safari Zone, so make sure you have s
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
-| Japanese |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| German   |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| Spanish  |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| French   |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| Italian  |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
+| Japanese |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| German   |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| Spanish  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| French   |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| Italian  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
 
 ✅ Tested, working
 

--- a/wiki/pages/Mode - Sudowoodo.md
+++ b/wiki/pages/Mode - Sudowoodo.md
@@ -13,11 +13,11 @@
 |          | 🟢 Emerald |
 |:---------|:----------:|
 | English  |     ✅      |
-| Japanese |     ❌      |
-| German   |     ❌      |
-| Spanish  |     ❌      |
-| French   |     ❌      |
-| Italian  |     ❌      |
+| Japanese |     ✅      |
+| German   |     ✅      |
+| Spanish  |     ✅      |
+| French   |     ✅      |
+| Italian  |     ✅      |
 
 ✅ Tested, working
 


### PR DESCRIPTION
### Description

This adds all needed symbols for Sudowoodo and Rocksmash modes to work in all languages in Emerald.

To get this to work the logic for loading the language patches had to be extended.
Symbols that get patched now get their old addresses actively removed.
With this symbols that get wrongly picked when using `get_symbol_name_before()` can now be "disabled" for specific languages by directly setting their address to 0 in the language patch.
Additionally some symbol names are used multiple times in the symbol files, to allow that to be done in the language patches the bot now can handle lists of addresses for symbols.

### Changes

`modules/game.py` -> new handling for language patches
`modules/data/symbols/patches/language/pokeemerald.json` -> new symbols

### Notes

The method to convert this in Code instead of requiring a list in every entry in the patch was chosen for simpler ease of use creating the patch files.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
