### PR TITLE
Add a simple plugin system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ roms/*
 !roms/.gitkeep
 stats/
 stream/
+plugins/

--- a/modules/main.py
+++ b/modules/main.py
@@ -6,6 +6,7 @@ from modules.console import console
 from modules.context import context
 from modules.memory import GameState, get_game_state
 from modules.modes import BotListener, BotMode, BotModeError, FrameInfo, get_bot_listeners, get_bot_mode_by_name
+from modules.plugins import plugin_profile_loaded
 from modules.tasks import get_global_script_context, get_tasks
 
 # Contains a queue of tasks that should be run the next time a frame completes.
@@ -20,6 +21,7 @@ def main_loop() -> None:
     This function is run after the user has selected a profile and the emulator has been started.
     """
     try:
+        plugin_profile_loaded(context.profile)
         current_mode: BotMode | None = None
 
         if context.config.discord.rich_presence:

--- a/modules/modes/__init__.py
+++ b/modules/modes/__init__.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING, Type
 
 from ._interface import BattleAction, BotListener, BotMode, BotModeError, FrameInfo
+from ..plugins import plugin_get_additional_bot_listeners, plugin_get_additional_bot_modes
 
 if TYPE_CHECKING:
     from modules.roms import ROM
@@ -56,6 +57,9 @@ def get_bot_modes() -> list[Type[BotMode]]:
             PokecenterLoopMode,
         ]
 
+        for mode in plugin_get_additional_bot_modes():
+            _bot_modes.append(mode)
+
     return _bot_modes
 
 
@@ -92,4 +96,6 @@ def get_bot_listeners(rom: "ROM") -> list[BotListener]:
     ]
     if rom.is_emerald:
         listeners.append(PokenavListener())
+    for listener in plugin_get_additional_bot_listeners():
+        listeners.append(listener)
     return listeners

--- a/modules/plugin_interface.py
+++ b/modules/plugin_interface.py
@@ -1,0 +1,33 @@
+from typing import TYPE_CHECKING, Iterable
+
+if TYPE_CHECKING:
+    from modules.battle import BattleOutcome
+    from modules.modes import BotMode, BotListener
+    from modules.pokemon import Pokemon
+    from modules.profiles import Profile
+
+
+class BotPlugin:
+    def get_additional_bot_modes(self) -> Iterable[type["BotMode"]]:
+        return []
+
+    def get_additional_bot_listeners(self) -> Iterable["BotListener"]:
+        return []
+
+    def on_profile_loaded(self, profile: "Profile") -> None:
+        pass
+
+    def on_battle_started(self, opponent: "Pokemon") -> None:
+        pass
+
+    def on_battle_ended(self, outcome: "BattleOutcome") -> None:
+        pass
+
+    def on_pokemon_evolved(self, evolved_pokemon: "Pokemon") -> None:
+        pass
+
+    def on_egg_hatched(self, hatched_pokemon: "Pokemon") -> None:
+        pass
+
+    def on_whiteout(self) -> None:
+        pass

--- a/modules/plugins.py
+++ b/modules/plugins.py
@@ -1,0 +1,90 @@
+import inspect
+from types import GeneratorType
+from typing import TYPE_CHECKING, Iterable
+
+from modules.battle import BattleOutcome
+from modules.plugin_interface import BotPlugin
+from modules.pokemon import Pokemon
+from modules.runtime import get_base_path
+
+if TYPE_CHECKING:
+    from modules.modes import BotMode, BotListener
+    from modules.profiles import Profile
+
+
+plugins: list[BotPlugin] = []
+
+
+def load_plugins():
+    plugins_dir = get_base_path() / "plugins"
+    if not plugins_dir.exists():
+        return
+
+    for file in plugins_dir.iterdir():
+        if file.name.endswith(".py"):
+            module_name = file.name[:-3]
+            imported_module = __import__(f"plugins.{module_name}")
+            classes = list(
+                filter(
+                    lambda c: issubclass(c[1], BotPlugin) and c[1] is not BotPlugin,
+                    inspect.getmembers(getattr(imported_module, module_name), inspect.isclass),
+                )
+            )
+            if len(classes) == 0:
+                raise RuntimeError(f"Could not load plugin `{file.name}`: It did not contain any class.")
+            if len(classes) > 1:
+                raise RuntimeError(f"Could not load plugin `{file.name}`: It contained more than one class.")
+            if not issubclass(classes[0][1], BotPlugin):
+                raise RuntimeError(f"Could not load plugin `{file.name}`: Class did not inherit from `BotPlugin`.")
+
+            plugins.append(classes[0][1]())
+
+
+def plugin_get_additional_bot_modes() -> Iterable["BotMode"]:
+    for plugin in plugins:
+        yield from plugin.get_additional_bot_modes()
+
+
+def plugin_get_additional_bot_listeners() -> Iterable["BotListener"]:
+    for plugin in plugins:
+        yield from plugin.get_additional_bot_listeners()
+
+
+def plugin_profile_loaded(profile: "Profile") -> None:
+    for plugin in plugins:
+        plugin.on_profile_loaded(profile)
+
+
+def plugin_battle_started(opponent: "Pokemon") -> None:
+    for plugin in plugins:
+        result = plugin.on_battle_started(opponent)
+        if isinstance(result, GeneratorType):
+            yield from result
+
+
+def plugin_battle_ended(outcome: "BattleOutcome") -> None:
+    for plugin in plugins:
+        result = plugin.on_battle_ended(outcome)
+        if isinstance(result, GeneratorType):
+            yield from result
+
+
+def plugin_pokemon_evolved(evolved_pokemon: "Pokemon") -> None:
+    for plugin in plugins:
+        result = plugin.on_pokemon_evolved(evolved_pokemon)
+        if isinstance(result, GeneratorType):
+            yield from result
+
+
+def plugin_egg_hatched(hatched_pokemon: "Pokemon") -> None:
+    for plugin in plugins:
+        result = plugin.on_egg_hatched(hatched_pokemon)
+        if isinstance(result, GeneratorType):
+            yield from result
+
+
+def plugin_whiteout() -> None:
+    for plugin in plugins:
+        result = plugin.on_whiteout()
+        if isinstance(result, GeneratorType):
+            yield from result

--- a/pokebot.py
+++ b/pokebot.py
@@ -7,6 +7,7 @@ import platform
 from dataclasses import dataclass
 
 from modules.modes import get_bot_mode_names
+from modules.plugins import load_plugins
 from modules.runtime import is_bundled_app, get_base_path
 from modules.version import pokebot_name, pokebot_version
 
@@ -114,6 +115,7 @@ if __name__ == "__main__":
     from updater import run_updater
 
     register_exception_hook()
+    load_plugins()
 
     # This catches the signal Windows emits when the underlying console window is closed
     # by the user. We still want to save the emulator state in that case, which would not


### PR DESCRIPTION
### Description

This allows adding certain custom code to the bot without having to modify any files or otherwise risk losing it during the next update.

Plugins are Python files that contain one (and exactly one) class that inherits from `BotPlugin`. That parent class defines a few hooks (such as battle started, battle ended, etc.) as well as offering a way to add custom bot modes and bot listeners.

The system looks for plugins like this:
- Check if the `plugins/` directory exists (by default it doesn't)
- Look for `*.py` files in that directory -- must be a **direct** child of the directory, files in subdirectories are ignored
- Load each of these Python files and make sure that there is one (and exactly one) class definition in there and that this class inherits from `BotPlugin`

A plugin that implements the special encounter behaviour of the stream (wait 60 seconds if a Shiny has been encountered, and save after the battle) might look like this:

```python
# Put this file in `plugins/stream.py`

from typing import TYPE_CHECKING

from modules.battle import BattleOutcome
from modules.encounter import judge_encounter
from modules.modes.util import save_the_game
from modules.plugin_interface import BotPlugin

if TYPE_CHECKING:
    from modules.pokemon import Pokemon


def wait(seconds: float):
    for _ in range(round(seconds * 60)):
        yield


class MyPlugin(BotPlugin):
    def on_battle_started(self, opponent: "Pokemon") -> None:
        if judge_encounter(opponent).is_of_interest:
            yield from wait(60)

    def on_battle_ended(self, outcome: "BattleOutcome") -> None:
        if outcome is BattleOutcome.Caught:
            yield from save_the_game()

```

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
