### PR TITLE
Fix logging of non-battle encounters (egg hatching, gift Pokémon, etc.)

### DIFF
--- a/modules/battle_state.py
+++ b/modules/battle_state.py
@@ -831,6 +831,8 @@ class EncounterType(Enum):
     FishingWithGoodRod = "fishing_good_rod"
     FishingWithSuperRod = "fishing_super_rod"
     RockSmash = "rock_smash"
+    Hatched = "hatched"
+    Gift = "gift"
 
     @property
     def is_wild(self) -> bool:
@@ -844,8 +846,21 @@ class EncounterType(Enum):
             EncounterType.FishingWithSuperRod,
         )
 
+    @property
+    def verb(self) -> str:
+        if self is EncounterType.Hatched:
+            return "hatched"
+        elif self is EncounterType.Gift:
+            return "received"
+        else:
+            return "encountered"
+
 
 def get_encounter_type() -> EncounterType:
+    script_stack = get_global_script_context().stack
+    if "EventScript_EggHatch" in script_stack or "S_EggHatch" in script_stack:
+        return EncounterType.Hatched
+
     battle_type = get_battle_type()
 
     if BattleType.WallyTutorial in battle_type:
@@ -877,7 +892,6 @@ def get_encounter_type() -> EncounterType:
         ):
             return EncounterType.Static
 
-    script_stack = get_global_script_context().stack
     if "EventScript_BattleKecleon" in script_stack:
         return EncounterType.Static
     if "BattleFrontier_OutsideEast_EventScript_WaterSudowoodo" in script_stack:

--- a/modules/built_in_plugins/obs.py
+++ b/modules/built_in_plugins/obs.py
@@ -19,7 +19,7 @@ from modules.discord import discord_send, DiscordMessage
 from modules.plugin_interface import BotPlugin
 
 if TYPE_CHECKING:
-    from modules.encounter import ActiveWildEncounter
+    from modules.encounter import EncounterInfo
     from modules.profiles import Profile
 
 
@@ -111,17 +111,17 @@ class OBSPlugin(BotPlugin):
     def on_profile_loaded(self, profile: "Profile") -> None:
         Thread(target=_obs_thread, args=(self._task_queue,)).start()
 
-    def on_wild_encounter_visible(self, wild_encounter: "ActiveWildEncounter") -> Generator | None:
-        if not wild_encounter.value.is_of_interest:
+    def on_logging_encounter(self, encounter: "EncounterInfo") -> Generator | None:
+        if not encounter.is_of_interest:
             return
 
         # Save a screenshot of the OBS output after encountering a Pokémon of interest.
         if context.config.obs.screenshot:
-            if wild_encounter.pokemon.is_shiny:
+            if encounter.pokemon.is_shiny:
                 self._task_queue.put("save_screenshot_and_send_to_discord")
             else:
                 self._task_queue.put("save_screenshot")
 
         # Save OBS replay buffer n seconds after encountering a shiny.
-        if context.config.obs.replay_buffer and wild_encounter.pokemon.is_shiny:
+        if context.config.obs.replay_buffer and encounter.pokemon.is_shiny:
             self._task_queue.put("save_replay_buffer")

--- a/modules/console.py
+++ b/modules/console.py
@@ -4,11 +4,12 @@ from rich.console import Console
 from rich.table import Table
 from rich.theme import Theme
 
+from modules.battle_state import EncounterType
 from modules.context import context
 
 if TYPE_CHECKING:
