### PR TITLE
Even more emerald mui

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.json
+++ b/modules/data/symbols/patches/language/pokeemerald.json
@@ -155,6 +155,13 @@
       "J":"813e4a8",
       "S":"813dfd8"
     },
+    "CB2_WHITEOUT":{
+      "D":"8085f74",
+      "F":"8085f68",
+      "I":"8085f6c",
+      "J":"80858c0",
+      "S":"8085f6c"
+    },
     "BattleMainCB1":{
       "J":"8039b35"
     },
@@ -543,6 +550,18 @@
     },
     "gBattleTypeFlags":{
       "J":"2022C90"
+    },
+    "gSideTimers":{
+      "J":"2023F38"
+    },
+    "gStatuses3":{
+      "J":"2023F50"
+    },
+    "gDisableStructs":{
+      "J":"2023F60"
+    },
+    "gBattleWeather":{
+      "J":"2024070"
     },
     "gBattlePartyCurrentOrder":{
       "J":"203cbcc"

--- a/wiki/pages/Mode - Acro Bike Bunny Hop.md
+++ b/wiki/pages/Mode - Acro Bike Bunny Hop.md
@@ -10,11 +10,11 @@ Register the Acro Bike and start the mode while in the overworld, in any patch o
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald |
 |:---------|:-------:|:-----------:|:----------:|
 | English  |    ✅    |      ✅      |     ✅      |
-| Japanese |    ❌    |      ❌      |     ❌      |
-| German   |    ❌    |      ❌      |     ❌      |
-| Spanish  |    ❌    |      ❌      |     ❌      |
-| French   |    ❌    |      ❌      |     ❌      |
-| Italian  |    ❌    |      ❌      |     ❌      |
+| Japanese |    ❌    |      ❌      |     ✅      |
+| German   |    ❌    |      ❌      |     ✅      |
+| Spanish  |    ❌    |      ❌      |     ✅      |
+| French   |    ❌    |      ❌      |     ✅      |
+| Italian  |    ❌    |      ❌      |     ✅      |
 
 ✅ Tested, working
 

--- a/wiki/pages/Mode - Feebas.md
+++ b/wiki/pages/Mode - Feebas.md
@@ -56,7 +56,7 @@ The lakes marked in red are highly likely to contain a Feebas tile.
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald |
 |:---------|:-------:|:-----------:|:----------:|
 | English  |    ✅    |      ✅      |     ✅      |
-| Japanese |    ❌    |      ❌      |     🟨      |
+| Japanese |    ❌    |      ❌      |     ✅      |
 | German   |    ❌    |      ❌      |     ✅      |
 | Spanish  |    ❌    |      ❌      |     ✅      |
 | French   |    ❌    |      ❌      |     ✅      |

--- a/wiki/pages/Mode - Kecleon.md
+++ b/wiki/pages/Mode - Kecleon.md
@@ -26,11 +26,11 @@ Start the mode facing the invisible Kecleon on Route 119.
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald |
 |:---------|:-------:|:-----------:|:----------:|
 | English  |    ❌    |      ❌      |     ✅      |
-| Japanese |    ❌    |      ❌      |     ❌      |
-| German   |    ❌    |      ❌      |     ❌      |
-| Spanish  |    ❌    |      ❌      |     ❌      |
-| French   |    ❌    |      ❌      |     ❌      |
-| Italian  |    ❌    |      ❌      |     ❌      |
+| Japanese |    ❌    |      ❌      |     ✅      |
+| German   |    ❌    |      ❌      |     ✅      |
+| Spanish  |    ❌    |      ❌      |     ✅      |
+| French   |    ❌    |      ❌      |     ✅      |
+| Italian  |    ❌    |      ❌      |     ✅      |
 
 ✅ Tested, working
 

--- a/wiki/pages/Mode - Level Grind.md
+++ b/wiki/pages/Mode - Level Grind.md
@@ -69,11 +69,11 @@ The following routes are supported:
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ✅    |      ✅      |     ✅      |     ✅      |      ✅       |
-| Japanese |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| German   |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| Spanish  |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| French   |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
-| Italian  |    ❌    |      ❌      |     ❌      |     ❌      |      ❌       |
+| Japanese |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| German   |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| Spanish  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| French   |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| Italian  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
 
 ✅ Tested, working
 


### PR DESCRIPTION
### Description

This fixes the Whiteout Listener enough to work for the Kecleon mode in all Emerald languages,
fixes the any battle mode to crash out right with the Japanese ROM and
updates the Wiki for Kecleon, Bunny Hop, Level Grind and Feebas after testing.

### Changes

Emerald symbols and wiki pages

### Notes

### Checklist

<!-- Pre-merge checks that should be completed -->

- [ ] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [ ] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
