### PR TITLE
Fix infinite loop when serialising Species data

### DIFF
--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -185,13 +185,16 @@ class FancyTreeview:
                     self._items[item_key] = item
                 found_items.append(item_key)
 
-                properties = {}
-                with contextlib.suppress(AttributeError):
-                    for k in data[key].__dict__:
-                        properties[k] = data[key].__dict__[k]
-                for k in dir(data[key].__class__):
-                    if isinstance(getattr(data[key].__class__, k), property):
-                        properties[k] = getattr(data[key], k)
+                if hasattr(data[key], "debug_dict_value") and callable(data[key].debug_dict_value):
+                    properties = data[key].debug_dict_value()
+                else:
+                    properties = {}
+                    with contextlib.suppress(AttributeError):
+                        for k in data[key].__dict__:
+                            properties[k] = data[key].__dict__[k]
+                    for k in dir(data[key].__class__):
+                        if isinstance(getattr(data[key].__class__, k), property):
+                            properties[k] = getattr(data[key], k)
 
                 found_items.extend(self._update_dict(properties, f"{key_prefix}{key}.", item))
 

--- a/modules/web/pokemon.d.ts
+++ b/modules/web/pokemon.d.ts
@@ -189,6 +189,22 @@ export type Species = {
     egg_groups: string[];
     base_experience_yield: number;
     ev_yield: StatsValues;
+
+    learnset: {
+        // List of move names that can only be learned by breeding.
+        egg: string[],
+
+        // List of moves that this species will learn by levelling up.
+        // Pattern: `{MOVE_NAME} at Lv. {LEVEL_NUMBER}`, e.g. 'Tackle at Lv. 1'
+        level_up: string[],
+
+        // List of TMs and HMs that this species is able to learn.
+        // Pattern: `{ITEM_NAME} ({MOVE_NAME}`, e.g. `TM06 (Toxic)`
+        tm_hm: string[],
+
+        // List of move names that this species can learned from move tutors.
+        tutor: string[],
+    }
 };
 
 export type Pokemon = {


### PR DESCRIPTION
### Description

There's a circular reference in species data (between `Item` and `Move` for HM/TM moves) which triggered an infinite loop in the serialising code.

This fixes that, and also updates the TypeScript information for the `Species` type.

### Notes

Fixes #379 

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
