### PR TITLE
Move more imports to after the requirements check in `pokebot.py`

### DIFF
--- a/pokebot.py
+++ b/pokebot.py
@@ -6,8 +6,6 @@ import pathlib
 import platform
 from dataclasses import dataclass
 
-from modules.modes import get_bot_mode_names
-from modules.plugins import load_plugins
 from modules.runtime import is_bundled_app, get_base_path
 from modules.version import pokebot_name, pokebot_version
 
@@ -62,7 +60,7 @@ def directory_arg(value: str) -> pathlib.Path:
     return path_obj
 
 
-def parse_arguments() -> StartupSettings:
+def parse_arguments(bot_mode_names: list[str]) -> StartupSettings:
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description=f"{pokebot_name} {pokebot_version}")
     parser.add_argument(
@@ -70,7 +68,7 @@ def parse_arguments() -> StartupSettings:
         nargs="?",
         help="Profile to initialize. Otherwise, the profile selection menu will appear.",
     )
-    parser.add_argument("-m", "--bot-mode", choices=get_bot_mode_names(), help="Initial bot mode (default: Manual).")
+    parser.add_argument("-m", "--bot-mode", choices=bot_mode_names, help="Initial bot mode (default: Manual).")
     parser.add_argument(
         "-s",
         "--emulation-speed",
@@ -113,6 +111,8 @@ if __name__ == "__main__":
     from modules.console import console
     from modules.exceptions_hook import register_exception_hook
     from modules.main import main_loop
+    from modules.modes import get_bot_mode_names
+    from modules.plugins import load_plugins
     from modules.profiles import Profile, profile_directory_exists, load_profile_by_name
     from updater import run_updater
 
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 
         win32api.SetConsoleCtrlHandler(win32_signal_handler, True)
 
-    startup_settings = parse_arguments()
+    startup_settings = parse_arguments(get_bot_mode_names())
     console.print(f"Starting [bold cyan]{pokebot_name} {pokebot_version}![/]")
 
     if not is_bundled_app() and not (get_base_path() / ".git").is_dir():


### PR DESCRIPTION
### Description

There are still some imports at the top of the file that will indirectly try to load packages that might not be available during the first run (third-party stuff.)

This moves those imports to after the requirements check has happened, which will hopefully resolve the issue that new users had where they had to run `requirements.py` manually.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
