### PR TITLE
feat(static_gift_resets): Enable 'Hoenn Fossils' for Ruby/Sapphire.

### DIFF
--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -149,6 +149,8 @@ class StaticGiftResetsMode(BotMode):
                     yield from wait_for_task_to_start_and_finish("Task_YesNoMenu_HandleInput", "A")
                     yield from wait_for_task_to_start_and_finish("Task_Fanfare", "B")
                     yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessageBox", "B")
+            if context.rom.is_rs and encounter[2] in ["Hoenn Fossils"]:
+                yield from wait_until_event_flag_is_true("RECEIVED_FOSSIL_MON", "A")
 
             # Don't rename pokemon
             if context.rom.is_frlg and encounter[2] not in ["Togepi"]:
@@ -160,6 +162,8 @@ class StaticGiftResetsMode(BotMode):
                 yield from wait_for_script_to_start_and_finish("Std_MsgboxDefault", "B")
             if context.rom.is_emerald and encounter[2] not in ["Wynaut"]:
                 yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessage", "B")
+                yield from wait_for_task_to_start_and_finish("Task_HandleYesNoInput", "B")
+            if context.rom.is_rs and encounter[2] in ["Hoenn Fossils"]:
                 yield from wait_for_task_to_start_and_finish("Task_HandleYesNoInput", "B")
 
             # Extra check for lapras and castform and clear extra message boxes


### PR DESCRIPTION
### Description

<!-- A brief overview of what the PR achieves -->
Enables Hoenn Fossils to be shiny hunted in Ruby and Sapphire.

### Changes

<!-- In depth changes per file, if feasible -->
* Initiates dialogue for fossils in R/S via waiting for event flag for receiving fossil mon
* Starts and finishes yes/no input after fossil is received to skip nicknaming

### Notes

<!-- Anything to be considered by reviewers -->
- Tested via Ruby and then ensured that Emerald still worked.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
![image](https://github.com/40Cakes/pokebot-gen3/assets/43832691/0029bda1-fd28-4f5f-8645-c83fbdee1ddc)

