### PR TITLE
Make sure that all inputs are tracked by HTTP event stream

### DIFF
--- a/modules/libmgba.py
+++ b/modules/libmgba.py
@@ -35,6 +35,14 @@ input_map = {
 }
 
 
+def inputs_to_strings(inputs: int) -> list[str]:
+    """
+    :return: Converts the bitfield representing the emulator's input state to a list
+             of button names that are being pressed.
+    """
+    return [key for key in input_map if inputs & input_map[key]]
+
+
 class PerformanceTracker:
     """
     This is a little helper utility used for measuring the FPS rate and allowing
@@ -428,17 +436,6 @@ class LibmgbaEmulator:
         :return: A bitfield with all the buttons that are currently being pressed
         """
         return self._core._core.getKeys(self._core._core)
-
-    def get_inputs_as_strings(self) -> list[str]:
-        """
-        :return: A list of all the button names that are currently being pressed
-        """
-        raw_inputs = self.get_inputs()
-        inputs = []
-        for key in input_map:
-            if raw_inputs & input_map[key]:
-                inputs.append(key)
-        return inputs
 
     def set_inputs(self, inputs: int):
         """

--- a/modules/web/http.py
+++ b/modules/web/http.py
@@ -2,7 +2,6 @@ import io
 import json
 import time
 from pathlib import Path
-from threading import Event
 
 import waitress
 from apispec import APISpec
@@ -17,6 +16,7 @@ from modules.context import context
 from modules.files import read_file
 from modules.game import _event_flags
 from modules.items import get_item_bag, get_item_storage
+from modules.libmgba import inputs_to_strings
 from modules.main import work_queue
 from modules.map import get_map_data
 from modules.map_data import MapFRLG, MapRSE
@@ -65,19 +65,15 @@ def _update_via_work_queue(
     if state_cache_entry.age_in_frames < maximum_age_in_frames:
         return
 
-    update_event = Event()
-
     def do_update():
         try:
             update_callback()
         except Exception:
             console.print_exception()
-        finally:
-            update_event.set()
 
     try:
         work_queue.put_nowait(do_update)
-        update_event.wait(timeout=5)
+        work_queue.join()
     except Exception:
         console.print_exception()
         return
@@ -617,7 +613,7 @@ def http_server() -> None:
           tags:
             - emulator
         """
-        return jsonify(context.emulator.get_inputs_as_strings())
+        return jsonify(inputs_to_strings(context.emulator.get_inputs()))
 
     @server.route("/input", methods=["POST"])
     def http_post_input():

--- a/modules/web/http_stream.py
+++ b/modules/web/http_stream.py
@@ -6,7 +6,8 @@ from time import sleep, time
 
 from modules.console import console
 from modules.context import context
-from modules.main import work_queue
+from modules.libmgba import inputs_to_strings
+from modules.main import work_queue, inputs_each_frame
 from modules.memory import GameState, get_game_state
 from modules.player import get_player, get_player_avatar
 from modules.pokedex import get_pokedex
@@ -202,9 +203,14 @@ def run_watcher():
             previous_emulator_state["message"] = context.message
             send_message(DataSubscription.Message, data=context.message, event_type="Message")
 
-        if subscriptions["Inputs"] > 0 and context.emulator.get_inputs() != previous_emulator_state["inputs"]:
-            previous_emulator_state["inputs"] = context.emulator.get_inputs()
-            send_message(DataSubscription.Inputs, data=context.emulator.get_inputs_as_strings(), event_type="Inputs")
+        if subscriptions["Inputs"] > 0:
+            combined_inputs = 0
+            for _ in range(len(inputs_each_frame)):
+                combined_inputs |= inputs_each_frame.popleft()
+
+            if combined_inputs != previous_emulator_state["inputs"]:
+                previous_emulator_state["inputs"] = combined_inputs
+                send_message(DataSubscription.Inputs, data=inputs_to_strings(combined_inputs), event_type="Inputs")
 
         if subscriptions["EmulatorSettings"] > 0:
             if context.emulation_speed != previous_emulator_state["emulation_speed"]:


### PR DESCRIPTION
### Description

Adds a buffer for input events so that each time the HTTP server sends an `Inputs` event via the event stream (every 1/30th of a second) it is guaranteed to contain _all_ buttons that have been pressed since the last update.

That means that the event does not necessarily report the exact state of the buttons but more of an 'echo'.

For example, when using the Spin mode unthrottled, the event will likely report all 4 directional buttons to have been pressed at the same time.

But I think that's a good tradeoff between accuracy and performance.

I've also changed the previously introduced mechanism to wait for the `work_queue` by using an `Event` to using the built-in `task_done()` and `join()` methods of the queue object. Just found those by accident in the Python docs.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