-    from modules.pokemon import Pokemon
-    from modules.stats import GlobalStats, EncounterSummary, SpeciesRecord
+    from modules.encounter import EncounterInfo
+    from modules.stats import GlobalStats, EncounterSummary
 
 theme = Theme(
     {
@@ -75,13 +76,14 @@ def sv_colour(value: "SpeciesRecord | int | None") -> str:
         return "red"
 
 
-def print_stats(stats: "GlobalStats", pokemon: "Pokemon") -> None:
+def print_stats(stats: "GlobalStats", encounter: "EncounterInfo") -> None:
+    pokemon = encounter.pokemon
     type_colour = pokemon.species.types[0].name.lower()
     rich_name = f"[{type_colour}]{pokemon.species_name_for_stats}[/]"
 
     match context.config.logging.console.encounter_data:
         case "verbose":
-            console.rule(f"\n{rich_name} encountered at {pokemon.location_met}", style=type_colour)
+            console.rule(f"\n{rich_name} {encounter.type.verb} at {pokemon.location_met}", style=type_colour)
             pokemon_table = Table()
             pokemon_table.add_column("PID", justify="center", width=10)
             pokemon_table.add_column("Level", justify="center")
@@ -103,7 +105,7 @@ def print_stats(stats: "GlobalStats", pokemon: "Pokemon") -> None:
             )
             console.print(pokemon_table)
         case "basic":
-            console.rule(f"\n{rich_name} encountered at {pokemon.location_met}", style=type_colour)
+            console.rule(f"\n{rich_name} {encounter.type.verb} at {pokemon.location_met}", style=type_colour)
             console.print(
                 f"{rich_name}: PID: {str(hex(pokemon.personality_value)[2:]).upper()} | "
                 f"Lv: {pokemon.level:,} | "

--- a/modules/modes/_interface.py
+++ b/modules/modes/_interface.py
@@ -7,10 +7,9 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Generator, Optional, TYPE_CHECKING
 
-from modules.battle_strategies import BattleStrategy
-
 if TYPE_CHECKING:
     from modules.battle_state import BattleOutcome
+    from modules.encounter import EncounterInfo
     from modules.memory import GameState
     from modules.pokemon import Pokemon
 
@@ -65,13 +64,15 @@ class BotMode:
         """
         raise NotImplementedError
 
-    def on_battle_started(self) -> BattleAction | BattleStrategy | None:
+    def on_battle_started(self, encounter: "EncounterInfo | None") -> "BattleAction | BattleStrategy | None":
         """
         This is called when a battle starts, i.e. a wild Pokémon is encountered or a trainer
         battle commenced.
 
         When this method is called, the game state is already `GameState.BATTLE`.
 
+        :param encounter: For wild encounters, information about the encounter. Otherwise (like in
+                          trainer battles) this is None.
         :return: What to do when the battle starts:
                  - `None` will lead to the default behaviour of `handle_encounter()`
                  - `BattleAction.RunAway` will run away from the battle, unless it is a trainer.
@@ -189,14 +190,14 @@ class BotMode:
         """
         return False
 
-    def on_egg_hatched(self, pokemon: "Pokemon", party_index: int) -> None:
+    def on_egg_hatched(self, encounter: "EncounterInfo", party_index: int) -> None:
         """
         This is called when an egg is hatching.
 
         The bot will call this method when the hatched Pokémon's sprite is
         visible during the cutscene.
 
-        :param pokemon: The Pokémon that has hatched.
+        :param encounter: Information about the Pokémon that has hatched.
         :param party_index: Party index (0-5) of the Pokémon that has hatched.
         """
         pass

--- a/modules/modes/_listeners.py
+++ b/modules/modes/_listeners.py
@@ -1,12 +1,12 @@
-from datetime import datetime
 from types import GeneratorType
+from typing import Iterable
 
 from modules.context import context
 from modules.debug import debug
-from modules.encounter import handle_encounter, ActiveWildEncounter, run_custom_catch_filters, judge_encounter
+from modules.encounter import handle_encounter, EncounterInfo, log_encounter
 from modules.map import get_map_objects, get_map_data_for_current_position
 from modules.map_data import MapFRLG, MapRSE
-from modules.memory import GameState, get_game_state, get_game_state_symbol, read_symbol, unpack_uint32
+from modules.memory import GameState, get_game_state, get_game_state_symbol, read_symbol, unpack_uint32, unpack_uint16
 from modules.menuing import CheckForPickup, MenuWrapper, should_check_for_pickup, RotatePokemon
 from modules.player import TileTransitionState, get_player_avatar, player_avatar_is_standing_still
 from modules.pokemon import StatusCondition, clear_opponent, get_opponent, get_party
@@ -14,7 +14,15 @@ from modules.tasks import get_global_script_context, task_is_active, get_task
 from ._interface import BattleAction, BotListener, BotMode, FrameInfo
 from .util import isolate_inputs, save_the_game
 from ..battle_handler import handle_battle
-from ..battle_state import get_last_battle_outcome, BattleOutcome, get_encounter_type, EncounterType
+from ..battle_state import (
+    get_last_battle_outcome,
+    BattleOutcome,
+    get_encounter_type,
+    EncounterType,
+    get_battle_state,
+    BattleType,
+    get_main_battle_callback,
+)
 from ..battle_strategies import DefaultBattleStrategy, BattleStrategy
 from ..battle_strategies.catch import CatchStrategy
 from ..battle_strategies.run_away import RunAwayStrategy
@@ -25,8 +33,28 @@ from ..plugins import (
     plugin_whiteout,
     plugin_egg_hatched,
     plugin_wild_encounter_visible,
+    plugin_egg_starting_to_hatch,
 )
 from ..text_printer import get_text_printer, TextPrinterState
+
+
+def _ensure_plugin_hook_will_run(generator: Iterable) -> None:
+    """
+    Executes a plugin hook.
+
+    This will either add the generator to the controller stack (which means it will be
+    run for each frame -- which could be used to add delays etc.)
+
+    Or, if the bot is in Manual mode and thus the controller stack would not be executed
+    it will unroll the generator loop right here and now.
+
+    :param generator: The generator to be executed.
+    """
+    if context.bot_mode == "Manual":
+        for _ in generator:
+            pass
+    else:
+        context.controller_stack.append(generator)
 
 
 class BattleListener(BotListener):
@@ -36,9 +64,9 @@ class BattleListener(BotListener):
         self._in_battle = False
         self._battle_start_frame: int = 0
         self._reported_start_of_battle = False
-        self._active_wild_encounter: ActiveWildEncounter | None = None
+        self._active_wild_encounter: EncounterInfo | None = None
         self._reported_wild_encounter_visible = False
-        self._text_printer_was_active = False
+        self._was_starting_to_become_visible = False
         self._reported_end_of_battle = False
         self._current_action: BattleAction | None = None
 
@@ -51,31 +79,35 @@ class BattleListener(BotListener):
             self._reported_start_of_battle = False
             self._active_wild_encounter = None
             self._reported_wild_encounter_visible = False
-            self._text_printer_was_active = False
+            self._was_starting_to_become_visible = False
             self._reported_end_of_battle = False
             self._current_action = None
 
         elif self._in_battle and not self._reported_start_of_battle and get_game_state() == GameState.BATTLE:
             self._reported_start_of_battle = True
-            action = bot_mode.on_battle_started()
             encounter_type = get_encounter_type()
             opponent = get_opponent()
 
+            if encounter_type not in (EncounterType.Trainer, EncounterType.Tutorial):
+                if BattleType.FirstBattle in get_battle_state().type:
+                    self._active_wild_encounter = EncounterInfo.create(get_party()[0])
+                else:
+                    self._active_wild_encounter = EncounterInfo.create(opponent)
+            else:
+                self._active_wild_encounter = None
+
+            action = bot_mode.on_battle_started(self._active_wild_encounter)
+
             if encounter_type is EncounterType.Trainer and not isinstance(action, BattleStrategy):
                 action = BattleAction.Fight
+            elif encounter_type is EncounterType.Tutorial:
+                action = BattleAction.CustomAction
             elif action is None:
-                action = handle_encounter(opponent)
+                action = handle_encounter(self._active_wild_encounter)
 
-            if encounter_type not in (EncounterType.Trainer, EncounterType.Tutorial):
-                self._active_wild_encounter = ActiveWildEncounter(
-                    pokemon=opponent,
-                    encounter_time=datetime.now(),
-                    type=encounter_type,
-                    value=judge_encounter(opponent),
-                    catch_filters_result=run_custom_catch_filters(opponent),
-                )
-
-            if isinstance(action, BattleStrategy):
+            if context.bot_mode == "Manual":
+                _ensure_plugin_hook_will_run(plugin_battle_started(self._active_wild_encounter))
+            elif isinstance(action, BattleStrategy):
                 context.controller_stack.append(self.fight(action))
             elif action == BattleAction.Fight:
                 context.controller_stack.append(self.fight(DefaultBattleStrategy()))
@@ -83,6 +115,8 @@ class BattleListener(BotListener):
                 context.controller_stack.append(self.run_away_from_battle())
             elif action == BattleAction.Catch:
                 context.controller_stack.append(self.catch())
+            else:
+                _ensure_plugin_hook_will_run(plugin_battle_started(self._active_wild_encounter))
 
             self._current_action = action
 
@@ -97,6 +131,8 @@ class BattleListener(BotListener):
                 self._reported_end_of_battle = True
                 clear_opponent()
                 bot_mode.on_battle_ended(outcome)
+                _ensure_plugin_hook_will_run(plugin_battle_ended(outcome))
+                context.stats.log_end_of_battle(outcome)
 
             if (
                 get_game_state_symbol() != "CB2_RETURNTOFIELD"
@@ -114,15 +150,38 @@ class BattleListener(BotListener):
                     )
 
         elif self._active_wild_encounter is not None and not self._reported_wild_encounter_visible:
-            text_printer = get_text_printer(0)
+            if BattleType.FirstBattle not in get_battle_state().type:
+                # For regular battle encounter, we want to wait until the 'Wild {SPECIES} appeared!'
+                # message and then trigger the `on_wild_encounter_visible()` callbacks as well as do
+                # the logging.
+                text_printer = get_text_printer()
+                is_finally_visible = not text_printer.active or text_printer.state == TextPrinterState.WaitForButton
+                is_starting_to_become_visible = text_printer.active
+            else:
+                # For the first battle on R/S/E we are actually interested in the player's starter
+                # Pokémon and not in the opponent. So we need to wait a bit longer until the starter
+                # becomes visible, hence the different trigger conditions.
+                first_turn_callback = "TryDoEventsBeforeFirstTurn" if context.rom.is_emerald else "BattleBeginFirstTurn"
+                main_battle_callback = get_main_battle_callback()
+                is_finally_visible = main_battle_callback != first_turn_callback
+                is_starting_to_become_visible = get_main_battle_callback() == first_turn_callback
 
-            if self._text_printer_was_active:
-                if not text_printer.active or text_printer.state == TextPrinterState.WaitForButton:
-                    context.controller_stack.append(plugin_wild_encounter_visible(self._active_wild_encounter))
+            if self._was_starting_to_become_visible:
+                if is_finally_visible:
+
+                    def report_visible():
+                        # First, run the `on_wild_encounter_visible()` callbacks -- which might
+                        # introduce some delay, so we want to wait for that.
+                        yield from plugin_wild_encounter_visible(self._active_wild_encounter)
+
+                        # Then log the encounter.
+                        log_encounter(self._active_wild_encounter)
+
+                    _ensure_plugin_hook_will_run(report_visible())
                     self._reported_wild_encounter_visible = True
 
-            elif text_printer.active:
-                self._text_printer_was_active = True
+            elif is_starting_to_become_visible:
+                self._was_starting_to_become_visible = True
 
         elif context.emulator.get_frame_count() < self._battle_start_frame:
             self._in_battle = False
@@ -138,11 +197,9 @@ class BattleListener(BotListener):
     @isolate_inputs
     @debug.track
     def fight(self, strategy: BattleStrategy):
-        yield from plugin_battle_started(get_opponent(), self._active_wild_encounter)
+        yield from plugin_battle_started(self._active_wild_encounter)
         yield from handle_battle(strategy)
         yield from self._wait_until_battle_is_over()
-        context.stats.log_end_of_battle(BattleOutcome(read_symbol("gBattleOutcome", size=1)[0]))
-        yield from plugin_battle_ended(outcome=BattleOutcome(read_symbol("gBattleOutcome", size=1)[0]))
 
         if (
             get_game_state() != GameState.BATTLE
@@ -171,11 +228,9 @@ class BattleListener(BotListener):
     @isolate_inputs
     @debug.track
     def catch(self):
-        yield from plugin_battle_started(get_opponent(), self._active_wild_encounter)
+        yield from plugin_battle_started(self._active_wild_encounter)
         yield from handle_battle(CatchStrategy())
         yield from self._wait_until_battle_is_over()
-        context.stats.log_end_of_battle(BattleOutcome(read_symbol("gBattleOutcome", size=1)[0]))
-        yield from plugin_battle_ended(outcome=BattleOutcome(read_symbol("gBattleOutcome", size=1)[0]))
         if context.config.battle.save_after_catching:
             yield from save_the_game()
 
@@ -184,11 +239,9 @@ class BattleListener(BotListener):
     def run_away_from_battle(self):
         while get_game_state() != GameState.BATTLE:
             yield
-        yield from plugin_battle_started(get_opponent(), self._active_wild_encounter)
+        yield from plugin_battle_started(self._active_wild_encounter)
         yield from handle_battle(RunAwayStrategy())
         yield from self._wait_until_battle_is_over()
-        context.stats.log_end_of_battle(BattleOutcome(read_symbol("gBattleOutcome", size=1)[0]))
-        yield from plugin_battle_ended(outcome=BattleOutcome(read_symbol("gBattleOutcome", size=1)[0]))
 
 
 class TrainerApproachListener(BotListener):
@@ -277,6 +330,9 @@ class PokenavListener(BotListener):
 class EggHatchListener(BotListener):
     def __init__(self):
         self._is_hatching = False
+        self._hatching_party_index: int = 0
+        self._encounter_info: EncounterInfo | None = None
+        self._reported_hatched_egg = False
         if context.rom.is_rs:
             self._script_name = "S_EggHatch"
             self._symbol_name = "gEggHatchData"
@@ -289,27 +345,38 @@ class EggHatchListener(BotListener):
             not self._is_hatching and frame.script_is_active(self._script_name)
         ):
             self._is_hatching = True
-            context.controller_stack.append(self.handle_hatching_egg(bot_mode))
+            self._reported_hatched_egg = False
+            self._hatching_party_index = unpack_uint16(read_symbol("gSpecialVar_0x8004"))
+            self._encounter_info = EncounterInfo.create(get_party()[self._hatching_party_index], EncounterType.Hatched)
+            if context.bot_mode != "Manual":
+                context.controller_stack.append(self.handle_hatching_egg())
+            else:
+                _ensure_plugin_hook_will_run(plugin_egg_starting_to_hatch(self._encounter_info))
+        elif self._is_hatching and not frame.script_is_active(self._script_name):
+            if not self._reported_hatched_egg and self._encounter_info is not None:
+                log_encounter(self._encounter_info)
+            self._is_hatching = False
+            self._reported_hatched_egg = False
+            self._encounter_info = None
+        elif self._is_hatching and not self._reported_hatched_egg and frame.script_is_active(self._script_name):
+            egg_data_pointer = unpack_uint32(read_symbol(self._symbol_name))
+            if egg_data_pointer & 0x0200_0000:
+                egg_data = context.emulator.read_bytes(egg_data_pointer, length=16)
+                if egg_data[2] >= 6:
+                    self._encounter_info.pokemon = get_party()[self._hatching_party_index]
+                    bot_mode.on_egg_hatched(self._encounter_info, self._hatching_party_index)
+
+                    def report_hatched():
+                        yield from plugin_egg_hatched(self._encounter_info)
+                        handle_encounter(self._encounter_info)
+
+                    _ensure_plugin_hook_will_run(report_hatched())
+                    self._reported_hatched_egg = True
 
     @isolate_inputs
     @debug.track
-    def handle_hatching_egg(self, bot_mode: BotMode):
-        while True:
-            egg_data = None
-            if get_game_state() == GameState.EGG_HATCH:
-                yield
-                egg_data_pointer = unpack_uint32(read_symbol(self._symbol_name))
-                if egg_data_pointer & 0x0200_0000:
-                    egg_data = context.emulator.read_bytes(egg_data_pointer, length=16)
-            if egg_data is None or egg_data[2] < 4:
-                context.emulator.press_button("B")
-                yield
-            else:
-                party_index = egg_data[4]
-                break
-        hatched_pokemon = get_party()[party_index]
-        bot_mode.on_egg_hatched(hatched_pokemon, party_index)
-        plugin_egg_hatched(hatched_pokemon)
+    def handle_hatching_egg(self):
+        yield from plugin_egg_starting_to_hatch(self._encounter_info)
         while self._script_name in get_global_script_context().stack:
             context.emulator.press_button("B")
             yield

--- a/modules/modes/feebas.py
+++ b/modules/modes/feebas.py
@@ -6,7 +6,7 @@ from modules.items import get_item_by_name, get_item_bag
 from modules.map import get_map_data
 from modules.map_data import MapRSE
 from modules.player import get_player, get_player_avatar, AvatarFlags
-from modules.pokemon import get_opponent, get_party
+from modules.pokemon import get_party
 from . import BattleAction
 from ._interface import BotMode, BotModeError
 from .util import (
@@ -17,8 +17,8 @@ from .util import (
     wait_for_task_to_start_and_finish,
     walk_one_tile,
 )
-from ..battle_state import get_encounter_type
 from ..clock import ClockTime, get_clock_time
+from ..encounter import EncounterInfo
 from ..memory import get_event_flag
 
 # How many times the bot tries to fish on the same tile before it deems it
@@ -130,14 +130,14 @@ class FeebasMode(BotMode):
         self._can_use_waterfall: bool = False
         super().__init__()
 
-    def on_battle_started(self) -> BattleAction | None:
-        if get_encounter_type().is_fishing:
+    def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | None:
+        if encounter.type.is_fishing:
             # Feebas tiles change each in-game day (based on RTC)
             if self._found_feebas is not None and self._found_feebas.days != get_clock_time().days:
                 self._found_feebas = None
                 self._fishing_spots.reset(self._can_use_waterfall)
 
-            if get_opponent().species.name == "Feebas":
+            if encounter.pokemon.species.name == "Feebas":
                 self._found_feebas = get_clock_time()
             else:
                 spot = self._fishing_spots.get_by_coordinates(get_player_avatar().map_location_in_front.local_position)

--- a/modules/modes/game_corner.py
+++ b/modules/modes/game_corner.py
@@ -1,7 +1,7 @@
 from typing import Generator
 
 from modules.context import context
-from modules.encounter import handle_encounter
+from modules.encounter import handle_encounter, EncounterInfo
 from modules.gui.multi_select_window import Selection, ask_for_choice
 from modules.map_data import MapFRLG
 from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
@@ -19,6 +19,7 @@ from .util import (
     wait_for_unique_rng_value,
     wait_until_task_is_active,
 )
+from ..battle_state import EncounterType
 
 
 class GameCornerMode(BotMode):
@@ -125,4 +126,8 @@ class GameCornerMode(BotMode):
             yield from StartMenuNavigator("POKEMON").step()
             yield from PokemonPartyMenuNavigator(len(get_party()) - 1, "summary").step()
 
-            handle_encounter(get_party()[-1], disable_auto_catch=True, do_not_log_battle_action=True)
+            handle_encounter(
+                EncounterInfo.create(get_party()[-1], EncounterType.Gift),
+                disable_auto_catch=True,
+                do_not_log_battle_action=True,
+            )

--- a/modules/modes/kecleon.py
+++ b/modules/modes/kecleon.py
@@ -1,11 +1,11 @@
 from typing import Generator
 
 from modules.context import context
-from modules.encounter import handle_encounter
+from modules.encounter import handle_encounter, EncounterInfo
 from modules.map_data import MapRSE
 from modules.memory import get_event_flag
 from modules.player import get_player_avatar
-from modules.pokemon import get_opponent, get_party
+from modules.pokemon import get_party
 from modules.save_data import get_last_heal_location
 from . import BattleAction
 from ._asserts import (
@@ -34,8 +34,8 @@ class KecleonMode(BotMode):
         super().__init__()
         self._has_whited_out = False
 
-    def on_battle_started(self) -> BattleAction | BattleStrategy | None:
-        handle_encounter(get_opponent(), disable_auto_catch=True, enable_auto_battle=True)
+    def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | BattleStrategy | None:
+        handle_encounter(encounter, disable_auto_catch=True, enable_auto_battle=True)
         return LoseOnPurposeBattleStrategy()
 
     def on_whiteout(self) -> bool:

--- a/modules/modes/level_grind.py
+++ b/modules/modes/level_grind.py
@@ -6,13 +6,13 @@ from modules.map_data import MapFRLG, MapRSE, PokemonCenter, get_map_enum
 from modules.map_path import calculate_path, PathFindingError
 from modules.modes import BattleAction
 from modules.player import get_player_avatar
-from modules.pokemon import get_party, get_opponent, StatusCondition
+from modules.pokemon import get_party, StatusCondition
 from ._interface import BotMode, BotModeError
 from .util import navigate_to, heal_in_pokemon_center, change_lead_party_pokemon, spin
 from ..battle_state import BattleOutcome
 from ..battle_strategies import BattleStrategy, DefaultBattleStrategy
 from ..battle_strategies.level_balancing import LevelBalancingBattleStrategy
-from ..encounter import handle_encounter
+from ..encounter import handle_encounter, EncounterInfo
 from ..gui.multi_select_window import ask_for_choice, Selection
 from ..runtime import get_sprites_path
 from ..sprites import get_sprite
@@ -70,8 +70,8 @@ class LevelGrindMode(BotMode):
         self._go_healing = True
         self._level_balance = False
 
-    def on_battle_started(self) -> BattleAction | BattleStrategy | None:
-        action = handle_encounter(get_opponent(), enable_auto_battle=True)
+    def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | BattleStrategy | None:
+        action = handle_encounter(encounter, enable_auto_battle=True)
         if action is BattleAction.Fight:
             if self._level_balance:
                 return LevelBalancingBattleStrategy()

--- a/modules/modes/nugget_bridge.py
+++ b/modules/modes/nugget_bridge.py
@@ -11,6 +11,7 @@ from ._interface import BotMode, BotModeError
 from .util import navigate_to, wait_for_player_avatar_to_be_standing_still
 from ..battle_strategies import BattleStrategy
 from ..battle_strategies.lose_on_purpose import LoseOnPurposeBattleStrategy
+from ..encounter import EncounterInfo
 
 
 class NuggetBridgeMode(BotMode):
@@ -33,7 +34,7 @@ class NuggetBridgeMode(BotMode):
         super().__init__()
         self._has_whited_out = False
 
-    def on_battle_started(self) -> BattleAction | BattleStrategy | None:
+    def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | BattleStrategy | None:
         return LoseOnPurposeBattleStrategy()
 
     def on_whiteout(self) -> bool:

--- a/modules/modes/puzzle_solver.py
+++ b/modules/modes/puzzle_solver.py
@@ -24,8 +24,7 @@ from .util import (
     wait_for_no_script_to_run,
 )
 from ..battle_strategies import BattleStrategy
-from ..encounter import handle_encounter
-from ..pokemon import get_opponent
+from ..encounter import handle_encounter, EncounterInfo
 
 
 @debug.track
@@ -66,8 +65,8 @@ class PuzzleSolverMode(BotMode):
         else:
             return False
 
-    def on_battle_started(self) -> BattleAction | BattleStrategy | None:
-        return handle_encounter(get_opponent(), enable_auto_battle=True)
+    def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | BattleStrategy | None:
+        return handle_encounter(encounter, enable_auto_battle=True)
 
     def on_repel_effect_ended(self) -> None:
         yield from apply_repel()

--- a/modules/modes/roamer_reset.py
+++ b/modules/modes/roamer_reset.py
@@ -1,7 +1,7 @@
 from typing import Generator
 
 from modules.context import context
-from modules.encounter import EncounterValue, handle_encounter, judge_encounter, log_encounter
+from modules.encounter import EncounterValue, handle_encounter, log_encounter, EncounterInfo
 from modules.gui.multi_select_window import Selection, ask_for_choice
 from modules.items import get_item_by_name
 from modules.map_data import MapFRLG, MapRSE
@@ -10,7 +10,6 @@ from modules.modes.util.event_flags_and_vars import wait_until_event_flag_is_tru
 from modules.modes.util.tasks_scripts import wait_for_script_to_start_and_finish
 from modules.modes.util.walking import wait_for_player_avatar_to_be_controllable
 from modules.player import get_player, get_player_avatar
-from modules.pokemon import get_opponent
 from modules.region_map import FlyDestinationFRLG, FlyDestinationRSE
 from modules.runtime import get_sprites_path
 from modules.save_data import get_save_data
@@ -73,14 +72,13 @@ class RoamerResetMode(BotMode):
         except RanOutOfRepels:
             self._ran_out_of_repels = True
 
-    def on_battle_started(self) -> BattleAction | None:
+    def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | None:
         # This excludes `EncounterValue.Roamer` which should not lead to a notification being
         # triggered. _All_ encounters in this mode should be roamers.
-        opponent = get_opponent()
-        if judge_encounter(opponent) in (EncounterValue.Shiny, EncounterValue.CustomFilterMatch):
-            return handle_encounter(opponent, disable_auto_catch=True)
+        if encounter.value in (EncounterValue.Shiny, EncounterValue.CustomFilterMatch):
+            return handle_encounter(encounter, disable_auto_catch=True)
         self._should_reset = True
-        log_encounter(opponent)
+        log_encounter(encounter)
         return BattleAction.CustomAction
 
     def run(self) -> Generator:

--- a/modules/modes/rock_smash.py
+++ b/modules/modes/rock_smash.py
@@ -3,7 +3,7 @@ from typing import Generator
 
 from modules.context import context
 from modules.debug import debug
-from modules.encounter import handle_encounter
+from modules.encounter import handle_encounter, EncounterInfo
 from modules.gui.multi_select_window import Selection, ask_for_choice
 from modules.items import get_item_bag, get_item_by_name
 from modules.map_data import MapRSE
@@ -62,8 +62,8 @@ class RockSmashMode(BotMode):
         self._in_safari_zone = False
         return True
 
-    def on_battle_started(self) -> BattleAction | None:
-        return handle_encounter(get_opponent())
+    def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | None:
+        return handle_encounter(encounter)
 
     def on_repel_effect_ended(self) -> None:
         if self._using_repel:

--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -2,7 +2,7 @@ import random
 from typing import Generator
 
 from modules.context import context
-from modules.encounter import handle_encounter
+from modules.encounter import handle_encounter, EncounterInfo
 from modules.gui.multi_select_window import Selection, ask_for_choice
 from modules.map_data import MapFRLG, MapRSE
 from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
@@ -22,7 +22,7 @@ from .util import (
     wait_until_task_is_active,
     wait_until_task_is_not_active,
 )
-from ..battle_state import battle_is_active, get_main_battle_callback
+from ..battle_state import battle_is_active, get_main_battle_callback, EncounterType
 
 
 def run_frlg() -> Generator:
@@ -70,7 +70,11 @@ def run_frlg() -> Generator:
         # Spam 'A' until we see the summary screen
         yield from wait_until_task_is_active("Task_DuckBGMForPokemonCry", button_to_press="A")
 
-        handle_encounter(get_party()[0], disable_auto_catch=True, do_not_log_battle_action=True)
+        handle_encounter(
+            EncounterInfo.create(get_party()[0], EncounterType.Gift),
+            disable_auto_catch=True,
+            do_not_log_battle_action=True,
+        )
 
 
 def run_rse_hoenn() -> Generator:
@@ -135,7 +139,11 @@ def run_rse_hoenn() -> Generator:
             context.emulator.press_button("A")
             yield
 
-        handle_encounter(get_party()[0], do_not_log_battle_action=True, disable_auto_catch=True)
+        handle_encounter(
+            EncounterInfo.create(get_party()[0], EncounterType.Gift),
+            do_not_log_battle_action=True,
+            disable_auto_catch=True,
+        )
 
 
 def run_rse_johto():
@@ -187,7 +195,11 @@ def run_rse_johto():
         yield from StartMenuNavigator("POKEMON").step()
         yield from PokemonPartyMenuNavigator(len(get_party()) - 1, "summary").step()
 
-        handle_encounter(get_party()[len(get_party()) - 1], disable_auto_catch=True, do_not_log_battle_action=True)
+        handle_encounter(
+            EncounterInfo.create(get_party()[-1], EncounterType.Gift),
+            disable_auto_catch=True,
+            do_not_log_battle_action=True,
+        )
 
 
 class StartersMode(BotMode):
@@ -203,7 +215,7 @@ class StartersMode(BotMode):
         if context.rom.is_rse:
             return player_avatar.map_group_and_number in [(0, 16), (1, 4)]
 
-    def on_battle_started(self) -> BattleAction | None:
+    def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | None:
         return BattleAction.CustomAction
 
     def run(self) -> Generator:

--- a/modules/modes/static_run_away.py
+++ b/modules/modes/static_run_away.py
@@ -1,7 +1,7 @@
 from typing import Generator
 
 from modules.context import context
-from modules.encounter import handle_encounter
+from modules.encounter import handle_encounter, EncounterInfo
 from modules.map import get_map_objects
 from modules.map_data import MapFRLG, MapRSE
 from modules.memory import get_event_flag
@@ -43,8 +43,8 @@ class StaticRunAway(BotMode):
             allowed_maps = []
         return get_player_avatar().map_group_and_number in allowed_maps
 
-    def on_battle_started(self) -> BattleAction | None:
-        return handle_encounter(get_opponent(), disable_auto_catch=True)
+    def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | None:
+        return handle_encounter(encounter, disable_auto_catch=True)
 
     def run(self) -> Generator:
         match get_player_avatar().map_group_and_number:

--- a/modules/modes/static_soft_resets.py
+++ b/modules/modes/static_soft_resets.py
@@ -2,11 +2,9 @@ from dataclasses import dataclass
 from typing import Generator, Optional
 
 from modules.context import context
-from modules.encounter import handle_encounter, judge_encounter, log_encounter
+from modules.encounter import handle_encounter, log_encounter, EncounterInfo
 from modules.map_data import MapFRLG, MapRSE
-from modules.memory import get_event_flag
 from modules.player import get_player_avatar
-from modules.pokemon import get_opponent
 from modules.save_data import get_save_data
 from ._asserts import SavedMapLocation, assert_save_game_exists, assert_saved_on_map
 from ._interface import BattleAction, BotMode, BotModeError
@@ -89,11 +87,10 @@ class StaticSoftResetsMode(BotMode):
     def is_selectable() -> bool:
         return _get_targeted_encounter() is not None
 
-    def on_battle_started(self) -> BattleAction | None:
-        opponent = get_opponent()
-        if judge_encounter(opponent).is_of_interest:
-            return handle_encounter(opponent, disable_auto_catch=True)
-        log_encounter(opponent)
+    def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | None:
+        if encounter.is_of_interest:
+            return handle_encounter(encounter, disable_auto_catch=True)
+        log_encounter(encounter)
         return BattleAction.CustomAction
 
     def run(self) -> Generator:

--- a/modules/modes/sudowoodo.py
+++ b/modules/modes/sudowoodo.py
@@ -1,10 +1,9 @@
 from typing import Generator
 
 from modules.context import context
-from modules.encounter import handle_encounter, judge_encounter, log_encounter
+from modules.encounter import handle_encounter, log_encounter, EncounterInfo
 from modules.map_data import MapRSE
 from modules.player import get_player_avatar
-from modules.pokemon import get_opponent
 from ._asserts import SavedMapLocation, assert_registered_item, assert_save_game_exists, assert_saved_on_map
 from ._interface import BattleAction, BotMode
 from .util import soft_reset, wait_for_task_to_start_and_finish, wait_for_unique_rng_value, wait_until_task_is_active
@@ -22,11 +21,10 @@ class SudowoodoMode(BotMode):
         targeted_tile = get_player_avatar().map_location_in_front
         return targeted_tile in MapRSE.BATTLE_FRONTIER_OUTSIDE_EAST and targeted_tile.local_position == (54, 62)
 
-    def on_battle_started(self) -> BattleAction | None:
-        opponent = get_opponent()
-        if judge_encounter(opponent).is_of_interest:
-            return handle_encounter(opponent, disable_auto_catch=True)
-        log_encounter(opponent)
+    def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | None:
+        if encounter.is_of_interest:
+            return handle_encounter(encounter, disable_auto_catch=True)
+        log_encounter(encounter)
         return BattleAction.CustomAction
 
     def run(self) -> Generator:

--- a/modules/plugin_interface.py
+++ b/modules/plugin_interface.py
@@ -1,9 +1,8 @@
 from typing import TYPE_CHECKING, Iterable, Generator
 
-
 if TYPE_CHECKING:
     from modules.battle_state import BattleOutcome
-    from modules.encounter import ActiveWildEncounter
+    from modules.encounter import EncounterInfo
     from modules.modes import BotMode, BotListener
     from modules.pokemon import Pokemon
     from modules.profiles import Profile
@@ -19,19 +18,25 @@ class BotPlugin:
     def on_profile_loaded(self, profile: "Profile") -> None:
         pass
 
-    def on_battle_started(self, opponent: "Pokemon", wild_encounter: "ActiveWildEncounter | None") -> Generator | None:
+    def on_battle_started(self, encounter: "EncounterInfo | None") -> Generator | None:
         pass
 
-    def on_wild_encounter_visible(self, wild_encounter: "ActiveWildEncounter") -> Generator | None:
+    def on_wild_encounter_visible(self, encounter: "EncounterInfo") -> Generator | None:
         pass
 
     def on_battle_ended(self, outcome: "BattleOutcome") -> Generator | None:
         pass
 
+    def on_logging_encounter(self, encounter: "EncounterInfo") -> None:
+        pass
+
     def on_pokemon_evolved(self, evolved_pokemon: "Pokemon") -> Generator | None:
         pass
 
-    def on_egg_hatched(self, hatched_pokemon: "Pokemon") -> Generator | None:
+    def on_egg_starting_to_hatch(self, hatching_pokemon: "EncounterInfo") -> Generator | None:
+        pass
+
+    def on_egg_hatched(self, hatched_pokemon: "EncounterInfo") -> Generator | None:
         pass
 
     def on_whiteout(self) -> Generator | None:

--- a/modules/plugins.py
+++ b/modules/plugins.py
@@ -9,7 +9,7 @@ from modules.pokemon import Pokemon
 from modules.runtime import get_base_path
 
 if TYPE_CHECKING:
-    from modules.encounter import ActiveWildEncounter
+    from modules.encounter import EncounterInfo
     from modules.modes import BotMode, BotListener
     from modules.profiles import Profile
 
@@ -75,16 +75,16 @@ def plugin_profile_loaded(profile: "Profile") -> None:
         plugin.on_profile_loaded(profile)
 
 
-def plugin_battle_started(opponent: "Pokemon", wild_encounter: "ActiveWildEncounter | None") -> Generator:
+def plugin_battle_started(encounter: "EncounterInfo | None") -> Generator:
     for plugin in plugins:
-        result = plugin.on_battle_started(opponent, wild_encounter)
+        result = plugin.on_battle_started(encounter)
         if isinstance(result, GeneratorType):
             yield from result
 
 
-def plugin_wild_encounter_visible(wild_encounter: "ActiveWildEncounter") -> Generator:
+def plugin_wild_encounter_visible(encounter: "EncounterInfo") -> Generator:
     for plugin in plugins:
-        result = plugin.on_wild_encounter_visible(wild_encounter)
+        result = plugin.on_wild_encounter_visible(encounter)
         if isinstance(result, GeneratorType):
             yield from result
 
@@ -96,6 +96,11 @@ def plugin_battle_ended(outcome: "BattleOutcome") -> Generator:
             yield from result
 
 
+def plugin_logging_encounter(encounter: "EncounterInfo") -> None:
+    for plugin in plugins:
+        plugin.on_logging_encounter(encounter)
+
+
 def plugin_pokemon_evolved(evolved_pokemon: "Pokemon") -> Generator:
     for plugin in plugins:
         result = plugin.on_pokemon_evolved(evolved_pokemon)
@@ -103,7 +108,14 @@ def plugin_pokemon_evolved(evolved_pokemon: "Pokemon") -> Generator:
             yield from result
 
 
-def plugin_egg_hatched(hatched_pokemon: "Pokemon") -> Generator:
+def plugin_egg_starting_to_hatch(hatching_pokemon: "EncounterInfo") -> Generator:
+    for plugin in plugins:
+        result = plugin.on_egg_starting_to_hatch(hatching_pokemon)
+        if isinstance(result, GeneratorType):
+            yield from result
+
+
+def plugin_egg_hatched(hatched_pokemon: "EncounterInfo") -> Generator:
     for plugin in plugins:
         result = plugin.on_egg_hatched(hatched_pokemon)
         if isinstance(result, GeneratorType):

--- a/modules/web/static/index.html
+++ b/modules/web/static/index.html
@@ -362,11 +362,15 @@
                     nameParts.push("✨");
                 }
 
-                if (data[index].nickname && data[index].nickname.toLowerCase() != data[index].species.name.toLowerCase()) {
-                    nameParts.push(`“${data[index].nickname}”`);
-                }
+                if (data[index].is_egg) {
+                    nameParts.unshift("🥚")
+                } else {
+                    if (data[index].nickname && data[index].nickname.toLowerCase() !== data[index].species.name.toLowerCase()) {
+                        nameParts.push(`“${data[index].nickname}”`);
+                    }
 
-                nameParts.push(`(lvl. ${data[index].level}, ${data[index].gender})`)
+                    nameParts.push(`(lvl. ${data[index].level}, ${data[index].gender})`);
+                }
 
                 listEntry.innerText = nameParts.join(" ");
 


### PR DESCRIPTION
### Description

- Unifies encounter logging into one single place.
- Fixes reporting for Starter, Hatched, and Gifted encounters.
- Adds GIF generation for hatched eggs, because why not.
- Console log, emulator message, and Discord messages use different verbs depending on how a Pokémon as been acquired (can be "encountered", "hatched", or "received" for Gift Pokémon)


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
