### PR TITLE
Unify Block List behaviour and support blocking individual Unown letters

### DIFF
--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -63,7 +63,8 @@ def judge_encounter(pokemon: Pokemon) -> EncounterValue:
 
     if pokemon.is_shiny:
         context.config.reload_file("catch_block")
-        if pokemon.species.name in context.config.catch_block.block_list:
+        block_list = context.config.catch_block.block_list
+        if pokemon.species_name_for_stats in block_list or pokemon.species.name in block_list:
             return EncounterValue.ShinyOnBlockList
         else:
             return EncounterValue.Shiny
@@ -78,7 +79,8 @@ def judge_encounter(pokemon: Pokemon) -> EncounterValue:
         and roamer.species == pokemon.species
     ):
         context.config.reload_file("catch_block")
-        if pokemon.species.name in context.config.catch_block.block_list:
+        block_list = context.config.catch_block.block_list
+        if pokemon.species_name_for_stats in block_list or pokemon.species.name in block_list:
             return EncounterValue.RoamerOnBlockList
         else:
             return EncounterValue.Roamer

--- a/profiles/customhooks.py
+++ b/profiles/customhooks.py
@@ -96,7 +96,7 @@ def custom_hooks(hook) -> None:
 
                 block = (
                     "\n❌Skipping catching shiny (on catch block list)!"
-                    if pokemon.species_name_for_stats in block_list
+                    if pokemon.species_name_for_stats in block_list or pokemon.species.name in block_list
                     else ""
                 )
 

--- a/wiki/pages/Configuration - Catch Block List.md
+++ b/wiki/pages/Configuration - Catch Block List.md
@@ -11,7 +11,7 @@ The catch block list is a list of shinies to skip, useful if you don't want to f
 - Phase stats will still be reset after encountering a shiny on the block list.
 - The block list is automatically reloaded by the bot during a shiny encounter, so you can modify this file while the bot is running!
 - To add Nidoran Male/Female, use `Nidoran♀` or `Nidoran♂` respectively
-- Unown forms can be added by inserting the character in parenthesis e.g. `Unown (F)` or `Unown (?)`
+- Unown forms can be added by inserting the character in parenthesis e.g. `Unown (F)` or `Unown (?)`, but you can also just use `Unown` to block all of them
 
 `block_list` - list of Pokémon to skip catching (one per line), example:
 


### PR DESCRIPTION
### Description

This strives to implement the same behaviour for block list handling in the Discord (`customhooks.py`) and Encounter-handling (`encounter.py`) code.

 It also updates the block list code so that it checks both the Pokémon-specific stats label and the actual species name, i.e. it will allow both `Unown (F)` and `Unown` to be blocked.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
