### PR TITLE
Allow reading and setting inputs via the HTTP API

### DIFF
--- a/modules/libmgba.py
+++ b/modules/libmgba.py
@@ -429,6 +429,17 @@ class LibmgbaEmulator:
         """
         return self._core._core.getKeys(self._core._core)
 
+    def get_inputs_as_strings(self) -> list[str]:
+        """
+        :return: A list of all the button names that are currently being pressed
+        """
+        raw_inputs = self.get_inputs()
+        inputs = []
+        for key in input_map:
+            if raw_inputs & input_map[key]:
+                inputs.append(key)
+        return inputs
+
     def set_inputs(self, inputs: int):
         """
         :param inputs: A bitfield with all the buttons that should now be pressed

--- a/modules/web/http.py
+++ b/modules/web/http.py
@@ -437,6 +437,21 @@ def http_server() -> None:
         else:
             return jsonify(list(reversed(context.emulator._performance_tracker.fps_history)))
 
+    @server.route("/bot_modes", methods=["GET"])
+    def http_get_bot_modes():
+        """
+        ---
+        get:
+          description: Returns a list of installed bot modes.
+          responses:
+            200:
+              content:
+                application/json: {}
+          tags:
+            - emulator
+        """
+        return jsonify(get_bot_mode_names())
+
     @server.route("/emulator", methods=["GET"])
     def http_get_emulator():
         """
@@ -537,6 +552,67 @@ def http_server() -> None:
                 return Response(f"Unrecognised setting: '{key}'.", status=422)
 
         return http_get_emulator()
+
+    @server.route("/input", methods=["GET"])
+    def http_get_input():
+        """
+        ---
+        get:
+          description: Returns a list of currently pressed buttons.
+          responses:
+            200:
+              content:
+                application/json: {}
+          tags:
+            - emulator
+        """
+        return jsonify(context.emulator.get_inputs_as_strings())
+
+    @server.route("/input", methods=["POST"])
+    def http_post_input():
+        """
+        ---
+        post:
+          description: Sets which buttons are being pressed. Accepts a JSON payload.
+          requestBody:
+            description: JSON payload
+            content:
+              application/json:
+                schema: {}
+                examples:
+                  press_right_and_b:
+                    summary: Press Right an B
+                    value: ["B", "Right"]
+                  release_all_buttons:
+                    summary: Release all buttons
+                    value: []
+          responses:
+            200:
+              content:
+                application/json: {}
+          tags:
+            - emulator
+        """
+        new_buttons = request.json
+        if not isinstance(new_buttons, list):
+            return Response("This endpoint expects a JSON array as its payload.", status=422)
+
+        possible_buttons = ["A", "B", "Select", "Start", "Right", "Left", "Up", "Down", "R", "L"]
+        buttons_to_press = []
+        for button in new_buttons:
+            for possible_button in possible_buttons:
+                if button.lower() == possible_button.lower():
+                    buttons_to_press.append(possible_button)
+
+        def update_inputs():
+            if context.bot_mode == "Manual":
+                context.emulator.reset_held_buttons()
+                for button_to_press in buttons_to_press:
+                    context.emulator.hold_button(button_to_press)
+
+        work_queue.put_nowait(update_inputs)
+
+        return Response(status=204)
 
     @server.route("/stream_events", methods=["GET"])
     def http_get_events_stream():

--- a/modules/web/http_stream.py
+++ b/modules/web/http_stream.py
@@ -31,6 +31,7 @@ class DataSubscription(IntFlag):
     BotMode = auto()
     Message = auto()
     EmulatorSettings = auto()
+    Inputs = auto()
     PerformanceData = auto()
 
     @classmethod
@@ -108,6 +109,7 @@ def run_watcher():
         "emulation_speed": context.emulation_speed,
         "audio_enabled": context.audio,
         "video_enabled": context.video,
+        "inputs": context.emulator.get_inputs(),
         "message": context.message,
     }
 
@@ -227,6 +229,10 @@ def run_watcher():
         if subscriptions["Message"] > 0 and context.message != previous_emulator_state["message"]:
             previous_emulator_state["message"] = context.message
             send_message(DataSubscription.Message, data=context.message, event_type="Message")
+
+        if subscriptions["Inputs"] > 0 and context.emulator.get_inputs() != previous_emulator_state["inputs"]:
+            previous_emulator_state["inputs"] = context.emulator.get_inputs()
+            send_message(DataSubscription.Inputs, data=context.emulator.get_inputs_as_strings(), event_type="Inputs")
 
         if subscriptions["EmulatorSettings"] > 0:
             if context.emulation_speed != previous_emulator_state["emulation_speed"]:

--- a/modules/web/index.html
+++ b/modules/web/index.html
@@ -32,11 +32,18 @@
             </p>
 
             <ul>
-                <li>Bot Mode: <strong id="bot_mode"></strong></li>
+                <li><label>Bot Mode: <select id="bot_mode"></select></label></li>
                 <li>Game State: <strong id="game_mode"></strong></li>
-                <li>Emulation Speed: <strong id="emulation_speed"></strong></li>
-                <li>Video Enabled: <strong id="video_enabled"></strong></li>
-                <li>Audio Enabled: <strong id="audio_enabled"></strong></li>
+                <li><label>Emulation Speed: <select id="emulation_speed">
+                    <option value="1">1×</option>
+                    <option value="2">2×</option>
+                    <option value="3">3×</option>
+                    <option value="4">4×</option>
+                    <option value="0">∞</option>
+                </select></label></li>
+                <li><label>Video Enabled: <input type="checkbox" id="video_enabled"> <strong id="video_enabled_label"></strong></label></li>
+                <li><label>Audio Enabled: <input type="checkbox" id="audio_enabled"> <strong id="audio_enabled_label"></strong></label></li>
+                <li>Buttons Pressed: <strong id="buttons_pressed" class="none">none</strong></li>
                 <li>Message: <strong id="message"></strong></li>
             </ul>
         </div>
@@ -118,7 +125,6 @@
             .then(response => response.json())
             .then(data => {
                 /** @var {PokeBotApi.GetEmulatorResponse} */
-                handleBotModeChange(data.bot_mode);
                 handleEmulationSpeedChange(data.emulation_speed);
                 handleVideoEnabledChange(data.video_enabled);
                 handleAudioEnabledChange(data.audio_enabled);
@@ -129,7 +135,62 @@
                     frame_count: 0,
                 });
                 handleMessageChange(data.current_message);
+
+                (() => {
+                    const select = document.getElementById("emulation_speed");
+                    select.addEventListener("change", () => {
+                        fetch("/emulator", {
+                            method: "POST",
+                            headers: {"Content-Type": "application/json"},
+                            body: JSON.stringify({"emulation_speed": Number.parseInt(select.value)})
+                        });
+                    });
+
+                    const videoEnabled = document.getElementById("video_enabled");
+                    videoEnabled.addEventListener("change", () => {
+                        fetch("/emulator", {
+                            method: "POST",
+                            headers: {"Content-Type": "application/json"},
+                            body: JSON.stringify({"video_enabled": videoEnabled.checked})
+                        });
+                    });
+
+                    const audioEnabled = document.getElementById("audio_enabled");
+                    audioEnabled.addEventListener("change", () => {
+                        fetch("/emulator", {
+                            method: "POST",
+                            headers: {"Content-Type": "application/json"},
+                            body: JSON.stringify({"audio_enabled": audioEnabled.checked})
+                        });
+                    });
+                })();
+
+                fetch("/bot_modes")
+                    .then(response => response.json())
+                    .then(available_modes => {
+                        const select = document.getElementById("bot_mode");
+                        select.addEventListener("change", () => {
+                            fetch("/emulator", {
+                                method: "POST",
+                                headers: {"Content-Type": "application/json"},
+                                body: JSON.stringify({"bot_mode": select.value})
+                            });
+                        });
+                        for (const mode_name of available_modes) {
+                            const option = document.createElement("option");
+                            option.value = mode_name;
+                            option.innerText = mode_name;
+                            if (mode_name === data.bot_mode) {
+                                option.selected = true;
+                            }
+                            select.append(option);
+                        }
+                    });
             }),
+
+            fetch("/input")
+                .then(response => response.json())
+                .then(data => handleInputsChange(data)),
 
             fetch("/game_state")
             .then(response => response.json())
@@ -191,6 +252,7 @@
         url.searchParams.append("topic", "Party");
         url.searchParams.append("topic", "PerformanceData");
         url.searchParams.append("topic", "Opponent");
+        url.searchParams.append("topic", "Inputs");
 
         /*
          * Initialise event-stream client and add event handlers for all the events we care about.
@@ -211,6 +273,7 @@
             eventSource.addEventListener("EmulationSpeed", event => handleEmulationSpeedChange(JSON.parse(event.data)));
             eventSource.addEventListener("AudioEnabled", event => handleAudioEnabledChange(JSON.parse(event.data)));
             eventSource.addEventListener("VideoEnabled", event => handleVideoEnabledChange(JSON.parse(event.data)));
+            eventSource.addEventListener("Inputs", event => handleInputsChange(JSON.parse(event.data)));
 
             document.getElementById("screen_loading").style.display = "none";
             eventSource.onerror = () => {
@@ -483,7 +546,7 @@
          */
         function handleBotModeChange(data) {
             log(`Bot mode changed to <strong>${data}</strong>`);
-            document.getElementById("bot_mode").innerText = data;
+            document.getElementById("bot_mode").value = data;
         }
 
         /**
@@ -496,7 +559,7 @@
             } else {
                 newValue = data + "×";
             }
-            document.getElementById("emulation_speed").innerText = newValue;
+            document.getElementById("emulation_speed").value = data.toString();
             log(`Emulation speed changed to <strong>${newValue}</strong>`);
         }
 
@@ -504,7 +567,8 @@
          * @param {StreamEvents.AudioEnabled} data
          */
         function handleAudioEnabledChange(data) {
-            document.getElementById("audio_enabled").innerText = data ? "yes" : "no";
+            document.getElementById("audio_enabled").checked = data;
+            document.getElementById("audio_enabled_label").innerText = data ? "yes" : "no";
 
             if (data) {
                 log(`Audio was <strong>enabled</strong>`);
@@ -517,12 +581,26 @@
          * @param {StreamEvents.VideoEnabled} data
          */
         function handleVideoEnabledChange(data) {
-            document.getElementById("video_enabled").innerText = data ? "yes" : "no";
+            document.getElementById("video_enabled").checked = data;
+            document.getElementById("video_enabled_label").innerText = data ? "yes" : "no";
 
             if (data) {
                 log(`Video was <strong>enabled</strong>`);
             } else {
                 log(`Video was <strong>disabled</strong>`);
+            }
+        }
+
+        /**
+         * @param {StreamEvents.Inputs} data
+         */
+        function handleInputsChange(data) {
+            if (data.length === 0) {
+                document.getElementById("buttons_pressed").innerText = "none";
+                document.getElementById("buttons_pressed").className = "none";
+            } else {
+                document.getElementById("buttons_pressed").innerText = data.join(", ");
+                document.getElementById("buttons_pressed").className = "";
             }
         }
 
@@ -662,6 +740,55 @@
                 root.style.setProperty(property, value);
             }
         }
+
+        const held_buttons = new Set();
+        const key_map = {
+            "ArrowUp": "Up",
+            "ArrowLeft": "Left",
+            "ArrowRight": "Right",
+            "ArrowDown": "Down",
+            "z": "B",
+            "x": "A",
+            "a": "L",
+            "s": "R",
+            " ": "Start",
+            "Backspace": "Select",
+        }
+
+        let abortController = null;
+        const updateInputs = () => {
+            if (document.getElementById("bot_mode").value === "Manual") {
+                if (abortController !== null) {
+                    abortController.abort();
+                }
+
+                abortController = new AbortController();
+                fetch("/input", {
+                    method: "POST",
+                    body: JSON.stringify([...held_buttons]),
+                    headers: {"Content-Type": "application/json"},
+                    signal: abortController.signal,
+                })
+                    .then(() => {
+                        abortController = null;
+                    });
+            }
+        };
+
+        window.addEventListener("keydown", event => {
+            if (key_map.hasOwnProperty(event.key)) {
+                event.preventDefault();
+                held_buttons.add(key_map[event.key]);
+                updateInputs();
+            }
+        });
+        window.addEventListener("keyup", event => {
+            if (key_map.hasOwnProperty(event.key)) {
+                event.preventDefault();
+                held_buttons.delete(key_map[event.key]);
+                updateInputs();
+            }
+        });
     </script>
 
     <style id="theme-styles">

--- a/modules/web/stream_events.d.ts
+++ b/modules/web/stream_events.d.ts
@@ -49,4 +49,6 @@ declare module StreamEvents {
     export type AudioEnabled = boolean;
 
     export type VideoEnabled = boolean;
+
+    export type Inputs = ("A" | "B" | "Select" | "Start" | "Right" | "Left" | "Up" | "Down" | "R" | "L")[]
 }


### PR DESCRIPTION
### Description

This adds the following features to the HTTP API:

- `GET /input` for retrieving a list of currently pressed buttons,
- `POST /input` for _setting_ the list of currently pressed buttons (only works in manual mode, same as pressing buttons in the GUI),
- `GET /bot_modes` for getting a list of all available bot modes,
- a new `Inputs` channel for the events stream, that can be used to subscribe to input changes.

I have made use of these new endpoints in the demo page (`index.html`) and also added form controls for bot mode, emulation speed and video/audio toggle.

Furthermore, the demo page will react to and relay button presses. Though the key mapping is currently hardcoded to the bot's defaults.

![image](https://github.com/user-attachments/assets/1793b26f-1dd5-4d01-a0b5-11199fb6af4b)


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
