### PR TITLE
Update customcatchfilters.py

### DIFF
--- a/profiles/customcatchfilters.py
+++ b/profiles/customcatchfilters.py
@@ -68,10 +68,10 @@ def custom_catch_filters(pokemon: Pokemon) -> str | bool:
             ivs = [
                 pokemon.ivs.hp,
                 pokemon.ivs.attack,
-                pokemon.ivs.defence,
+                pokemon.ivs.defense,
                 pokemon.ivs.speed,
                 pokemon.ivs.special_attack,
-                pokemon.ivs.special_defence,
+                pokemon.ivs.special_defense,
             ]
 
             # Pokémon with 6 identical IVs of any value


### PR DESCRIPTION
fixed spelling for defense

### Description

I just noticed that the spelling for defense was different from the in-game spelling and thought I'd ask if it was worth changing incase some one added their own catch filters and had issues because they spelled defense differently than what was used in the code prior.

### Changes

I changed the spelling from "defence" to "defense"

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [ ] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [ ] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
