### PR TITLE
feat(static_gift_resets): Enable "Beldum" in Ruby and Sapphire.

### DIFF
--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -163,7 +163,7 @@ class StaticGiftResetsMode(BotMode):
             if context.rom.is_emerald and encounter[2] not in ["Wynaut"]:
                 yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessage", "B")
                 yield from wait_for_task_to_start_and_finish("Task_HandleYesNoInput", "B")
-            if context.rom.is_rs and encounter[2] in ["Hoenn Fossils"]:
+            if context.rom.is_rs and encounter[2] in ["Hoenn Fossils", "Beldum"]:
                 yield from wait_for_task_to_start_and_finish("Task_HandleYesNoInput", "B")
 
             # Extra check for lapras and castform and clear extra message boxes


### PR DESCRIPTION
### Description

<!-- A brief overview of what the PR achieves -->

### Changes
Beldum couldn't be hunted in R/S since the nicknaming was not being skipped.

<!-- In depth changes per file, if feasible -->
- modules/modes/static_gift_resets.py
  - Added Beldum to the list of Gift pokemon to skip renaming for R/S specifically

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
