### PR TITLE
Add random choice to all starter modes

### DIFF
--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -6,6 +6,7 @@ from modules.encounter import handle_encounter
 from modules.gui.multi_select_window import Selection, ask_for_choice
 from modules.map_data import MapFRLG, MapRSE
 from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
+from modules.modes.util.walking import navigate_to
 from modules.player import get_player_avatar
 from modules.pokemon import get_party
 from modules.runtime import get_sprites_path
@@ -23,11 +24,32 @@ from .util import (
 
 
 def run_frlg() -> Generator:
+    starter_choice = ask_for_choice(
+        [
+            Selection("Bulbasaur", get_sprites_path() / "pokemon" / "normal" / "Bulbasaur.png"),
+            Selection("Charmander", get_sprites_path() / "pokemon" / "normal" / "Charmander.png"),
+            Selection("Squirtle", get_sprites_path() / "pokemon" / "normal" / "Squirtle.png"),
+            Selection("Random", get_sprites_path() / "pokemon" / "normal" / "Unown (qm).png"),
+        ],
+        window_title="Select a starter...",
+    )
+    if starter_choice is None:
+        return
+    
     while context.bot_mode != "Manual":
         yield from soft_reset(mash_random_keys=True)
-        yield from wait_for_unique_rng_value()
-
+        starter = starter_choice
+        if starter == "Random":
+            starter = random.choice(["Bulbasaur", "Charmander", "Squirtle"])
+        match starter:
+            case "Bulbasaur":
+                yield from navigate_to(map=MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB,coordinates=(8,5))
+            case "Charmander":
+                yield from navigate_to(map=MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB,coordinates=(10,5))
+            case "Squirtle":
+                yield from navigate_to(map=MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB,coordinates=(9,5))
         yield from ensure_facing_direction("Up")
+        yield from wait_for_unique_rng_value()
 
         # Wait for and confirm the first question (the 'Do you choose ...')
         while len(get_party()) == 0:
@@ -109,15 +131,37 @@ def run_rse_hoenn() -> Generator:
 
 
 def run_rse_johto():
+    starter_choice = ask_for_choice(
+        [
+            Selection("Chikorita", get_sprites_path() / "pokemon" / "normal" / "Chikorita.png"),
+            Selection("Cyndaquil", get_sprites_path() / "pokemon" / "normal" / "Cyndaquil.png"),
+            Selection("Totodile", get_sprites_path() / "pokemon" / "normal" / "Totodile.png"),
+            Selection("Random", get_sprites_path() / "pokemon" / "normal" / "Unown (qm).png"),
+        ],
+        window_title="Select a starter...",
+    )
+    if starter_choice is None:
+        return
+    
     while context.bot_mode != "Manual":
         yield from soft_reset(mash_random_keys=True)
+        starter = starter_choice
+        if starter == "Random":
+            starter = random.choice(["Chikorita", "Cyndaquil", "Totodile"])
+        match starter:
+            case "Chikorita":
+                yield from navigate_to(map=MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB,coordinates=(10,5))
+            case "Cyndaquil":
+                yield from navigate_to(map=MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB,coordinates=(8,5))
+            case "Totodile":
+                yield from navigate_to(map=MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB,coordinates=(9,5))
 
         if len(get_party()) >= 6:
             raise BotModeError("This mode requires at least one empty party slot, but your party is full.")
 
-        yield from wait_for_unique_rng_value()
-
         yield from ensure_facing_direction("Up")
+
+        yield from wait_for_unique_rng_value()
 
         # Wait for and confirm the first question (the 'Do you choose ...')
         yield from wait_for_task_to_start_and_finish("Task_HandleYesNoInput", button_to_press="A")
@@ -157,9 +201,7 @@ class StartersMode(BotMode):
         if context.rom.is_frlg:
             assert_saved_on_map(
                 [
-                    SavedMapLocation(MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB, (8, 4), facing=True),
-                    SavedMapLocation(MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB, (9, 4), facing=True),
-                    SavedMapLocation(MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB, (10, 4), facing=True),
+                    SavedMapLocation(MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB)
                 ],
                 error_message="The game has not been saved while standing in front of one of the starter Poké balls.",
             )
@@ -170,9 +212,7 @@ class StartersMode(BotMode):
                     # Hoenn Starter Bag
                     SavedMapLocation(MapRSE.ROUTE101, (7, 14), facing=True),
                     # Johto Starters (on table)
-                    SavedMapLocation(MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB, (8, 4), facing=True),
-                    SavedMapLocation(MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB, (9, 4), facing=True),
-                    SavedMapLocation(MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB, (10, 4), facing=True),
+                    SavedMapLocation(MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB),
                 ],
                 error_message=(
                     "The game has not been saved in front of the starter Pokémon bag (for Hoenn starters) "

--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -35,7 +35,7 @@ def run_frlg() -> Generator:
     )
     if starter_choice is None:
         return
-    
+
     while context.bot_mode != "Manual":
         yield from soft_reset(mash_random_keys=True)
         starter = starter_choice
@@ -43,11 +43,11 @@ def run_frlg() -> Generator:
             starter = random.choice(["Bulbasaur", "Charmander", "Squirtle"])
         match starter:
             case "Bulbasaur":
-                yield from navigate_to(map=MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB,coordinates=(8,5))
+                yield from navigate_to(map=MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB, coordinates=(8, 5))
             case "Charmander":
-                yield from navigate_to(map=MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB,coordinates=(10,5))
+                yield from navigate_to(map=MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB, coordinates=(10, 5))
             case "Squirtle":
-                yield from navigate_to(map=MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB,coordinates=(9,5))
+                yield from navigate_to(map=MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB, coordinates=(9, 5))
         yield from ensure_facing_direction("Up")
         yield from wait_for_unique_rng_value()
 
@@ -142,7 +142,7 @@ def run_rse_johto():
     )
     if starter_choice is None:
         return
-    
+
     while context.bot_mode != "Manual":
         yield from soft_reset(mash_random_keys=True)
         starter = starter_choice
@@ -150,11 +150,11 @@ def run_rse_johto():
             starter = random.choice(["Chikorita", "Cyndaquil", "Totodile"])
         match starter:
             case "Chikorita":
-                yield from navigate_to(map=MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB,coordinates=(10,5))
+                yield from navigate_to(map=MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB, coordinates=(10, 5))
             case "Cyndaquil":
-                yield from navigate_to(map=MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB,coordinates=(8,5))
+                yield from navigate_to(map=MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB, coordinates=(8, 5))
             case "Totodile":
-                yield from navigate_to(map=MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB,coordinates=(9,5))
+                yield from navigate_to(map=MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB, coordinates=(9, 5))
 
         if len(get_party()) >= 6:
             raise BotModeError("This mode requires at least one empty party slot, but your party is full.")
@@ -200,9 +200,7 @@ class StartersMode(BotMode):
 
         if context.rom.is_frlg:
             assert_saved_on_map(
-                [
-                    SavedMapLocation(MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB)
-                ],
+                [SavedMapLocation(MapFRLG.PALLET_TOWN_PROFESSOR_OAKS_LAB)],
                 error_message="The game has not been saved while standing in front of one of the starter Poké balls.",
             )
             yield from run_frlg()


### PR DESCRIPTION
### Description

This adds the same selection menu to all variants of the starter mode. the bot will then navigate to the appropriate position
it also allows to start the mode anywhere in the Lab but of cause starting in front of the balls is still the fastest
"fixes" #198 

### Changes

`modules/modes/starters.py` -> adds the choice menus for the two variants in the labs

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
