### PR TITLE
Emerald Roamer all Languages

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.json
+++ b/modules/data/symbols/patches/language/pokeemerald.json
@@ -124,6 +124,13 @@
       "J":"81afe88",
       "S":"81afdd0"
     },
+    "CB2_FLYMAP":{
+      "D":"81244f8",
+      "F":"8124518",
+      "I":"81244e4",
+      "J":"81248e0",
+      "S":"81244ec"
+    },
     "BATTLEMAINCB2":{
       "D":"8038424",
       "F":"8038420",
@@ -277,6 +284,20 @@
       "J":"8121f2c",
       "S":"8121b54"
     },
+    "Task_FlyIntoMap":{
+      "D":"80b6b28",
+      "F":"80b6b20",
+      "I":"80b6b20",
+      "J":"80b6264",
+      "S":"80b6b20"
+    },
+    "ExecuteMatchCall":{
+      "D":"8195bec",
+      "F":"8195d0c",
+      "I":"8195bdc",
+      "J":"8195ce0",
+      "S":"8195ce4"
+    },
     "AnimTask_ThrowBall_Step":{
       "D":"8170b58",
       "F":"8170c80",
@@ -375,6 +396,9 @@
     "sCurrentStartMenuActions":{
       "J":"20372b0"
     },
+    "sRegionMap":{
+      "J":"2039e10"
+    },
     "GMAIN":{
       "J":"3002360"
     },
@@ -468,6 +492,48 @@
     "Route110_TrickHousePuzzle8_EventScript_ItemBeadMail":{
       "I":"0"
     },
+    "RivalsHouse_2F_Text_MayWhereShouldIGoNext":{
+      "I":"0"
+    },
+    "OldaleTown_PokemonCenter_1F_EventScript_Gentleman":{
+      "D":"0"
+    },
+    "OldaleTown_PokemonCenter_1F_EventScript_Boy":{
+      "D":"0"
+    },
+    "OldaleTown_PokemonCenter_1F_EventScript_Girl":{
+      "D":"0"
+    },
+    "OldaleTown_PokemonCenter_1F_EventScript_WirelessClubAvailable":{
+      "D":"0"
+    },
+    "OldaleTown_PokemonCenter_1F_Text_TrainersCanUsePC":{
+      "D":"0"
+    },
+    "OldaleTown_PokemonCenter_1F_Text_PokemonCentersAreGreat":{
+      "D":"0"
+    },
+    "OldaleTown_PokemonCenter_1F_EventScript_Nurse":{
+      "D":"0"
+    },
+    "Route111_EventScript_Celia":{
+      "J":"0"
+    },
+    "Route111_EventScript_Bryan":{
+      "J":"0"
+    },
+    "Route111_EventScript_Branden":{
+      "J":"0"
+    },
+    "Route111_Text_BattleOurFamily":{
+      "J":"0"
+    },
+    "Route111_EventScript_TrainerHillSign":{
+      "J":"0"
+    },
+    "LittlerootTown_ProfessorBirchsLab_Text_BirchEnjoysRivalsHelpToo":{
+      "S":"0"
+    },
     "Route121_SafariZoneEntrance_EventScript_EntranceCounterTrigger":{
       "D": "82326e4",
       "F": "822fb95",
@@ -481,6 +547,13 @@
       "I": "822ba67",
       "J": "8212aa3",
       "S": "822ded1"
+    },
+    "LittlerootTown_ProfessorBirchsLab_EventScript_UpgradeToNationalDex":{
+      "D": "81fc014",
+      "F": "81fb46a",
+      "I": "81f9a6d",
+      "J": "81f141b",
+      "S": "81fa666"
     },
     "SafariZone_EventScript_TimesUp":{
       "D": "82b676d",

--- a/modules/modes/roamer_reset.py
+++ b/modules/modes/roamer_reset.py
@@ -6,6 +6,8 @@ from modules.gui.multi_select_window import Selection, ask_for_choice
 from modules.items import get_item_by_name
 from modules.map_data import MapFRLG, MapRSE
 from modules.memory import GameState, get_event_var, get_game_state
+from modules.modes.util.tasks_scripts import wait_for_script_to_start_and_finish
+from modules.modes.util.walking import wait_for_player_avatar_to_be_controllable
 from modules.player import get_player, get_player_avatar
 from modules.pokemon import get_opponent
 from modules.region_map import FlyDestinationFRLG, FlyDestinationRSE
@@ -183,15 +185,10 @@ class RoamerResetMode(BotMode):
 
             # Cut scene where you get the National Dex
             if get_event_var("DEX_UPGRADE_JOHTO_STARTER_STATE") == 1:
-                script_name = "LittlerootTown_ProfessorBirchsLab_EventScript_UpgradeToNationalDex"
-                while script_name not in get_global_script_context().stack:
-                    context.emulator.press_button("B")
-                    yield
-                while script_name in get_global_script_context().stack:
-                    context.emulator.press_button("B")
-                    yield
-                yield
-                yield
+                yield from wait_for_script_to_start_and_finish(
+                    "LittlerootTown_ProfessorBirchsLab_EventScript_UpgradeToNationalDex", "B"
+                )
+                yield from wait_for_player_avatar_to_be_controllable()
                 yield from deprecated_navigate_to_on_current_map(6, 12)
                 yield from walk_one_tile("Down")
 

--- a/wiki/pages/Mode - Roamer Resets.md
+++ b/wiki/pages/Mode - Roamer Resets.md
@@ -45,11 +45,11 @@ This mode does not yet support Ruby/Sapphire (save state is required for develop
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
-| Japanese |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| German   |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| Spanish  |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| French   |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| Italian  |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
+| Japanese |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| German   |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| Spanish  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| French   |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| Italian  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
 
 ✅ Tested, working
 


### PR DESCRIPTION
### Description

this adds the symbols needed for the Roamer mode to work in every languages in Emerald.
this contains the `fly_to()` util now working in all languages.
and by complete chance while testing the listener for Nav Calls now also works in all Languages.

### Changes

`modules/data/symbols/patches/language/pokeemerald.json` -> all needed Symbols added and the ones that conflict deactivated for specific languages
`modules/modes/roamer_reset.py` -> the smallest bit of refactor to use the `wait_for_script_to_start_and_finish()` and `wait_for_player_avatar_to_be_controllable()` util instead of implementing it directly in the mode

### Notes

`roamer_reset` could probably use a bit more rework to use the new pathing functions

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
