### PR TITLE
Fix Safari Zone Rock Smash getting stuck when walking

### DIFF
--- a/modules/modes/rock_smash.py
+++ b/modules/modes/rock_smash.py
@@ -158,12 +158,21 @@ class RockSmashMode(BotMode):
                             break
                 case MapRSE.SAFARI_ZONE_SOUTH | MapRSE.SAFARI_ZONE_SOUTHEAST:
                     self._in_safari_zone = True
-                    while (
+
+                    def is_near_entrance_door():
+                        return (
+                            get_player_avatar().map_group_and_number == MapRSE.SAFARI_ZONE_SOUTH
+                            and get_player_avatar().local_coordinates in ((32, 33), (32, 34))
+                        )
+
+                    if is_near_entrance_door() or (
                         get_player_avatar().map_group_and_number == MapRSE.SAFARI_ZONE_SOUTH
-                        and get_player_avatar().local_coordinates in ((32, 33), (32, 34))
-                    ) or get_global_script_context().is_active:
-                        yield
-                    yield from wait_for_player_avatar_to_be_standing_still()
+                        and get_global_script_context().is_active
+                    ):
+                        while is_near_entrance_door() or get_global_script_context().is_active:
+                            yield
+                        yield from wait_for_player_avatar_to_be_standing_still()
+
                     if self._using_mach_bike:
                         yield from self.mount_bicycle()
                         yield from navigate_to(MapRSE.SAFARI_ZONE_NORTHEAST, (15, 7))


### PR DESCRIPTION
### Description

When using the Rock Smash mode in Emerald's Safari Zone (for hunting Shuckle) and not using the bicycle (peasant!) the bot would get stuck after a few rounds.

This is probably due to in in-game bug (pointed out by @Terasol!) where the scripting context did not always get cleared after using rock smash.

A script that was originally meant to handle the Safari Zone entrance sequence would then wait for the script to 'finish' -- which would never happen, thus stalling the bot.

Fixes #314

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
