### PR TITLE
fix BattleScript_AskToLearnMove emerald

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.json
+++ b/modules/data/symbols/patches/language/pokeemerald.json
@@ -390,10 +390,10 @@
     },
     "BattleScript_AskToLearnMove":{
       "D":"82f0923",
-      "F":"81c1388",
+      "F":"82e3bb7",
       "I":"82dbb6f",
       "J":"828916b",
-      "S":"82e236f"
+      "S":"82e2373"
     },
     "BattleScript_ForgotAndLearnedNewMove": {
       "D":"82f0950",


### PR DESCRIPTION
for Spanish and French

### Description

this fixes the Symbol translation of  `BattleScript_AskToLearnMove` for French and Spanish
apparently learning new moves didn't even work before the battle rework or it was less precise.

### Changes

modules/data/symbols/patches/language/pokeemerald.json -> fixed symbols

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [ ] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [ ] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
