### PR TITLE
Add a headless (no GUI) mode

### DIFF
--- a/modules/gui/__init__.py
+++ b/modules/gui/__init__.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import platform
 from tkinter import Tk, ttk
@@ -5,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import PIL.Image
 import PIL.ImageTk
-import contextlib
 import darkdetect
 from ttkthemes import ThemedTk
 
@@ -39,6 +39,7 @@ class PokebotGui:
         self._on_exit = on_exit
         self._startup_settings: "StartupSettings | None" = None
         self.inputs_enabled = True
+        self.is_headless = False
 
         self.window.geometry("540x400")
         self.window.resizable(context.debug, True)

--- a/modules/gui/headless.py
+++ b/modules/gui/headless.py
@@ -1,0 +1,38 @@
+from typing import TYPE_CHECKING
+
+from modules.context import context
+from modules.game import set_rom
+from modules.libmgba import LibmgbaEmulator
+
+if TYPE_CHECKING:
+    from pokebot import StartupSettings
+
+
+class PokebotHeadless:
+    def __init__(self, main_loop: callable, on_exit: callable):
+        self._main_loop = main_loop
+        self._on_exit = on_exit
+        self.is_headless = True
+
+    def run(self, startup_settings: "StartupSettings"):
+        if startup_settings.profile is None:
+            raise RuntimeError("Headless mode cannot be started without selecting a profile.")
+
+        context.profile = startup_settings.profile
+        context.config.load(startup_settings.profile.path, strict=False)
+        set_rom(startup_settings.profile.rom)
+        context.emulator = LibmgbaEmulator(startup_settings.profile, self._on_frame)
+        context.audio = not startup_settings.no_audio
+        context.video = not startup_settings.no_video
+        context.emulation_speed = startup_settings.emulation_speed
+        context.debug = False
+        context.bot_mode = startup_settings.bot_mode
+
+        self._main_loop()
+
+    def on_settings_updated(self) -> None:
+        pass
+
+    def _on_frame(self):
+        if context.emulator._performance_tracker.time_since_last_render() >= (1 / 60) * 1_000_000_000:
+            context.emulator._performance_tracker.track_render()

--- a/modules/gui/multi_select_window.py
+++ b/modules/gui/multi_select_window.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from tkinter import Canvas, PhotoImage, Toplevel, ttk
 
+from rich.prompt import Prompt
+
 from modules.context import context
 
 
@@ -14,6 +16,9 @@ class Selection:
 
 
 def ask_for_choice(choices: list[Selection], window_title: str = "Choose...") -> str | None:
+    if context.gui.is_headless:
+        return Prompt.ask(window_title, choices=[choice.button_label for choice in choices])
+
     window = Toplevel(context.gui.window)
     selected_value: str | None = None
 

--- a/modules/modes/_listeners.py
+++ b/modules/modes/_listeners.py
@@ -1,4 +1,3 @@
-import inspect
 from types import GeneratorType
 
 from modules.battle import BattleHandler, BattleOutcome, RotatePokemon, check_lead_can_battle, flee_battle
@@ -427,16 +426,3 @@ class SafariZoneListener(BotListener):
                 f"The player used up all their {limited_by} in the Safari Zone. Switched back to manual mode."
             )
             context.set_manual_mode()
-
-
-class LinuxTimeoutListener(BotListener):
-    def __init__(self):
-        def raise_timeout_error(*args):
-            if not context.gui._emulator_screen._stepping_mode:
-                raise TimeoutError
-
-        signal.signal(signal.SIGALRM, raise_timeout_error)
-
-    def handle_frame(self, bot_mode: BotMode, frame: FrameInfo):
-        pass
-        # signal.alarm(10)

--- a/modules/web/http.py
+++ b/modules/web/http.py
@@ -3,6 +3,7 @@ import json
 import time
 from pathlib import Path
 
+import waitress
 from apispec import APISpec
 from apispec_webframeworks.flask import FlaskPlugin
 from flask import Flask, Response, jsonify, request
@@ -673,9 +674,11 @@ def http_server() -> None:
         spec.path(view=http_get_video_stream)
 
     server.register_blueprint(swaggerui_blueprint)
-    server.run(
-        debug=False,
-        threaded=True,
+
+    waitress.serve(
+        server,
         host=context.config.obs.http_server.ip,
         port=context.config.obs.http_server.port,
+        threads=2,
+        ident=f"{pokebot_name}/{pokebot_version} (waitress)",
     )

--- a/pokebot.py
+++ b/pokebot.py
@@ -6,6 +6,7 @@ import pathlib
 import platform
 from dataclasses import dataclass
 
+from modules.gui.headless import PokebotHeadless
 from modules.modes import get_bot_mode_names
 from modules.plugins import load_plugins
 from modules.runtime import is_bundled_app, get_base_path
@@ -41,6 +42,7 @@ class StartupSettings:
     profile: "Profile | None"
     debug: bool
     bot_mode: str
+    headless: bool
     no_video: bool
     no_audio: bool
     emulation_speed: int
@@ -76,6 +78,7 @@ def parse_arguments() -> StartupSettings:
         choices=["0", "1", "2", "3", "4"],
         help="Initial emulation speed (0 for unthrottled; default: 1)",
     )
+    parser.add_argument("-hl", "--headless", action="store_true", help="Run without a GUI, only using the console.")
     parser.add_argument("-nv", "--no-video", action="store_true", help="Turn off video output by default.")
     parser.add_argument("-na", "--no-audio", action="store_true", help="Turn off audio output by default.")
     parser.add_argument(
@@ -93,6 +96,7 @@ def parse_arguments() -> StartupSettings:
         profile=preselected_profile,
         debug=bool(args.debug),
         bot_mode=args.bot_mode or "Manual",
+        headless=bool(args.headless),
         no_video=bool(args.no_video),
         no_audio=bool(args.no_audio),
         emulation_speed=int(args.emulation_speed or "1"),
@@ -135,7 +139,10 @@ if __name__ == "__main__":
     if not is_bundled_app() and not (get_base_path() / ".git").is_dir():
         run_updater()
 
-    gui = PokebotGui(main_loop, on_exit)
+    if startup_settings.headless:
+        gui = PokebotHeadless(main_loop, on_exit)
+    else:
+        gui = PokebotGui(main_loop, on_exit)
     context.gui = gui
 
     gui.run(startup_settings)

--- a/requirements.py
+++ b/requirements.py
@@ -36,6 +36,7 @@ required_modules = [
     "ttkthemes~=3.2.2",
     "darkdetect~=0.8.0",
     "show-in-file-manager~=1.1.4",
+    "waitress~=3.0.0",
 ]
 
 if platform.system() == "Windows":


### PR DESCRIPTION
### Description

This adds the command line argument `--headless` which allows running the bot without the GUI.

It's meant for people (i.e. me) that want to run the bot on a server system and remotely control it using the HTTP server.

Currently, it does not support creating or selecting profiles interactively, so a profile needs to exist and it needs to be specified when starting the bot.

I have also added [Waitress](https://pypi.org/project/waitress/) as a dependency, which is a simple production-ready HTTP server. Using this avoids Flask's warning message ('This is a development server...') and also makes it less noisy in general (the access log is no longer written to stdout.)

### Notes

This works best in conjunction with #371 which adds some more interactive features (as well as button controls) to the HTTP server.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
