### PR TITLE
Disable Static Run Aways mode for R/S

### DIFF
--- a/modules/modes/static_run_away.py
+++ b/modules/modes/static_run_away.py
@@ -24,7 +24,7 @@ class StaticRunAway(BotMode):
 
     @staticmethod
     def is_selectable() -> bool:
-        if context.rom.is_rse:
+        if context.rom.is_emerald:
             allowed_maps = [
                 MapRSE.NAVEL_ROCK_TOP,
                 MapRSE.NAVEL_ROCK_BOTTOM,
@@ -37,8 +37,10 @@ class StaticRunAway(BotMode):
                 MapRSE.SKY_PILLAR_TOP,
                 MapRSE.FARAWAY_ISLAND_ENTRANCE,
             ]
-        else:
+        elif context.rom.is_frlg:
             allowed_maps = [MapFRLG.NAVEL_ROCK_BASE, MapFRLG.NAVEL_ROCK_SUMMIT]
+        else:
+            allowed_maps = []
         return get_player_avatar().map_group_and_number in allowed_maps
 
     def on_battle_started(self) -> BattleAction | None:


### PR DESCRIPTION
### Description

As far as I can tell, none of the encounters supported by the Static Run Aways mode actually work on R/S.

Either the location isn't even available in these games (Navel Rock, Marine Cave, Terra Cave, Sky pillar, Faraway Island), or the encounter doesn't re-appear after running away (Island Cave, Ancient Tomb, Desert Ruins, Southern Island)

 I've disabled all of these encounters for R/S.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
