### PR TITLE
fix: tcg card can't gen when move type is ???

### DIFF
--- a/modules/tcg_card.py
+++ b/modules/tcg_card.py
@@ -138,6 +138,7 @@ def generate_tcg_card(pokemon: Pokemon, location: str = "") -> Path | None:
             # Moves
             for i, move in enumerate(pokemon.moves):
                 if move:
+                    move_type_name = "Unknown" if move.move.type.name == "???" else move.move.type.name
                     move_name = "Unknown" if move.move.name == "???" else move.move.name
                     move_power = "-" if move.move.base_power == 0 else str(move.move.base_power)
                     if move_name == "Hidden Power":
@@ -162,7 +163,7 @@ def generate_tcg_card(pokemon: Pokemon, location: str = "") -> Path | None:
                         shadow_colour="#000",
                         anchor="rm",
                     )
-                    move_type = Image.open(get_sprites_path() / "types" / "swsh" / f"{move.move.type}.png")
+                    move_type = Image.open(get_sprites_path() / "types" / "swsh" / f"{move_type_name}.png")
                     if move.move.name == "Hidden Power":
                         move_type = Image.open(
                             get_sprites_path() / "types" / "swsh" / f"{pokemon.hidden_power_type}.png"


### PR DESCRIPTION
### Description

<!-- A brief overview of what the PR achieves -->
When encounter regi trio. They learned Curse move
This Curse move type is ???

### Changes

<!-- In depth changes per file, if feasible -->
Change move type name ??? to Unknown in `generate_tcg_card`

### Notes

<!-- Anything to be considered by reviewers -->
https://github.com/40Cakes/pokebot-gen3/issues/348

Tested on Emerald (E) encounter Regirock

![2024-08-02_01-45-54](https://github.com/user-attachments/assets/3b812e16-96be-4a51-98c2-6369670945dc)

![377 ★ - REGIROCK - Relaxed  127  - 26F5C98](https://github.com/user-attachments/assets/240f1a21-9a48-4e40-abdd-8d07041fd6e8)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [ ] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->

