### PR TITLE
Add `--user` to `pip` flags when not running in a virtualenv

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -130,6 +130,9 @@ def update_requirements(ask_for_confirmation: bool = True) -> bool:
     import subprocess
 
     pip_flags = ["--disable-pip-version-check", "--no-python-version-warning"]
+    if not is_virtualenv():
+        pip_flags.append("--user")
+
     for module in required_modules:
         subprocess.check_call(
             [sys.executable, "-m", "pip", "install", *pip_flags, module],


### PR DESCRIPTION
### Description

By default, `pip` tries to install packages globally -- which leads to permission issues if Python is not installed in a user directory and the requirements script not run as superuser.

This changes the requirements script to it adds the `--user` flag to `pip` so it tries to install the packages only for the current user.

Fixes #420

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
