### PR TITLE
Fix Puzzle Solver modes using bicycle

### DIFF
--- a/modules/modes/util/items.py
+++ b/modules/modes/util/items.py
@@ -136,7 +136,6 @@ def apply_repel() -> Generator:
     yield from use_item_from_bag(repel_item)
 
 
-@debug.track
 def replenish_repel() -> None:
     """
     This can be used in a bot mode's `on_repel_effect_ended()` callback to re-enable the repel


### PR DESCRIPTION
### Description

Sky Pillar and Mirage Tower rely on the Mach Bike going fast enough to outrun the cracked floor tiles breaking.

That does not work with the old navigation function because it hits the buttons at the wrong time, so cycling is very slow.

This change updates the Puzzle Solver mode to use the new navigation functions.

It also fixes an issue with replenishing repel, which probably affected Roamer Reset mode.

Fixes #309 

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
