### PR TITLE
Make the bot at least run on Python 3.13

### DIFF
--- a/modules/libmgba.py
+++ b/modules/libmgba.py
@@ -1,20 +1,14 @@
 import atexit
-import fractions
 import queue
 import time
 import zlib
 from collections import deque
 from contextlib import contextmanager
-from pathlib import Path
 from queue import Queue
-from sys import maxsize
 
 import PIL.Image
 import PIL.PngImagePlugin
-import numpy
 import sounddevice
-from av import AudioFrame
-from av.audio.stream import AudioStream
 
 import mgba.audio
 import mgba.core

--- a/modules/web/http.py
+++ b/modules/web/http.py
@@ -9,12 +9,18 @@ from typing import Union
 
 import aiohttp.client_exceptions
 from aiohttp import web
-from aiortc import MediaStreamTrack, VideoStreamTrack, RTCPeerConnection, RTCSessionDescription
-from aiortc.contrib.media import MediaRelay
 from apispec import APISpec
 from apispec.yaml_utils import load_operations_from_docstring
-from av import VideoFrame, Packet, AudioFrame
-from av.frame import Frame
+
+try:
+    from aiortc import MediaStreamTrack, VideoStreamTrack, RTCPeerConnection, RTCSessionDescription
+    from aiortc.contrib.media import MediaRelay
+    from av import VideoFrame, Packet, AudioFrame
+    from av.frame import Frame
+
+    webrtc_available = True
+except ImportError:
+    webrtc_available = False
 
 from modules.console import console
 from modules.context import context
@@ -700,95 +706,106 @@ def http_server(host: str, port: int) -> web.AppRunner:
 
         return response
 
-    rtc_connections: set[RTCPeerConnection] = set()
+    if webrtc_available:
+        rtc_connections: set[RTCPeerConnection] = set()
 
-    class EmuVideo(VideoStreamTrack):
-        def __init__(self):
-            super().__init__()
+        class EmuVideo(VideoStreamTrack):
+            def __init__(self):
+                super().__init__()
 
-        async def recv(self) -> Union[Frame, Packet]:
-            pts, time_base = await self.next_timestamp()
+            async def recv(self) -> Union[Frame, Packet]:
+                pts, time_base = await self.next_timestamp()
 
-            frame = VideoFrame.from_image(context.emulator.get_current_screen_image())
-            frame.pts = pts
-            frame.time_base = time_base
+                frame = VideoFrame.from_image(context.emulator.get_current_screen_image())
+                frame.pts = pts
+                frame.time_base = time_base
 
-            return frame
+                return frame
 
-    class EmuAudio(MediaStreamTrack):
-        kind = "audio"
+        class EmuAudio(MediaStreamTrack):
+            kind = "audio"
 
-        def __init__(self):
-            super().__init__()
-            self._queue: Queue[bytes] = context.emulator.get_last_audio_data()
-            self._start: float | None = None
-            self._timestamp: float = 0
+            def __init__(self):
+                super().__init__()
+                self._queue: Queue[bytes] = context.emulator.get_last_audio_data()
+                self._start: float | None = None
+                self._timestamp: float = 0
 
-        async def recv(self) -> Union[Frame, Packet]:
-            sample_rate = context.emulator.get_sample_rate()
-            data = b""
-            while len(data) == 0:
-                try:
-                    part = self._queue.get_nowait()
-                except queue.Empty:
-                    await asyncio.sleep(1 / 480)
-                    continue
-                data += part
+            async def recv(self) -> Union[Frame, Packet]:
+                sample_rate = context.emulator.get_sample_rate()
+                data = b""
+                while len(data) == 0:
+                    try:
+                        part = self._queue.get_nowait()
+                    except queue.Empty:
+                        await asyncio.sleep(1 / 480)
+                        continue
+                    data += part
 
-            if self._start is None:
-                self._start = time.time()
+                if self._start is None:
+                    self._start = time.time()
 
