### PR TITLE
CB2 Evolution States

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.json
+++ b/modules/data/symbols/patches/language/pokeemerald.json
@@ -141,6 +141,20 @@
       "J":"8071498",
       "S":"8071a90"
     },
+    "CB2_BEGINEVOLUTIONSCENE":{
+      "D":"813d5ec",
+      "F":"813d60c",
+      "I":"813d5dc",
+      "J":"813dab4",
+      "S":"813d5e4"
+    },
+    "CB2_EVOLUTIONSCENEUPDATE":{
+      "D":"813dfe0",
+      "F":"813e000",
+      "I":"813dfd0",
+      "J":"813e4a8",
+      "S":"813dfd8"
+    },
     "BATTLEMAINCB2":{
       "D":"8038424",
       "F":"8038420",


### PR DESCRIPTION
### Description

The symbols for the evolution game state where missing in the language patches for Emerald.
Result of this was, that the bot never detected evolutions and aborting the evolution with the `stop_evolution` config option was not possible.

### Changes

modules/data/symbols/patches/language/pokeemerald.json -> added missing symbols

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [ ] ~[Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument~
- [ ] ~Wiki has been updated (if relevant)~

<!-- Any further information can be added below here such as images/videos -->
