### PR TITLE
Fix Flag in Roamer Moder for FRLG

### DIFF
--- a/modules/modes/roamer_reset.py
+++ b/modules/modes/roamer_reset.py
@@ -126,7 +126,7 @@ class RoamerResetMode(BotMode):
                 raise BotModeError("You have already given the Sapphire to Celio. Try loading an earlier save game.")
 
             if save_data.get_item_bag().quantity_of(get_item_by_name("Sapphire")) == 0:
-                if save_data.get_event_flag("FLAG_RECOVERED_SAPPHIRE"):
+                if save_data.get_event_flag("RECOVERED_SAPPHIRE"):
                     raise BotModeError("You do not have the Sapphire in your inventory. Go and get it!")
                 else:
                     raise BotModeError("You haven't recovered the Sapphire yet.")


### PR DESCRIPTION
### Description

when Starting the Roamer Mode before obtaining the Sapphire the wrong FLAG gets checked witch results in a Error

RuntimeError: Unknown event flag: 'FLAG_RECOVERED_SAPPHIRE

### Changes

`modules\modes\roamer_reset.py` --> Change `FLAG_RECOVERED_SAPPHIRE` to `RECOVERED_SAPPHIRE`

### Notes

`modules/data/event_flags/frlg.txt`
got changed 8 months ago from upstream and i guess this check hasn't worked since

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [ ] ~~Wiki has been updated (if relevant)~~

<!-- Any further information can be added below here such as images/videos -->
