### PR TITLE
SGR: Use different path for Togepi egg hatching to avoid wandering NPC

### DIFF
--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -180,8 +180,8 @@ class StaticGiftResetsMode(BotMode):
                     point_a = get_map_data(MapRSE.LAVARIDGE_TOWN, (2, 9))
                     point_b = get_map_data(MapRSE.LAVARIDGE_TOWN, (19, 10))
                 elif encounter[2] == "Togepi":
-                    point_a = get_map_data(MapFRLG.FIVE_ISLAND_WATER_LABYRINTH, (15, 9))
-                    point_b = get_map_data(MapFRLG.FIVE_ISLAND_WATER_LABYRINTH, (8, 7))
+                    point_a = get_map_data(MapFRLG.FIVE_ISLAND_WATER_LABYRINTH, (11, 9))
+                    point_b = get_map_data(MapFRLG.FIVE_ISLAND_WATER_LABYRINTH, (17, 13))
                 else:
                     raise BotModeError("Unknown encounter type")
 


### PR DESCRIPTION
### Description

When using the Static Gift Resets mode in FR/LG to reset the Togepi egg, there is an NPC on the island that may wander around.

The path programmed for cycling in a circle to hatch the egg intersected that NPC's path so the player would get stuck pretty quickly.

This just chooses a different area for cycling in.

### Notes

Fixes #334 

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
