### PR TITLE
Add Sweet Scent Mode

### DIFF
--- a/modules/modes/__init__.py
+++ b/modules/modes/__init__.py
@@ -30,6 +30,7 @@ def get_bot_modes() -> list[Type[BotMode]]:
         from .static_run_away import StaticRunAway
         from .static_gift_resets import StaticGiftResetsMode
         from .static_soft_resets import StaticSoftResetsMode
+        from .sweet_scent import SweetScentMode
         from .pokecenterloop import PokecenterLoopMode
 
         _bot_modes = [
@@ -48,6 +49,7 @@ def get_bot_modes() -> list[Type[BotMode]]:
             StaticRunAway,
             StaticGiftResetsMode,
             StaticSoftResetsMode,
+            SweetScentMode,
             SudowoodoMode,
             PokecenterLoopMode,
         ]

--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -16,6 +16,7 @@ from ._interface import BattleAction, BotMode, BotModeError
 from .util import (
     ensure_facing_direction,
     soft_reset,
+    wait_for_n_frames,
     wait_for_task_to_start_and_finish,
     wait_for_unique_rng_value,
     wait_until_task_is_active,
@@ -169,8 +170,11 @@ def run_rse_johto():
         # Wait for and say no to the second question (the 'Do you want to give ... a nickname')
         yield from wait_for_task_to_start_and_finish("Task_HandleYesNoInput", button_to_press="B")
 
-        # Wait for the rival to pick up their starter
-        yield from wait_until_task_is_not_active("ScriptMovement_MoveObjects", button_to_press="B")
+        yield from wait_until_task_is_not_active("Task_Fanfare", "B")
+        yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessage", "A")
+        
+        yield from wait_for_n_frames(2)
+        context.emulator.press_button("A")
 
         # Navigate to the summary screen to check for shininess
         yield from StartMenuNavigator("POKEMON").step()

--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -172,7 +172,7 @@ def run_rse_johto():
 
         yield from wait_until_task_is_not_active("Task_Fanfare", "B")
         yield from wait_for_task_to_start_and_finish("Task_DrawFieldMessage", "A")
-        
+
         yield from wait_for_n_frames(2)
         context.emulator.press_button("A")
 

--- a/modules/modes/sweet_scent.py
+++ b/modules/modes/sweet_scent.py
@@ -23,7 +23,7 @@ class SweetScentMode(BotMode):
         assert_has_pokemon_with_move(
             "Sweet Scent", "None of your party Pokémon know the move Sweet Scent. Please teach it to someone."
         )
-        
+
         yield from StartMenuNavigator("POKEMON").step()
 
         move_pokemon = None

--- a/modules/modes/sweet_scent.py
+++ b/modules/modes/sweet_scent.py
@@ -1,0 +1,40 @@
+from asyncio import log
+from typing import Generator
+
+from modules.context import context
+from modules.menu_parsers import CursorOptionEmerald, CursorOptionFRLG, CursorOptionRS
+from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
+from modules.player import get_player_avatar
+from modules.pokemon import get_move_by_name, get_party
+from ._interface import BotMode
+
+
+class SweetScentMode(BotMode):
+    @staticmethod
+    def name() -> str:
+        return "Sweet Scent"
+
+    @staticmethod
+    def is_selectable() -> bool:
+        return get_player_avatar().map_location.has_encounters
+
+    def run(self) -> Generator:
+        yield from StartMenuNavigator("POKEMON").step()
+
+        move_pokemon = None
+        move_wanted = get_move_by_name("Sweet Scent")
+        for index in range(len(get_party())):
+            for learned_move in get_party()[index].moves:
+                if learned_move is not None and learned_move.move == move_wanted:
+                    move_pokemon = index
+                    break
+
+        cursor = None
+        if context.rom.is_emerald:
+            cursor = CursorOptionEmerald
+        elif context.rom.is_rs:
+            cursor = CursorOptionRS
+        elif context.rom.is_frlg:
+            cursor = CursorOptionFRLG
+
+        yield from PokemonPartyMenuNavigator(move_pokemon, "", cursor.SWEET_SCENT).step()

--- a/modules/modes/sweet_scent.py
+++ b/modules/modes/sweet_scent.py
@@ -4,6 +4,7 @@ from typing import Generator
 from modules.context import context
 from modules.menu_parsers import CursorOptionEmerald, CursorOptionFRLG, CursorOptionRS
 from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
+from modules.modes._asserts import assert_has_pokemon_with_move
 from modules.player import get_player_avatar
 from modules.pokemon import get_move_by_name, get_party
 from ._interface import BotMode
@@ -19,6 +20,10 @@ class SweetScentMode(BotMode):
         return get_player_avatar().map_location.has_encounters
 
     def run(self) -> Generator:
+        assert_has_pokemon_with_move(
+            "Sweet Scent", "None of your party Pokémon know the move Sweet Scent. Please teach it to someone."
+        )
+        
         yield from StartMenuNavigator("POKEMON").step()
 
         move_pokemon = None

--- a/wiki/Readme.md
+++ b/wiki/Readme.md
@@ -32,6 +32,7 @@ For quick help and support, reach out in Discord [#pokebot-gen3-support❔](http
 - 🏃🏼 [Static Run Away](pages/Mode%20-%20Static%20Run%20Aways.md)
 - ♻ [Static Soft Resets](pages/Mode%20-%20Static%20Soft%20Resets.md)
 - 🥦 [Sudowoodo](pages/Mode%20-%20Sudowoodo.md)
+- 🍂 [Sweet Scent](pages/Mode%20-%20Sweet%20Scent.md)
 
 ### Configuration
 

--- a/wiki/pages/Mode - Sweet Scent.md
+++ b/wiki/pages/Mode - Sweet Scent.md
@@ -2,7 +2,9 @@
 
 # 🔄 Sweet Scent Mode
 
-Sweet Scent will make a wild Pokémon automatically appear
+Sweet Scent will make a wild Pokémon automatically appear.
+
+Make sure you have a Pokémon that knows **[Sweet Scent](<https://bulbapedia.bulbagarden.net/wiki/Sweet_Scent_(move)>)** in your party.
 
 Start the mode while in the overworld, in any patch of grass/water/cave with encounters.
 

--- a/wiki/pages/Mode - Sweet Scent.md
+++ b/wiki/pages/Mode - Sweet Scent.md
@@ -1,0 +1,24 @@
+🍂 [`pokebot-gen3` Wiki Home](../Readme.md)
+
+# 🔄 Sweet Scent Mode
+
+Sweet Scent will make a wild Pokémon automatically appear
+
+Start the mode while in the overworld, in any patch of grass/water/cave with encounters.
+
+## Game Support
+
+|          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
+| :------- | :-----: | :---------: | :--------: | :--------: | :----------: |
+| English  |   🟨    |     🟨      |     ✅     |     ✅     |      ✅      |
+| Japanese |   ❌    |     ❌      |     ✅     |     ❌     |      ❌      |
+| German   |   ❌    |     ❌      |     🟨     |     ❌     |      ❌      |
+| Spanish  |   ❌    |     ❌      |     🟨     |     ❌     |      ❌      |
+| French   |   ❌    |     ❌      |     🟨     |     ❌     |      ❌      |
+| Italian  |   ❌    |     ❌      |     🟨     |     ❌     |      ❌      |
+
+✅ Tested, working
+
+🟨 Untested, may not work
+
+❌ Untested, not working


### PR DESCRIPTION
### Description

Sweet Scent Mode

Start menu > Party > Find Sweet Scent Pokémon > Use Sweet Scent > Repeat

### Changes

<!-- In depth changes per file, if feasible -->

### Notes

https://github.com/40Cakes/pokebot-gen3/issues/74

Tested on Emerald (J), Fire Red (U)

https://github.com/user-attachments/assets/b08b71f4-13f6-4656-99b0-0696f08e7762

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
