### PR TITLE
Don't rotate lead in Level Grind mode if only lead is selected to be levelled

### DIFF
--- a/modules/modes/level_grind.py
+++ b/modules/modes/level_grind.py
@@ -47,6 +47,11 @@ closest_pokemon_centers: dict[MapFRLG | MapRSE, list[PokemonCenter]] = {
 }
 
 
+class NoRotateLeadDefaultBattleStrategy(DefaultBattleStrategy):
+    def choose_new_lead_after_battle(self) -> int | None:
+        return None
+
+
 class LevelGrindMode(BotMode):
     @staticmethod
     def name() -> str:
@@ -76,7 +81,7 @@ class LevelGrindMode(BotMode):
             if self._level_balance:
                 return LevelBalancingBattleStrategy()
             else:
-                return DefaultBattleStrategy()
+                return NoRotateLeadDefaultBattleStrategy()
         else:
             return action
 


### PR DESCRIPTION
### Description

If the user chooses the 'level lead only' option, we use the default battle strategy -- but depending on configuration, this might rotate the lead after a battle if the previous lead was too weak.

This would mess up that mode because now a different Pokémon is being levelled.

### Changes

I've added a modified battle strategy for that.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
