### PR TITLE
[FIX] Faster soft resets with `random_soft_reset_rng` cheat `true`

### DIFF
--- a/modules/modes/util/soft_reset.py
+++ b/modules/modes/util/soft_reset.py
@@ -48,7 +48,7 @@ def wait_for_unique_rng_value() -> Generator:
     Wait until the RNG value is unique. This is faster if the `random_soft_reset_rng`
     is enabled.
     """
-    rng_history = get_rng_state_history()
+    rng_history = set(get_rng_state_history())
     rng_value = unpack_uint32(read_symbol("gRngValue"))
 
     context.message = "Waiting for a unique frame before continuing..."
@@ -61,5 +61,5 @@ def wait_for_unique_rng_value() -> Generator:
             yield
     context.message = ""
 
-    rng_history.append(rng_value)
-    save_rng_state_history(rng_history)
+    rng_history.add(rng_value)
+    save_rng_state_history(list(rng_history))


### PR DESCRIPTION
### Description
Using set() we create an iterable array, which is significantly quicker to run through the while loop. 
This means the black frame/emulator freeze up during longer SR sessions (e.g. all 9 starters) is significantly faster.

In testing, I've gone from 2k enc/hr at start down to 700 using the old method, then immediately switching over to this it's back up to 2000/hr. There's no black screen while generating the new RNG value as the while loop doesn't hang checking all values.


### Changes
Changed `wait_for_unique_rng_value` function to convert the array from `soft_reset_frames.json` to an iterable array. This should improve the speed of the while loop.

### Notes
I recommend testing this, but from what I have seen over the few thousand encounters since amending it, we still don't get duplicate values in soft_reset_frames.json

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

