### PR TITLE
Various bug fixes

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -49,8 +49,12 @@ def main_loop() -> None:
             if context.bot_mode != "Manual":
                 game_state = get_game_state()
                 script_context = get_global_script_context()
-                script_stack = script_context.stack if script_context.is_active else []
-                active_tasks = [task.symbol.lower() for task in get_tasks()]
+                script_stack = script_context.stack if script_context is not None and script_context.is_active else []
+                task_list = get_tasks()
+                if task_list is not None:
+                    active_tasks = [task.symbol.lower() for task in task_list]
+                else:
+                    active_tasks = []
             else:
                 game_state = GameState.UNKNOWN
                 script_stack = []

--- a/modules/map.py
+++ b/modules/map.py
@@ -986,6 +986,12 @@ class MapLocation:
             for index in range(object_event_count)
         ]
 
+    def object_by_local_id(self, local_id: int) -> "ObjectEventTemplate | None":
+        for object_template in self.objects:
+            if object_template.local_id == local_id:
+                return object_template
+        return None
+
     @property
     def coord_events(self) -> list[MapCoordEvent]:
         coord_event_count = self._event_list[2]

--- a/modules/menuing.py
+++ b/modules/menuing.py
@@ -516,6 +516,63 @@ class CheckForPickup(BaseMenuNavigator):
 
     def __init__(self):
         super().__init__()
+
+        if context.rom.is_rs:
+            self.possible_pickup_items = [
+                "Super Potion",
+                "Ultra Ball",
+                "Full Restore",
+                "Full Heal",
+                "Nugget",
+                "Revive",
+                "Rare Candy",
+                "Protein",
+                "PP Up",
+                "King’s Rock",
+            ]
+        elif context.rom.is_frlg:
+            self.possible_pickup_items = [
+                "Oran Berry",
+                "Aspear Berry",
+                "Cheri Berry",
+                "Chesto Berry",
+                "Pecha Berry",
+                "Persim Berry",
+                "Rawst Berry",
+                "Nugget",
+                "PP Up",
+                "Rare Candy",
+                "TM10",
+                "Belue Berry",
+                "Durin Berry",
+                "Pamtre Berry",
+                "Spelon Berry",
+                "Watmel Berry",
+            ]
+        else:
+            self.possible_pickup_items = [
+                "Potion",
+                "Antidote",
+                "Super Potion",
+                "Great Ball",
+                "Repel",
+                "Escape Rope",
+                "X Attack",
+                "Full Heal",
+                "Ultra Ball",
+                "Hyper Potion",
+                "Nugget",
+                "King’s Rock",
+                "Full Restore",
+                "Ether",
+                "White Herb",
+                "TM44",
+                "Elixir",
+                "TM01",
+                "Leftovers",
+                "TM26",
+            ]
+
         self.party = get_party()
         self.pokemon_with_pickup = 0
         self.pokemon_with_pickup_and_item = []
@@ -533,7 +590,7 @@ class CheckForPickup(BaseMenuNavigator):
         for i, mon in enumerate(self.party):
             if mon.ability.name == "Pickup":
                 self.pokemon_with_pickup += 1
-                if mon.held_item is not None and mon.held_item.name != "Exp. Share":
+                if mon.held_item is not None and mon.held_item.name in self.possible_pickup_items:
                     self.pokemon_with_pickup_and_item.append(i)
                     self.picked_up_items.append(mon.held_item)
 

--- a/modules/modes/util/higher_level_actions.py
+++ b/modules/modes/util/higher_level_actions.py
@@ -138,6 +138,7 @@ def heal_in_pokemon_center(pokemon_center_door_location: PokemonCenter) -> Gener
 
     # Walk up to the nurse and talk to her
     yield from navigate_to(get_player_avatar().map_group_and_number, (7, 4))
+    yield
     context.emulator.press_button("A")
     yield from wait_for_yes_no_question("Yes")
     yield from wait_for_no_script_to_run("B")

