### PR TITLE
Do not avoid weather-changing tiles when pathfinding

### DIFF
--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -1235,7 +1235,11 @@ class MapTab(DebugTab):
         coord_events_list = {"__value": len(map_coord_events)}
         for i in range(len(map_coord_events)):
             event = map_coord_events[i]
-            coord_events_list[format_coordinates(event.local_coordinates)] = event.script_symbol
+            if event.type == "weather" and event.weather:
+                label = f"Change weather to: {event.weather}"
+            else:
+                label = event.script_symbol
+            coord_events_list[format_coordinates(event.local_coordinates)] = label
 
         map_bg_events = map_data.bg_events
         bg_events_list = {"__value": len(map_bg_events)}

--- a/modules/map.py
+++ b/modules/map.py
@@ -434,6 +434,21 @@ WEATHER_TYPES = [
     "Route 119 Cycle",
     "Route 123 Cycle",
 ]
+WEATHER_SCRIPTS = {
+    1: "Sunny Clouds",
+    2: "Sunny",
+    3: "Rain",
+    4: "Snow",
+    5: "Thunderstorm",
+    6: "Fog (Horizontal)",
+    7: "Fog (Diagonal)",
+    8: "Volcanic Ash",
+    9: "Sandstorm",
+    10: "Shade",
+    11: "Drought",
+    20: "Route 119 Cycle",
+    21: "Route 123 Cycle",
+}
 
 
 class MapConnection:
@@ -554,6 +569,13 @@ class MapCoordEvent:
         self._data = data
 
     @property
+    def type(self) -> str:
+        if self.script_pointer == 0:
+            return "weather"
+        else:
+            return "script"
+
+    @property
     def local_coordinates(self) -> tuple[int, int]:
         return unpack_uint16(self._data[:2]), unpack_uint16(self._data[2:4])
 
@@ -578,13 +600,25 @@ class MapCoordEvent:
         symbol = get_symbol_name(self.script_pointer, pretty_name=True)
         return hex(self.script_pointer) if symbol == "" else symbol
 
+    @property
+    def weather(self) -> str | None:
+        if self.script_pointer != 0:
+            return None
+        else:
+            try:
+                return WEATHER_SCRIPTS[unpack_uint16(self._data[6:8])]
+            except KeyError:
+                return None
+
     def to_dict(self) -> dict:
         return {
             "local_coordinates": self.local_coordinates,
+            "type": self.type,
             "trigger_var": get_event_var_name(self.trigger_var_number),
             "trigger_value": self.trigger_value,
             "elevation": self.elevation,
             "script": self.script_symbol,
+            "weather": self.weather,
         }
 
 

--- a/modules/map_path.py
+++ b/modules/map_path.py
@@ -78,7 +78,7 @@ class PathMap:
 
                 on_enter_event_triggers = {}
                 for event in map_data.coord_events:
-                    if event.local_coordinates == tile.local_position:
+                    if event.local_coordinates == tile.local_position and event.type != "weather":
                         on_enter_event_triggers[event.trigger_var_number] = event.trigger_value
 
                 warps_to = None


### PR DESCRIPTION
### Description

The pathfinding algorithm attempts to avoid tiles where a script could trigger.

This leads to an issue with the Kecleon mode where the player needs to cross some tiles that will change the weather. There is currently no handling for this special event type, so the bot tries to avoid those tiles and will inadvertently run into tall grass in the process.

I have added a detection for this event type, improved the debug map view and exempted those scripts in the pathfinding function.

Fixes #331

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