-            frame = AudioFrame(format="s16", layout="stereo", samples=len(data) // 4)
-            frame.planes[0].update(data)
-            frame.pts = self._timestamp
-            frame.sample_rate = sample_rate
+                frame = AudioFrame(format="s16", layout="stereo", samples=len(data) // 4)
+                frame.planes[0].update(data)
+                frame.pts = self._timestamp
+                frame.sample_rate = sample_rate
 
-            self._timestamp += len(data) // 4
+                self._timestamp += len(data) // 4
 
-            return frame
+                return frame
 
-    relay = MediaRelay()
-    emu_audio = None
-    emu_video = None
+        relay = MediaRelay()
+        emu_audio = None
+        emu_video = None
 
-    @route.post("/rtc")
-    async def http_post_rtc(request: web.Request):
-        nonlocal rtc_connections, emu_video, emu_audio
+        @route.post("/rtc")
+        async def http_post_rtc(request: web.Request):
+            nonlocal rtc_connections, emu_video, emu_audio
 
-        params = await request.json()
-        offer = RTCSessionDescription(sdp=params["sdp"], type=params["type"])
+            params = await request.json()
+            offer = RTCSessionDescription(sdp=params["sdp"], type=params["type"])
 
-        connection = RTCPeerConnection()
-        rtc_connections.add(connection)
+            connection = RTCPeerConnection()
+            rtc_connections.add(connection)
 
-        @connection.on("datachannel")
-        def on_datachannel(channel):
-            @channel.on("message")
-            def on_message(message):
-                if isinstance(message, str) and message.startswith("ping"):
-                    channel.send("pong" + message[4:])
+            @connection.on("datachannel")
+            def on_datachannel(channel):
+                @channel.on("message")
+                def on_message(message):
+                    if isinstance(message, str) and message.startswith("ping"):
+                        channel.send("pong" + message[4:])
 
-        @connection.on("connectionstatechange")
-        async def on_connection_state_change():
-            if connection.connectionState == "failed":
-                await connection.close()
-                rtc_connections.discard(connection)
+            @connection.on("connectionstatechange")
+            async def on_connection_state_change():
+                if connection.connectionState == "failed":
+                    await connection.close()
+                    rtc_connections.discard(connection)
 
-        if emu_video is None:
-            emu_video = EmuVideo()
+            if emu_video is None:
+                emu_video = EmuVideo()
 
-        if emu_audio is None:
-            emu_audio = EmuAudio()
+            if emu_audio is None:
+                emu_audio = EmuAudio()
 
-        connection.addTrack(relay.subscribe(emu_video))
-        connection.addTrack(relay.subscribe(emu_audio))
+            connection.addTrack(relay.subscribe(emu_video))
+            connection.addTrack(relay.subscribe(emu_audio))
 
-        await connection.setRemoteDescription(offer)
+            await connection.setRemoteDescription(offer)
 
-        answer = await connection.createAnswer()
-        await connection.setLocalDescription(answer)
+            answer = await connection.createAnswer()
+            await connection.setLocalDescription(answer)
 
-        return web.json_response({"sdp": connection.localDescription.sdp, "type": connection.localDescription.type})
+            return web.json_response({"sdp": connection.localDescription.sdp, "type": connection.localDescription.type})
+
+    else:
+
+        @route.post("/rtc")
+        async def http_post_rtc(request: web.Request):
+            return web.Response(
+                text="WebRTC is not available because aiortc was not installed.",
+                status=503,
+                headers={"Content-Type": "text/plain"},
+            )
 
     @route.get("/stream_video")
     async def http_get_video_stream(request: web.Request):

--- a/wiki/pages/Getting Started.md
+++ b/wiki/pages/Getting Started.md
@@ -9,7 +9,7 @@
 - Windows
 - MacOS
 - Linux, tested and confirmed working on the following distros:
-  - Ubuntu 23.04, 23.10
+  - Ubuntu 24.04
   - Debian 12
   - Pop!_OS 22.04 LTS
   - Arch Linux


### PR DESCRIPTION
### Description

Updates some dependencies so we get versions that are compatible with Python 3.13.

This wasn't possible for all versions: For `aiortc` (used for providing a WebRTC-based video/audio stream via the HTTP server) there is no compatible version yet.

Since that is a rather niche use case, I have modified `requirements.py` to just not install that library if the user's Python version is too new. The video stream won't be available in that case.

I also modified the script slightly so that if the user's Python version is _newer_ than the newest version we have marked as compatible, it will offer a 'do it anyway' choice.

![image](https://github.com/user-attachments/assets/48466a24-e87d-4a7a-b311-089ef67d7338)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
