### PR TITLE
Suppress 'unsupported platform' error message for Desktop Notifications on Windows 11

### DIFF
--- a/modules/gui/desktop_notification.py
+++ b/modules/gui/desktop_notification.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from notifypy import Notify
+from notifypy.exceptions import UnsupportedPlatform
 
 from modules.console import console
 from modules.context import context
@@ -23,5 +24,9 @@ def desktop_notification(title: str, message: str, icon: Path = None) -> None:
         notification.icon = icon
 
         notification.send()
+    except UnsupportedPlatform:
+        # The `notifypy` library does not support Windows 11 and will throw that error, so in that case
+        # there's nothing the user (or we) could do about it. Just ignore that error silently.
+        pass
     except Exception:
         console.print_exception()


### PR DESCRIPTION
### Description

The `notifypy` does not support Windows 11 and will raise an Exception when used on that platform.

Showing that error does not really help anyone -- we know about that issue, there's nothing we can do about it, and it just means that desktop notifications (a mostly cosmetic feature) won't work.

So rather than spamming confusing error message, this will just silently ignore the error.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
