### PR TITLE
fix: johto starters hanging after picking pokemon

### DIFF
--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -16,6 +16,7 @@ from ._interface import BattleAction, BotMode, BotModeError
 from .util import (
     ensure_facing_direction,
     soft_reset,
+    wait_for_n_frames,
     wait_for_task_to_start_and_finish,
     wait_for_unique_rng_value,
     wait_until_task_is_active,
@@ -169,8 +170,11 @@ def run_rse_johto():
         # Wait for and say no to the second question (the 'Do you want to give ... a nickname')
         yield from wait_for_task_to_start_and_finish("Task_HandleYesNoInput", button_to_press="B")
 
-        # Wait for the rival to pick up their starter
-        yield from wait_until_task_is_not_active("ScriptMovement_MoveObjects", button_to_press="B")
+        yield from wait_until_task_is_not_active("Task_Fanfare", "B")
+        yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessage", "A")
+        
+        yield from wait_for_n_frames(2)
+        context.emulator.press_button("A")
 
         # Navigate to the summary screen to check for shininess
         yield from StartMenuNavigator("POKEMON").step()


### PR DESCRIPTION
### Description

Issue: https://github.com/40Cakes/pokebot-gen3/issues/346
After picking Johto starter bot is hanging in message box 

### Changes

modules\modes\starters.py

-  The ScriptMovement_MoveObjects task does not exist in Tasks tab when using debug mode
-  The rival does not pick up starter
- Add press A key for skip hanging in message box

### Notes

Tested via Emerald Japan

### Checklist

<!-- Pre-merge checks that should be completed -->

- [ ] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [ ] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->


![image](https://github.com/40Cakes/pokebot-gen3/assets/43336971/b25321cb-84f4-4274-8c89-2e4b9ef38270)

https://github.com/40Cakes/pokebot-gen3/assets/43336971/5cb16c43-2f91-49c8-8c85-ae4e7f37125e