### PR TITLE
Fix using item from bag

### DIFF
--- a/modules/modes/util/items.py
+++ b/modules/modes/util/items.py
@@ -5,7 +5,7 @@ from modules.debug import debug
 from modules.items import Item, ItemPocket, get_item_bag, get_item_by_name, get_item_by_move_id
 from modules.memory import GameState, get_event_flag, get_game_state, read_symbol, unpack_uint16
 from modules.menuing import StartMenuNavigator, scroll_to_item_in_bag as real_scroll_to_item
-from modules.player import get_player, player_avatar_is_standing_still
+from modules.player import get_player
 from modules.pokemon import get_party, LearnedMove
 from modules.tasks import task_is_active
 from ._util_helper import isolate_inputs
@@ -41,22 +41,17 @@ def use_item_from_bag(item: Item) -> Generator:
     yield from scroll_to_item_in_bag(item)
 
     if context.rom.is_rs:
-        # confirmation_after_use_item_task = "sub_80F9090"
+        confirmation_menu_task = "sub_80A5414"
         start_menu_task = "sub_80712B4"
     elif context.rom.is_emerald:
-        # confirmation_after_use_item_task = "Task_ContinueTaskAfterMessagePrints"
+        confirmation_menu_task = "Task_ItemContext_MultipleRows"
         start_menu_task = "Task_ShowStartMenu"
     else:
-        # confirmation_after_use_item_task = "Task_ContinueTaskAfterMessagePrints"
+        confirmation_menu_task = "Task_FieldItemContextMenuHandleInput"
         start_menu_task = "Task_StartMenuHandleInput"
 
-    while not player_avatar_is_standing_still():
-        if task_is_active(start_menu_task):
-            yield from wait_for_task_to_start_and_finish("start_menu_task", "B")
-            break
-        else:
-            context.emulator.press_button("A")
-            yield
+    yield from wait_for_task_to_start_and_finish(confirmation_menu_task, "A")
+    yield from wait_for_task_to_start_and_finish(start_menu_task, "B")
     yield
 
 


### PR DESCRIPTION
### Description

In #376 I introduced a fix that would allow using items that did not display a message after use (such as the bicycle.)

Unfortunately, that inadvertently broke items _with_ a message, such as Repel. Which breaks the Roamer Reset mode.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
