### PR TITLE
Fix navigation getting tripped up by turning around at the start

### DIFF
--- a/modules/map_path.py
+++ b/modules/map_path.py
@@ -20,6 +20,30 @@ class Direction(IntEnum):
     def opposite(self):
         return Direction((self.value + 2) % 4)
 
+    def button_name(self):
+        if self is Direction.North:
+            return "Up"
+        elif self is Direction.East:
+            return "Right"
+        elif self is Direction.South:
+            return "Down"
+        else:
+            return "Left"
+
+    @staticmethod
+    def from_string(value: str) -> "Direction":
+        match value.lower():
+            case "up" | "north":
+                return Direction.North
+            case "right" | "east":
+                return Direction.East
+            case "down" | "south":
+                return Direction.South
+            case "left" | "west":
+                return Direction.West
+            case _:
+                raise RuntimeError(f"Value {value} could not be converted into a direction.")
+
 
 @dataclass
 class PathTile:

--- a/modules/memory.py
+++ b/modules/memory.py
@@ -175,7 +175,7 @@ def get_game_state() -> GameState:
             result = GameState.BAG_MENU
         case "CB2_UPDATEPARTYMENU" | "CB2_PARTYMENUMAIN":
             result = GameState.PARTY_MENU
-        case "CB2_INITBATTLE" | "CB2_HANDLESTARTBATTLE":
+        case "CB2_INITBATTLE" | "CB2_HANDLESTARTBATTLE" | "CB2_OVERWORLDBASIC":
             result = GameState.BATTLE_STARTING
         case "CB2_ENDWILDBATTLE":
             result = GameState.BATTLE_ENDING

--- a/modules/modes/roamer_reset.py
+++ b/modules/modes/roamer_reset.py
@@ -284,7 +284,7 @@ class RoamerResetMode(BotMode):
                 # Go to the first spot of tall grass on Route 1 and spin around for a while
                 yield from navigate_to(MapFRLG.ROUTE1, (12, 39))
                 directions = ["Left", "Down", "Right", "Up"]
-                for index in range(18 if has_good_ability else 36):
+                for index in range(18 if has_good_ability else 38):
                     yield from ensure_facing_direction(directions[index % 4])
 
                 # Walk into rival's house to get an additional map transition.


### PR DESCRIPTION
### Description

When starting to walk while originally facing a different direction, the player avatar actually does _two_ steps: First turning around, then moving to the next tile.

If the tile the player is standing on can have encounters, this means for a single navigation step there are actually two opportunities for an encounter to happen.

This trips up the navigation system because it waits for the player to reach the next tile and will eventually re-attempt the navigation. Since a battle would have started at that point, navigation is not possible and an error will be thrown.

This was triggered in Roamer Reset mode **if the leading Pokémon did not have the Illuminate ability**. That's because _with_ the ability we do 18 turns (which means we face South at the end) while _without_ it we do 36 turns (facing North at the end.)

I have also adjusted that turn number.

### Notes

Fixes #344

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
