### PR TITLE
Re-add `profiles/` directory to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ __pycache__
 .last-requirements-check
 .last-update-check
 build/
-profiles/*/
+profiles/*
+!profiles/.gitkeep
 dist/
 logs/
 mgba/
@@ -18,6 +19,3 @@ roms/*
 stats/
 stream/
 plugins/
-
-profiles/*.yml
-profiles/*.py

--- a/modules/context.py
+++ b/modules/context.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from typing import Generator, Optional, TYPE_CHECKING
 
@@ -26,6 +27,8 @@ def _initialise_config() -> None:
     """
     config_templates_path = get_base_path() / "modules" / "config" / "templates"
     profiles_path = get_base_path() / "profiles"
+    if not profiles_path.exists():
+        os.mkdir(profiles_path)
     for dist_file in config_templates_path.iterdir():
         if dist_file.is_file():
             regular_file = profiles_path / dist_file.name


### PR DESCRIPTION
### Description

By removing the default configuration files from `profiles/`, that directory disappeared from the repository (since Git does not support empty directories.)

This adds a `.gitkeep` file like we did for the `roms/` directory, and also cleans up `.gitignore` a bit.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
