### PR TITLE
Add `setuptools` to requirements

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -16,6 +16,7 @@ required_modules = [
     "numpy~=1.26.1",
     "Flask~=2.3.2",
     "Flask-Cors~=4.0.0",
+    "setuptools",
     "ruamel.yaml~=0.18.2",
     "pypresence~=4.3.0",
     "obsws-python~=1.6.0",


### PR DESCRIPTION
### Description

This adds `setuptools` to our list of dependencies, which now seems to be required in order to have the `pkg_resources` package available (which is needed for Flask.)

### Changes

See https://stackoverflow.com/a/10538412/3163142

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
