### PR TITLE
Fix "Suicine" typo in default custom catch filters

### DIFF
--- a/profiles/customcatchfilters.py.dist
+++ b/profiles/customcatchfilters.py.dist
@@ -32,7 +32,7 @@ exceptions = [
     "Mewtwo",
     "Raikou",
     "Entei",
-    "Suicine",
+    "Suicune",
     "Castform",
     "Lileep",
     "Anorith",


### PR DESCRIPTION
Was wondering why it kept flagging a 0 IV Suicune roamer but not Latios, This is why.

### Description

Fixes Suicune not getting ignored by custom catch filters.

### Changes

Literally one character.

### Notes

I ran out of things to say 7 words ago.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [ ] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument (i don't think this's needed in this case)
- [ ] Wiki has been updated (if relevant)

