### PR TITLE
Correct information on Daycare mode's wiki page

### DIFF
--- a/wiki/pages/Mode - Daycare.md
+++ b/wiki/pages/Mode - Daycare.md
@@ -18,13 +18,16 @@
 - A compatible breeding couple in the Daycare
 
 ### Optional, but recommended
-- (E/FR/LG) Lead Pokémon with [Flame Body](https://bulbapedia.bulbagarden.net/wiki/Flame_Body_(Ability)) or [Magma Armor](https://bulbapedia.bulbagarden.net/wiki/Magma_Armor_(Ability)) ability
-- [Mach Bike](https://bulbapedia.bulbagarden.net/wiki/Mach_Bike) (R/S/E) or [Bicycle](https://bulbapedia.bulbagarden.net/wiki/Bicycle) (FR/LG) registered to Select
-- (R/S/E) Defeated all trainers on [Route 117](https://bulbapedia.bulbagarden.net/wiki/Hoenn_Route_117) (Preferred)
+- (Emerald only) Having a Pokémon with [Flame Body](https://bulbapedia.bulbagarden.net/wiki/Flame_Body_(Ability)) or [Magma Armor](https://bulbapedia.bulbagarden.net/wiki/Magma_Armor_(Ability)) ability in your
+  party (even if it's fained) halves the number of steps required. 
+- [Mach Bike](https://bulbapedia.bulbagarden.net/wiki/Mach_Bike) (R/S/E) or [Bicycle](https://bulbapedia.bulbagarden.net/wiki/Bicycle) (FR/LG) registered to `Select` will help getting
+  those steps in quicker.
 
 ## Instructions
 
-Start this mode while being on Route 117 (in R/S/E) or Sevii Island Four (FR/LG), the bot will collect up to five eggs, and once all have hatched, release them in the Daycare PC.
+Start this mode while being on Route 117 (in R/S/E) or Sevii Island Four (FR/LG), the bot will
+collect up to five eggs, and once all have hatched, release them in the Daycare PC if they're
+not Shiny.
 
 ![image](../images/daycare.png)
 


### PR DESCRIPTION
### Description

Updates the Daycare wiki page:

- Flame Body and Magma Armor only work on Emerald (not FR/LG), and do not need to be the leading Pokémon in order to work.
- Removed that part about defeating trainers on Route 117 because the path we're now taking doesn't actually pass any trainers.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
