### PR TITLE
Fix TCG card, Starter mode, shiny reporting on console

### DIFF
--- a/modules/built_in_plugins/discord_integration.py
+++ b/modules/built_in_plugins/discord_integration.py
@@ -138,7 +138,7 @@ class DiscordPlugin(BotPlugin):
                         f"IVs ({opponent.ivs.sum()})": iv_table(opponent),
                         "Held item": opponent.held_item.name if opponent.held_item else "None",
                         f"{opponent.species_name_for_stats} Encounters": f"{species_stats.total_encounters:,} ({species_stats.shiny_encounters:,}✨)",
-                        f"{opponent.species_name_for_stats} Phase Encounters": f"{context.stats.last_shiny_species_phase_encounters:,}",
+                        f"{opponent.species_name_for_stats} Phase Encounters": f"{int(context.stats.last_shiny_species_phase_encounters):,}",
                     }
                     | phase_summary_fields(opponent, shiny_phase),
                     thumbnail=get_shiny_sprite(opponent),

--- a/modules/built_in_plugins/generate_encounter_media.py
+++ b/modules/built_in_plugins/generate_encounter_media.py
@@ -90,7 +90,9 @@ class GenerateEncounterMediaPlugin(BotPlugin):
             # Set the TCG card's path so that other plugins can use it.
             wild_encounter.tcg_card_path = cards_dir / file_name
 
-            Thread(target=generate_tcg_card, args=(wild_encounter.pokemon, wild_encounter.pokemon.location_met)).start()
+            Thread(
+                target=generate_tcg_card, args=(wild_encounter.pokemon.data, wild_encounter.pokemon.location_met)
+            ).start()
 
         return None
 

--- a/modules/clock.py
+++ b/modules/clock.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from modules.context import context
 from modules.memory import read_symbol, unpack_uint16, get_save_block
 
 
@@ -26,6 +27,10 @@ def get_clock_time() -> ClockTime:
              not update this value all the time, so it is normal for it to return the
              same value when called multiple times within a couple of seconds.
     """
+
+    # There is no RTC-based clock in FR/LG.
+    if context.rom.is_frlg:
+        return ClockTime(0, 0, 0, 0)
 
     data = read_symbol("gLocalTime")
     return ClockTime(unpack_uint16(data[0:2]), data[2], data[3], data[4])

--- a/modules/discord.py
+++ b/modules/discord.py
@@ -3,7 +3,6 @@ import time
 from asyncio import Queue, set_event_loop, new_event_loop, AbstractEventLoop
 from dataclasses import dataclass
 from pathlib import Path
-from threading import Thread
 
 from discord_webhook import DiscordEmbed, DiscordWebhook
 from pypresence import Presence
@@ -61,7 +60,7 @@ async def _process_message(message: DiscordMessage) -> None:
 
     async def wait_for_image_file_to_exist(image_file: Path) -> bool:
         nonlocal allowed_wait_time_in_seconds
-        while not image_file.exists() or image_file.stat().st_size == 0:
+        while (not image_file.exists() or image_file.stat().st_size == 0) and allowed_wait_time_in_seconds > 0:
             await asyncio.sleep(0.5)
             allowed_wait_time_in_seconds -= 0.5
 

--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -111,8 +111,8 @@ def log_encounter(pokemon: "Pokemon", action: BattleAction | None = None) -> Non
         return
 
     ccf_result = run_custom_catch_filters(pokemon)
-    context.stats.log_encounter(pokemon, ccf_result)
     print_stats(context.stats.get_global_stats(), pokemon)
+    context.stats.log_encounter(pokemon, ccf_result)
     if context.config.logging.save_pk3.all:
         save_pk3(pokemon)
 

--- a/modules/tcg_card.py
+++ b/modules/tcg_card.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from PIL import Image, ImageDraw, ImageFont
 
+from modules.console import console
 from modules.context import context
 from modules.files import make_string_safe_for_file_name
 from modules.player import get_player, get_player_avatar
@@ -56,7 +57,9 @@ def get_tcg_card_file_name(pokemon: Pokemon) -> str:
     )
 
 
-def generate_tcg_card(pokemon: Pokemon, location: str = "") -> Path | None:
+def generate_tcg_card(pokemon_data: bytes, location: str = "") -> Path | None:
+    pokemon = Pokemon(pokemon_data)
+
     try:
         tcg_sprites = get_sprites_path() / "tcg"
 
@@ -304,11 +307,12 @@ def generate_tcg_card(pokemon: Pokemon, location: str = "") -> Path | None:
         file_name = get_tcg_card_file_name(pokemon)
         tmp_card_file = cards_dir / (file_name + ".tmp")
         card_file = cards_dir / file_name
-        card.save(tmp_card_file)
+        card.save(tmp_card_file, format="png")
 
         os.replace(tmp_card_file, card_file)
 
         return card_file
 
     except Exception:
+        console.print_exception()
         return None


### PR DESCRIPTION
### Description

Collection of smaller fixes:

(1) **Starters** mode on R/S/E no longer checks for both Pokémon cries to happen. This wasn't the case if the opponent Poochyena/Zigzagoon happened to be shiny and in that case the bot would get stuck. No more.

(2) A shiny encounter is now reported to the console _before_ it is logged by the stats system. That means that all the old shiny phase data is still available at that point, rather than being completely empty. It also means that the shiny's stats aren't included in the totals, but I guess that's OK.

(3) Added a failsafe in the `get_clock_time()` to report a zeroed-out time on FR/LG where there is no RTC system, rather than unceremoniously crashing.

(4) TCG card generation was broken because we are now first saving the image in a temporary file with a `.tmp` extension, which meant that PIL didn't know what format to use and silently failed.

I've added error reporting to the TCG card generation and fixed that particular issue.

(5) Possibly related to that, the Discord plugin had a mistake where it would indefinitely wait for an image file to appear. I intended there to be a timeout, but that was never actually checked.

This meant that if TCG card generation was enabled, it would just get stuck after the first shiny because it would wait forever for that card image to become available.

<!-- A brief overview of what the PR achieves -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
