### PR TITLE
Update Kecleon mode to use the 'new' navigation feature

### DIFF
--- a/modules/modes/kecleon.py
+++ b/modules/modes/kecleon.py
@@ -12,7 +12,7 @@ from ._asserts import (
     assert_has_pokemon_with_move,
 )
 from ._interface import BotMode, BotModeError
-from .util import ensure_facing_direction, deprecated_navigate_to_on_current_map, walk_one_tile
+from .util import ensure_facing_direction, navigate_to
 
 
 class KecleonMode(BotMode):
@@ -52,13 +52,8 @@ class KecleonMode(BotMode):
 
         while context.bot_mode != "Manual":
             self._has_whited_out = False
-            if get_player_avatar().map_group_and_number == MapRSE.ROUTE119:
-                yield from deprecated_navigate_to_on_current_map(31, 7)
-                yield from ensure_facing_direction("Up")
-                while not self._has_whited_out:
-                    context.emulator.press_button("A")
-                    yield
-            if get_player_avatar().map_group_and_number == MapRSE.FORTREE_CITY:
-                yield from deprecated_navigate_to_on_current_map(0, 7)
-                yield from walk_one_tile("Left")
+            yield from navigate_to(MapRSE.ROUTE119, (31, 7))
+            yield from ensure_facing_direction("Up")
+            while not self._has_whited_out:
+                context.emulator.press_button("A")
                 yield


### PR DESCRIPTION
### Description

This removes calls to the deprecated walking function in Kecleon mode (the one that could only navigate _within_ the current map.)

While that change should make the mode all-so-slightly faster because the player avatar doesn't need to stop before transitioning to the Route 119 map, this was mainly done to slowly get rid of that deprecated function.

### Checklist

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)
