### PR TITLE
Re-add '1×' and unthrottled buttons to speed controls

### DIFF
--- a/modules/gui/__init__.py
+++ b/modules/gui/__init__.py
@@ -198,6 +198,12 @@ class PokebotGui:
                         context.emulation_speed = 3
                     case "set_speed_4x":
                         context.emulation_speed = 4
+                    case "set_speed_8x":
+                        context.emulation_speed = 8
+                    case "set_speed_16x":
+                        context.emulation_speed = 16
+                    case "set_speed_32x":
+                        context.emulation_speed = 32
                     case "set_speed_unthrottled":
                         context.emulation_speed = 0
                     case "screenshot":

--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -52,6 +52,9 @@ def _get_targeted_encounter() -> tuple[MapFRLG | MapRSE, tuple[int, int], str] |
         ]
 
     targeted_tile = get_player_avatar().map_location_in_front
+    if targeted_tile is None:
+        return None
+
     return next(
         (
             entry

--- a/requirements.py
+++ b/requirements.py
@@ -183,6 +183,9 @@ def update_requirements(ask_for_confirmation: bool = True) -> bool:
             print("Unzipping libmgba into `./mgba`...")
             with zipfile.ZipFile(io.BytesIO(response.content)) as zip_handle:
                 zip_handle.extractall(get_base_path())
+        else:
+            print(f"ERROR: Could not download libmgba-py ({libmgba_url})")
+            sys.exit(1)
 
     # Mark the requirements for the current bot version as checked, so we do not
     # have to run all of this again until the next update.


### PR DESCRIPTION
### Description

![image](https://github.com/user-attachments/assets/5f421877-8536-4644-a026-d1eb1a803070)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
