### PR TITLE
Fix encounter logging issues with breeding and soft resetting

### DIFF
--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -103,6 +103,13 @@ def judge_encounter(pokemon: "Pokemon") -> EncounterValue:
 
 
 def log_encounter(pokemon: "Pokemon", action: BattleAction | None = None) -> None:
+    if (
+        context.stats.last_encounter is not None
+        and context.stats.last_encounter.pokemon.personality_value == pokemon.personality_value
+    ):
+        # Avoid double-logging an encounter.
+        return
+
     ccf_result = run_custom_catch_filters(pokemon)
     context.stats.log_encounter(pokemon, ccf_result)
     print_stats(context.stats.get_global_stats(), pokemon)

--- a/modules/modes/_listeners.py
+++ b/modules/modes/_listeners.py
@@ -34,6 +34,7 @@ class BattleListener(BotListener):
 
     def __init__(self):
         self._in_battle = False
+        self._battle_start_frame: int = 0
         self._reported_start_of_battle = False
         self._active_wild_encounter: ActiveWildEncounter | None = None
         self._reported_wild_encounter_visible = False
@@ -46,6 +47,7 @@ class BattleListener(BotListener):
             frame.game_state in self.battle_states or frame.task_is_active("Task_BattleStart")
         ):
             self._in_battle = True
+            self._battle_start_frame = context.emulator.get_frame_count()
             self._reported_start_of_battle = False
             self._active_wild_encounter = None
             self._reported_wild_encounter_visible = False
@@ -121,6 +123,10 @@ class BattleListener(BotListener):
 
             elif text_printer.active:
                 self._text_printer_was_active = True
+
+        elif context.emulator.get_frame_count() < self._battle_start_frame:
+            self._in_battle = False
+            self._active_wild_encounter = None
 
     @debug.track
     def _wait_until_battle_is_over(self):
@@ -304,7 +310,6 @@ class EggHatchListener(BotListener):
         hatched_pokemon = get_party()[party_index]
         bot_mode.on_egg_hatched(hatched_pokemon, party_index)
         plugin_egg_hatched(hatched_pokemon)
-        handle_encounter(hatched_pokemon, do_not_log_battle_action=True)
         while self._script_name in get_global_script_context().stack:
             context.emulator.press_button("B")
             yield

--- a/modules/modes/daycare.py
+++ b/modules/modes/daycare.py
@@ -3,7 +3,7 @@ from typing import Generator
 from modules.console import console
 from modules.context import context
 from modules.daycare import DaycareCompatibility, get_daycare_data
-from modules.encounter import judge_encounter
+from modules.encounter import judge_encounter, handle_encounter
 from modules.items import get_item_bag, get_item_by_name, get_item_storage
 from modules.map import get_map_objects
 from modules.map_data import MapFRLG, MapRSE
@@ -63,6 +63,7 @@ class DaycareMode(BotMode):
 
     def on_egg_hatched(self, pokemon: "Pokemon", party_index: int) -> None:
         self._update_message_soon = True
+        handle_encounter(pokemon, do_not_log_battle_action=False)
 
     def run(self) -> Generator:
         if context.rom.is_emerald:

--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -27,7 +27,6 @@ from .util import (
     wait_until_event_flag_is_true,
     wait_until_task_is_active,
     wait_until_task_is_not_active,
-    wait_for_player_avatar_to_be_standing_still,
     wait_for_no_script_to_run,
 )
 
@@ -108,14 +107,16 @@ class StaticGiftResetsMode(BotMode):
             )
             if save_data.get_event_flag("RECEIVED_LAVARIDGE_EGG"):
                 raise BotModeError("You have already received the Wynaut egg in your saved game.")
-        if encounter[2] in ["Wynaut", "Togepi"] and save_data.get_party()[0].ability.name not in [
-            "Flame Body",
-            "Magma Armor",
-        ]:
-            console.print(
-                "[bold yellow]WARNING: First Pokemon in party does not have Flame Body / Magma Armor ability."
-            )
-            console.print("[bold yellow]This will slow down the egg hatching process.")
+        if encounter[2] in ["Wynaut", "Togepi"] and not any(
+            pokemon.ability.name
+            in [
+                "Flame Body",
+                "Magma Armor",
+            ]
+            for pokemon in save_data.get_party()
+        ):
+            console.print("[bold yellow]WARNING: None of your Pokémon has the Flame Body / Magma Armor ability.[/]")
+            console.print("[yellow]Hatching will take twice as long this way.[/]")
         if encounter[2] == "Togepi":
             if save_data.get_event_flag("GOT_TOGEPI_EGG"):
                 raise BotModeError("You have already received the Togepi egg in your saved game.")

--- a/modules/modes/sudowoodo.py
+++ b/modules/modes/sudowoodo.py
@@ -25,7 +25,7 @@ class SudowoodoMode(BotMode):
     def on_battle_started(self) -> BattleAction | None:
         opponent = get_opponent()
         if judge_encounter(opponent).is_of_interest:
-            return handle_encounter(get_opponent(), disable_auto_catch=True)
+            return handle_encounter(opponent, disable_auto_catch=True)
         log_encounter(opponent)
         return BattleAction.CustomAction
 

--- a/modules/web/http.py
+++ b/modules/web/http.py
@@ -302,7 +302,7 @@ def http_server(host: str, port: int) -> web.AppRunner:
 
         return web.json_response(effective_encounters.value.to_dict())
 
-    @route.get("/map/{map_group:\d+}/{map_number:\d+}")
+    @route.get("/map/{map_group:\\d+}/{map_number:\\d+}")
     async def http_get_map_by_group_and_number(request: web.Request):
         """
         ---


### PR DESCRIPTION
### Description

This fixes two issues:

(1) Affecting **Static Gift Resets with Togepi and Wynaut:** When hatching an egg, the `EggHatchListener` is logging the encounter. But the SGR mode itself also logs the encounter after 'looking' at the summary screen before resetting. So the encounter got logged twice.

I've fixed this by (a) adding a missing check in `log_encounter()` whether the Personality Value of an encounter matches the previous one, and (b) removing the encounter-logging from `EggHatchListener` and have the mode do that. I've updated Daycare mode as well, the only other one that does hatching.

Also, this mode was still warning about Magma Armor/Flame Body missing if such a Pokémon is in the player's party, but not in the first slot. Changed that.

(2) And then, affecting **Static Soft Resets** and **Sudowoodo** modes (and possibly others): When resetting the emulator, the `BattleListener` would not reset itself and continue thinking that it's mid-battle.

Thus, it would never register another encounter until a battle actually _ended_, which in these modes never occurs.

I've fixed this by letting the listener compare the emulator's frame counter. If it's suddenly _less_ than before, it resets its state.

(Also fixes a syntax warning in the HTTP server.)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
