### PR TITLE
fix use_item_from_bag for Emerald MUI

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.json
+++ b/modules/data/symbols/patches/language/pokeemerald.json
@@ -357,6 +357,13 @@
       "J":"8172f94",
       "S":"8172f18"
     },
+    "Task_ItemContext_MultipleRows":{
+      "D":"81ac798",
+      "F":"81ac8ac",
+      "I":"81ac778",
+      "J":"81aca70",
+      "S":"81ac890"
+    },
     "ExecuteMatchCall":{
       "D":"8195bec",
       "F":"8195d0c",


### PR DESCRIPTION
### Description

this fixes a regression reported on discord and adds the missing translated symbols.
`use_item_from_bag()` now functions correctly in all languages for Emerald, fixing the Roamer mode for non English Emerald versions.
### Changes

`modules/data/symbols/patches/language/pokeemerald.json` ->added missing translated symbols

### Notes



### Checklist

<!-- Pre-merge checks that should be completed -->

- [ ] ~[Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument~
- [ ] ~Wiki has been updated (if relevant)~

<!-- Any further information can be added below here such as images/videos -->
