### PR TITLE
Fix HTTP API hanging on consecutive calls

### DIFF
--- a/modules/web/http.py
+++ b/modules/web/http.py
@@ -130,7 +130,7 @@ def http_server() -> None:
             work_queue.put_nowait(get_item_bag)
         if cached_storage.age_in_seconds > 1:
             work_queue.put_nowait(get_item_storage)
-        while cached_bag.age_in_seconds > 1 or cached_storage.age_in_seconds > 1:
+        while cached_bag.age_in_frames > 60 or cached_storage.age_in_frames > 60:
             time.sleep(0.05)
 
         return jsonify(
@@ -179,7 +179,7 @@ def http_server() -> None:
         cached_pokedex = state_cache.pokedex
         if cached_pokedex.age_in_seconds > 1:
             work_queue.put_nowait(get_pokedex)
-            while cached_pokedex.age_in_seconds > 1:
+            while cached_pokedex.age_in_frames > 60:
                 time.sleep(0.05)
 
         return jsonify(cached_pokedex.value.to_dict())


### PR DESCRIPTION
### Description

When doing multiple HTTP API calls to the `/items` endpoint in particular, there was a good chance for the HTTP thread to hang in an infinite loop.

The reason for this was that the HTTP API would issue an update instruction to the main thread and then wait for the data's `age_in_seconds` to update -- but this would only change if the underlying _value_ (i.e. the item bag/PC storage) changed.

Instead, we now check `age_in_frames` which updates every time the value is _checked_ even if it didn't change.

Fixes #325

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
