### PR TITLE
Update Roamer mode to use new navigation functions

### DIFF
--- a/modules/map_path.py
+++ b/modules/map_path.py
@@ -108,7 +108,12 @@ class PathMap:
                     )
                 )
             for map_object in map_data.objects:
-                tile = self._tiles[tile_index(*map_object.local_coordinates)]
+                try:
+                    tile = self._tiles[tile_index(*map_object.local_coordinates)]
+                except IndexError:
+                    # If loaded map object data is invalid, a map object's coordinates might be out of bounds.
+                    # This `except` block catches that case and pretends like the object is not loaded at all.
+                    continue
                 if map_object.flag_id != 0:
                     tile.dynamic_collision_flag = map_object.flag_id
                 else:

--- a/modules/modes/util/items.py
+++ b/modules/modes/util/items.py
@@ -147,7 +147,12 @@ def replenish_repel() -> None:
     if get_item_bag().number_of_repels == 0:
         raise RanOutOfRepels("Player ran out of repels")
     else:
-        context.controller_stack.insert(len(context.controller_stack) - 1, apply_repel())
+
+        def apply_repel_and_reset_inputs():
+            yield from apply_repel()
+            context.emulator.reset_held_buttons()
+
+        context.controller_stack.insert(len(context.controller_stack) - 1, apply_repel_and_reset_inputs())
 
 
 @debug.track


### PR DESCRIPTION
### Description

This removes calls to the deprecated same-map navigation function in favour of the new cross-map one.

Doing that simplifies the code a little bit, and hopefully also fixes #316 (at least I wasn't able to reproduce the behaviour anymore.)

As a semi-related fix, this resolves an issue where reapplying Repel would lead to the player continue running in the same direction until they hit an obstacle.

### Changes

- `modules/map_path.py` - Fix a bug where the bot would crash if map object data wasn't fully loaded yet by the game.
- `modules/modes/util/items.py` - Fix the bug where the player would stuck running in one direction after re-applying Repel.
- `modules/modes/roamer_reset.py` - Migrated navigation functions.

### Checklist

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)
