### PR TITLE
Add lookup function whether a trainer has been defeated

### DIFF
--- a/modules/web/pokemon.d.ts
+++ b/modules/web/pokemon.d.ts
@@ -430,7 +430,7 @@ type MapRegularObjectTemplate = {
     // This is not an official name and only here for easier reading of the list.
     script: string;
 
-    trainer: { type: "None" | "Normal" | "See All Directions" | "Buried"; range: number; } | null;
+    trainer: { type: "None" | "Normal" | "See All Directions" | "Buried"; range: number; is_defeated: boolean; } | null;
     movement: { type: string; range: [number, number]; };
 };
 


### PR DESCRIPTION
### Description

This adds a lookup method to `ObjectEventTemplate` to see whether a trainer (map object) has already been defeated.

Since this is only available for `ObjectEventTemplate` and not for `ObjectEvent` itself, I have added a lookup function to get the former from the latter.

This has no immediate use (though it could be used in some modes to verify that relevant trainers have been defeated) but **chesta** provided that code in the `development-chat` Discord channel and I didn't want to let it go to waste.

I have added a 'defeated' indicator to the object list in the `Map` debug tab.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
