### PR TITLE
Fix handling of fainted Pokémon in non-English games

### DIFF
--- a/modules/battle_action_selection.py
+++ b/modules/battle_action_selection.py
@@ -82,7 +82,7 @@ def handle_battle_action_selection(strategy: BattleStrategy) -> Generator:
                 if index.battle_use in (ItemBattleUse.Healing, ItemBattleUse.PpRecovery) and target_index is None:
                     raise RuntimeError(f"Item `{index.name}` needs a target Pokémon.")
 
-                yield from battle_action_use_item(index, target_index)
+                yield from battle_action_use_item(battle_state, index, target_index)
 
             case TurnAction.RotateLead:
                 if index >= len(get_party()):
@@ -155,7 +155,7 @@ def handle_battle_action_selection(strategy: BattleStrategy) -> Generator:
 
 
 @debug.track
-def battle_action_use_item(item: Item, target_index: int = 0):
+def battle_action_use_item(battle_state: BattleState, item: Item, target_index: int = 0):
     yield from scroll_to_battle_action(1)
     context.emulator.press_button("A")
     yield
@@ -166,7 +166,8 @@ def battle_action_use_item(item: Item, target_index: int = 0):
     context.emulator.press_button("A")
     yield
     if target_index is not None:
-        yield from scroll_to_party_menu_index(target_index)
+        in_battle_index = battle_state.map_battle_party_index(target_index)
+        yield from scroll_to_party_menu_index(in_battle_index)
         context.emulator.press_button("A")
         yield
         while get_game_state_symbol() != "BATTLEMAINCB2":

--- a/modules/data/symbols/patches/language/pokeemerald.json
+++ b/modules/data/symbols/patches/language/pokeemerald.json
@@ -409,6 +409,13 @@
       "J":"8288d8a",
       "S":"82e1f8e"
     },
+    "BattleScript_FaintedMonTryChoose":{
+      "D":"82f0556",
+      "F":"82e37ea",
+      "I":"82db7a2",
+      "J":"8288d9e",
+      "S":"82e1fa2"
+    },
     "EventScript_TrainerApproach":{
       "D":"827ca57",
       "F":"8276617",


### PR DESCRIPTION
### Description

In non-English versions of Emerald, there was a symbol missing and because of that the bot didn't detect that it was already _past_ the selection of a new lead.

So it tried to start the faint handling again and got stuck in a loop.

Also, there was an issue with `TurnAction.use_item_on(item, party_index)`, where it wouldn't map the party index to the in-battle party order. That meant that it sometimes chose the wrong Pokémon to use the item on.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