--- a/modules/modes/util/walking.py
+++ b/modules/modes/util/walking.py
@@ -211,6 +211,7 @@ def navigate_to(
     run: bool = True,
     avoid_encounters: bool = True,
     avoid_scripted_events: bool = True,
+    expecting_script: bool = False,
 ) -> Generator:
     """
     Tries to walk the player to a given location while circumventing obstacles.
@@ -229,6 +230,8 @@ def navigate_to(
                              It will also not avoid the activation range of unbattled trainers.
     :param avoid_scripted_events: Try to avoid tiles that would trigger a scripted event when moving onto them. It will
                                   still navigate via those tiles of there is no other option.
+    :param expecting_script: This will accept if a script is triggered during navigation (presumably at the destination)
+                             and will not show an error about that.
     """
 
     def waypoint_generator():
@@ -281,9 +284,12 @@ def navigate_to(
             #
             # In the third case, we consider that an unexpected event and will abort the navigation.
             if get_global_script_context().is_active:
-                raise BotModeError(
-                    f"We unexpectedly triggered a scripted event while trying to reach {coordinates} @ {map}.\nSwitching to manual mode."
-                )
+                if expecting_script:
+                    return
+                else:
+                    raise BotModeError(
+                        f"We unexpectedly triggered a scripted event while trying to reach {coordinates} @ {map}.\nSwitching to manual mode."
+                    )
             pass
 
 

--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -1443,8 +1443,13 @@ def get_party() -> list[Pokemon]:
         # (1) advancing the emulation by one frame, (2) reading the memory, (3) restoring the previous
         # frame's state, so we don't mess with frame accuracy.
         if mon is None:
+            retries = 5
             with context.emulator.peek_frame():
-                mon = parse_pokemon(read_symbol("gPlayerParty", o, 100))
+                while retries > 0 and mon is None:
+                    retries -= 1
+                    mon = parse_pokemon(read_symbol("gPlayerParty", o, 100))
+                    if mon is None:
+                        context.emulator._core.run_frame()
         if mon is None:
             if read_symbol("gPlayerParty", o, 100).count(b"\x00") >= 99:
                 continue

--- a/modules/web/index.html
+++ b/modules/web/index.html
@@ -231,8 +231,10 @@
             .then(response => response.json())
             .then(data => {
                 /** @var {PokeBotApi.GetMapResponse} */
-                handleMapChange(data);
-                handleMapTileChange(data.player_position);
+                if (data !== null) {
+                    handleMapChange(data);
+                    handleMapTileChange(data.player_position);
+                }
             }),
         ];
 
@@ -318,6 +320,10 @@
          * @param {StreamEvents.Player} data
          */
         function handlePlayerChange(data) {
+            if (data === null) {
+                return;
+            }
+
             document.getElementById("player_name").innerText = data.name;
             document.getElementById("player_gender").innerText = data.gender;
             if (data.gender === "male") {


### PR DESCRIPTION
### Description

This combines a bunch of fixes for issues I've noticed while working on a Playthrough mode.

### Changes

- `debug_tabs.py`, `main.py`: Better error handling when things like tasks, script contexts etc. are invalid (usually because the emulator is currently resetting.) These cases shouldn't crash the bot anymore.
- `http.py`, `index.html`: Fixed an issue where the data-updating logic didn't work as expected. Previously, whenever data was older than 5 frames, the HTTP server would issue an update call to the main thread, wait 50 ms, and then check again whether the data is younger than 5 frames. Problem is: If the bot is fast enough to to more than 5 frames within those 50 ms, the data will never be considered up-to-date and the HTTP server will just hang.
- `map_path.py`: Fixed an issue on R/S/E where Route 104 and Rustboro City weren't considered to be connected. That's because some other maps are a bit larger so they don't quite line up in global coordinate space.
- `menuing.py`: Fixed Pickup checks so it only takes items that can actually be acquired by Pickup. Previously, this check would take _any_ item from Pokémon with that ability (except for the hard-coded Exp. Share), even those that have been given to the Pokémon manually.
- `pokemon.py`: If a party Pokémon's data is invalid, peek ahead for up to 5 frames (instead of just one) until valid data is encountered. I've seen multiple cases where the retry-once behaviour wasn't enough.
- `walking.py`: Added an `expecting_script` parameter to `navigate_to()`, which if set to `True` will not throw an error if a script is triggered at the final destination of the path. This is useful for situations where we purposefully want to trigger an on-tile-enter script.
- 
### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
