### PR TITLE
Fix faint handling if the battle ended

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.json
+++ b/modules/data/symbols/patches/language/pokeemerald.json
@@ -416,6 +416,13 @@
       "J":"8288d9e",
       "S":"82e1fa2"
     },
+    "BattleScript_FaintedMonEnd":{
+      "D":"82f0635",
+      "F":"82e38c9",
+      "I":"82db881",
+      "J":"8288e7d",
+      "S":"82e2081"
+    },
     "EventScript_TrainerApproach":{
       "D":"827ca57",
       "F":"8276617",


### PR DESCRIPTION
### Description

When the player's Pokémon faints, it's possible that the battle ends at the same time -- if moves like Explosion or Self Destruct, or recoil damage were involved _both_ battlers might have fainted.

In that case the bot kept waiting for a Yes/No question ('do you want to send in another Pokémon?') that never came.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
