### PR TITLE
Fix occasional 'player avatar is currently not controllable' error in FR/LG roamer reset mode

### DIFF
--- a/modules/modes/roamer_reset.py
+++ b/modules/modes/roamer_reset.py
@@ -242,6 +242,7 @@ class RoamerResetMode(BotMode):
                 context.emulator.press_button("B")
                 yield
             yield
+            yield from wait_for_player_avatar_to_be_standing_still("B")
 
             # Leave the building
             yield from navigate_to(MapFRLG.ONE_ISLAND_POKEMON_CENTER_1F, (9, 9))


### PR DESCRIPTION
Fixes #316