### PR TITLE
Fix player running one additional tile before re-applying Repel

### DIFF
--- a/modules/modes/puzzle_solver.py
+++ b/modules/modes/puzzle_solver.py
@@ -20,7 +20,6 @@ from .util import (
     wait_for_task_to_start_and_finish,
     walk_one_tile,
     apply_repel,
-    replenish_repel,
 )
 
 
@@ -62,7 +61,7 @@ class PuzzleSolverMode(BotMode):
             return False
 
     def on_repel_effect_ended(self) -> None:
-        replenish_repel()
+        yield from apply_repel()
 
     def run(self) -> Generator:
         assert_no_auto_battle("This mode should not be used with auto-battle.")

--- a/modules/modes/roamer_reset.py
+++ b/modules/modes/roamer_reset.py
@@ -23,7 +23,6 @@ from .util import (
     ensure_facing_direction,
     fly_to,
     navigate_to,
-    replenish_repel,
     soft_reset,
     wait_for_player_avatar_to_be_standing_still,
     wait_for_unique_rng_value,
@@ -70,7 +69,7 @@ class RoamerResetMode(BotMode):
 
     def on_repel_effect_ended(self) -> None:
         try:
-            replenish_repel()
+            yield from apply_repel()
         except RanOutOfRepels:
             self._ran_out_of_repels = True
 

--- a/modules/modes/rock_smash.py
+++ b/modules/modes/rock_smash.py
@@ -25,7 +25,6 @@ from .util import (
     apply_white_flute_if_available,
     ensure_facing_direction,
     follow_path,
-    replenish_repel,
     soft_reset,
     wait_for_player_avatar_to_be_standing_still,
     wait_for_script_to_start_and_finish,
@@ -69,9 +68,9 @@ class RockSmashMode(BotMode):
     def on_repel_effect_ended(self) -> None:
         if self._using_repel:
             try:
-                replenish_repel()
+                yield from apply_repel()
             except RanOutOfRepels:
-                context.controller_stack.insert(len(context.controller_stack) - 1, self.reset_and_wait())
+                yield from self.reset_and_wait()
 
     def run(self) -> Generator:
         self._in_safari_zone = False

--- a/modules/modes/util/items.py
+++ b/modules/modes/util/items.py
@@ -136,25 +136,6 @@ def apply_repel() -> Generator:
     yield from use_item_from_bag(repel_item)
 
 
-def replenish_repel() -> None:
-    """
-    This can be used in a bot mode's `on_repel_effect_ended()` callback to re-enable the repel
-    effect as soon as it expires.
-
-    It should not be used anywhere else.
-    """
-
-    if get_item_bag().number_of_repels == 0:
-        raise RanOutOfRepels("Player ran out of repels")
-    else:
-
-        def apply_repel_and_reset_inputs():
-            yield from apply_repel()
-            context.emulator.reset_held_buttons()
-
-        context.controller_stack.insert(len(context.controller_stack) - 1, apply_repel_and_reset_inputs())
-
-
 @debug.track
 def teach_hm_or_tm(hm_or_tm: Item, party_index: int, move_index_to_replace: int = 3) -> Generator:
     """


### PR DESCRIPTION
### Description

The repel listener had an issue where it would close the notification message about repel expiring, but then yield control back to the bot mode for one extra frame before attempting to re-apply another repel.

If that happened in or right next to tall grass, that would mean that the player moved inside the grass and might lead to an unexpected encounter.

The bot would then hang because it would keep spamming `Start` to open the menu.

### Changes

Rather than having to modify the `context.controller_stack` list, the `on_repel_effect_ended()` callback of a bot mode can just yield further actions, just like the `run()` method does. This avoids the 1-frame gap, but also allows using that callback in a more intuitive way as it behaves like the rest of the bot.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
