### PR TITLE
Fix Misc debug tab for FR/LG

### DIFF
--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -853,7 +853,7 @@ class MiscTab(DebugTab):
 
         from modules.region_map import get_map_cursor
 
-        return {
+        block_data = {
             "Daycare": {
                 "__value": daycare_value,
                 "Pokémon #1": pokemon1,
@@ -869,9 +869,13 @@ class MiscTab(DebugTab):
             "Text Printer #1": get_text_printer(0),
             "gMain.state": read_symbol("gMain", offset=0x438, size=1)[0],
             "Fade Active": is_fade_active(),
-            "Local Time": get_clock_time(),
             "Play Time": get_play_time(),
         }
+
+        if not context.rom.is_frlg:
+            block_data["Local Time"] = get_clock_time()
+
+        return block_data
 
 
 class EventFlagsTab(DebugTab):


### PR DESCRIPTION
### Description

Misc debug was crashing in FR/LG since the games doesn't have an inner Clock

### Changes

Remove local time for FR/LG debug tab

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
