### PR TITLE
Add missing `COMMIT` after creating stats DB

### DIFF
--- a/modules/stats.py
+++ b/modules/stats.py
@@ -1281,3 +1281,4 @@ class StatsDatabase:
 
         self._cursor.execute("DELETE FROM schema_version")
         self._cursor.execute("INSERT INTO schema_version VALUES (?)", (current_schema_version,))
+        self._connection.commit()


### PR DESCRIPTION
### Description

Each time when starting, the bot reads the `schema_version` table in `stats.db` and verifies that it's equal to the current schema version.

This is so that in the future we can have migration code that will convert users' databases from one schema to another.

If this table does not exist (or is empty) the bot will attempt to initialise the schema. Then, it writes the current schema version to the `schema_version` table.

Unfortunately, I forgot a `COMMIT` after that `INSERT` statement -- so the database transaction was still 'open' until another write was made (i.e. an encounter happened.)

If the user closed a new profile _before_ anything else was written, the `schema_version` table would remain empty and lead to an error message during the next start of that profile.

<!-- A brief overview of what the PR achieves -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
