### PR TITLE
Fix re-disabling video after generating a GIF

### DIFF
--- a/modules/built_in_plugins/generate_encounter_media.py
+++ b/modules/built_in_plugins/generate_encounter_media.py
@@ -8,6 +8,7 @@ import PIL.Image
 
 from modules.context import context
 from modules.encounter import EncounterValue
+from modules.main import work_queue
 from modules.modes import BotListener, BotMode, FrameInfo
 from modules.plugin_interface import BotPlugin
 from modules.tcg_card import get_tcg_card_file_name, generate_tcg_card
@@ -61,7 +62,11 @@ class GifGeneratorListener(BotListener):
             os.replace(directory / (file_name + ".tmp"), directory / file_name)
 
         if not self._video_was_enabled_before:
-            context.video = False
+
+            def disable_video_again():
+                context.video = False
+
+            work_queue.put_nowait(disable_video_again)
 
 
 class GenerateEncounterMediaPlugin(BotPlugin):


### PR DESCRIPTION
### Description

When trying to generate a GIF with video disabled, the bot will enable video for the duration of the image generation and then disable it again.

That works fine for the enabling part, but the disabling call happens inside another thread which can lead to issues with Tkinter (`RuntimeError: main thread is not in main loop`.)

This change makes it so that the video disabling is done by the main thread.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
