### PR TITLE
Simplify logging config

### DIFF
--- a/modules/built_in_plugins/discord_integration.py
+++ b/modules/built_in_plugins/discord_integration.py
@@ -24,34 +24,28 @@ if TYPE_CHECKING:
 
 
 def iv_table(pokemon: "Pokemon") -> str:
-    if context.config.discord.iv_format == "formatted":
-        return (
-            "```"
-            "╔═══╤═══╤═══╤═══╤═══╤═══╗\n"
-            "║HP │ATK│DEF│SPA│SPD│SPE║\n"
-            "╠═══╪═══╪═══╪═══╪═══╪═══╣\n"
-            f"║{pokemon.ivs.hp:^3}│"
-            f"{pokemon.ivs.attack:^3}│"
-            f"{pokemon.ivs.defence:^3}│"
-            f"{pokemon.ivs.special_attack:^3}│"
-            f"{pokemon.ivs.special_defence:^3}│"
-            f"{pokemon.ivs.speed:^3}║\n"
-            "╚═══╧═══╧═══╧═══╧═══╧═══╝"
-            "```"
-        )
-    else:
-        return (
-            f"HP: {pokemon.ivs.hp} | "
-            f"ATK: {pokemon.ivs.attack} | "
-            f"DEF: {pokemon.ivs.defence} | "
-            f"SPATK: {pokemon.ivs.special_attack} | "
-            f"SPDEF: {pokemon.ivs.special_defence} | "
-            f"SPE: {pokemon.ivs.speed}"
-        )
+    return (
+        "```"
+        "╔═══╤═══╤═══╤═══╤═══╤═══╗\n"
+        "║HP │ATK│DEF│SPA│SPD│SPE║\n"
+        "╠═══╪═══╪═══╪═══╪═══╪═══╣\n"
+        f"║{pokemon.ivs.hp:^3}│"
+        f"{pokemon.ivs.attack:^3}│"
+        f"{pokemon.ivs.defence:^3}│"
+        f"{pokemon.ivs.special_attack:^3}│"
+        f"{pokemon.ivs.special_defence:^3}│"
+        f"{pokemon.ivs.speed:^3}║\n"
+        "╚═══╧═══╧═══╧═══╧═══╧═══╝"
+        "```"
+    )
 
 
 def pokemon_label(pokemon: "Pokemon") -> str:
-    return f"{pokemon.nature.name} {pokemon.species_name_for_stats} (Lv. {pokemon.level:,}) at {pokemon.location_met}!"
+    if pokemon.gender is not None and not pokemon.species.name.startswith("Nidoran"):
+        gender_code = "♂" if pokemon.gender == "male" else "♀"
+    else:
+        gender_code = ""
+    return f"{pokemon.nature.name} **{pokemon.species_name_for_stats}{gender_code}** (Lv. {pokemon.level:,}) at {pokemon.location_met}!"
 
 
 def pokemon_fields(pokemon: "Pokemon", species_stats: "EncounterSummary", short: bool = False) -> dict[str, str]:

--- a/modules/config/schemas_v1.py
+++ b/modules/config/schemas_v1.py
@@ -190,27 +190,17 @@ class Logging(BaseConfig):
     """Schema for the logging configuration."""
 
     filename: ClassVar = "logging.yml"
-    console: LoggingConsole = Field(default_factory=lambda: LoggingConsole())
     save_pk3: LoggingSavePK3 = Field(default_factory=lambda: LoggingSavePK3())
     log_encounters: bool = False
+    log_encounters_to_console: bool = True
     desktop_notifications: bool = True
     shiny_gifs: bool = True
     tcg_cards: bool = True
 
 
-class LoggingConsole(BaseConfig):
-    """Schema for the console section in the Logging config."""
-
-    encounter_data: Literal["verbose", "basic", "disable"] = "verbose"
-    encounter_ivs: Literal["verbose", "basic", "disable"] = "verbose"
-    encounter_moves: Literal["verbose", "basic", "disable"] = "disable"
-    statistics: Literal["verbose", "basic", "disable"] = "verbose"
-
-
 class LoggingSavePK3(BaseConfig):
     """Schema for the save_pk3 section in the Logging config."""
 
-    all: bool = False
     shiny: bool = True
     custom: bool = True
     roamer: bool = True

--- a/modules/config/templates/logging.yml
+++ b/modules/config/templates/logging.yml
@@ -1,30 +1,40 @@
 # See wiki for documentation: https://github.com/40Cakes/pokebot-gen3/tree/main/wiki/pages/Console,%20Logging%20and%20Image%20Config.md
 
-# Log all encounters to .csv (`stats/encounters/` folder), each phase is logged to a separate file
-log_encounters: false # `true`, `false`
+# Log _all_ encounters (and not just shiny ones) to the stats database.
+# This doesn't impact performance much, but it means that the database
+# file (`stats.db` in the profile directory) will grow much quicker.
+#
+# It adds about 200 byte for each encounter. So for each 1 million
+# encounters, the database would have a size of about 190 MB.
+log_encounters: false
 
 # Show a desktop notification if a shiny, roamer, or Pokémon matching your
 # Custom Catch Filters is encountered, or the bot is switched to manual
 # mode.
 desktop_notifications: true
 
-# Console output
-# `verbose`, `basic`, `disable`
-console:
-  encounter_data: verbose
-  encounter_ivs: verbose
-  encounter_moves: disable
-  statistics: verbose
+# Log information about wild encounters (or gift Pokémon) to the console.
+log_encounters_to_console: true
 
-# Save .pk3 files
+# Save .pk3 files that can be used with PKHeX. These are stored in
+# the `pokemon/` directory inside the profile directory.
 save_pk3:
-  all: false
+  # Create .pk3 files for Shiny encounters
   shiny: true
+  # Create .pk3 files for Pokémon that match your custom catch filters.
   custom: true
+  # Create .pk3 files for the Roaming Pokémon (Latias/Latios on R/S/E,
+  # Entei/Raikou/Suicine on FR/LG) the first time it is encountered.
   roamer: true
 
-# Save shiny GIFs
+# Save short GIF clips of the start of a battle whenever a Shiny is
+# encountered. These are saved in `screenshots/gifs/` in the profile
+# directory.
+# If you're using the Discord integration, these GIFs will then also
+# be added to Shiny notifications.
 shiny_gifs: true
 
-# Generate TCG cards
+# Generate TCG card-style images whenever a Shiny is encountered,
+# containing information (stats, moves) about that Pokémon.
+# These are saved in `screenshots/cards/` in the profile directory.
 tcg_cards: true

--- a/modules/console.py
+++ b/modules/console.py
@@ -1,14 +1,13 @@
 from typing import TYPE_CHECKING
 
-from rich.console import Console
+from rich.console import Console, Group
+from rich.panel import Panel
 from rich.table import Table
 from rich.theme import Theme
 
-from modules.battle_state import EncounterType
-from modules.context import context
-
 if TYPE_CHECKING:
     from modules.encounter import EncounterInfo
+    from modules.pokemon import Pokemon
     from modules.stats import GlobalStats, EncounterSummary
 
 theme = Theme(
@@ -33,6 +32,16 @@ theme = Theme(
         "question_marks": "#68a090",
     }
 )
+
+
+def iv_value(pokemon: "Pokemon", iv_stat: str):
+    iv = pokemon.ivs[iv_stat]
+    result = f"[{iv_colour(iv)}]{iv}[/]"
+    if iv_stat != "hp" and pokemon.nature.modifiers[iv_stat] > 1:
+        result += "[default]↑[/]"
+    elif iv_stat != "hp" and pokemon.nature.modifiers[iv_stat] < 1:
+        result += "[default]↓[/]"
+    return result
 
 
 def iv_colour(value: "SpeciesRecord | int | None") -> str:
@@ -76,183 +85,134 @@ def sv_colour(value: "SpeciesRecord | int | None") -> str:
         return "red"
 
 
+def format_shiny_average(encounter_summary: "EncounterSummary | EncounterTotals") -> str:
+    if encounter_summary.shiny_encounters > 0:
+        return f"1/{int(encounter_summary.total_encounters / encounter_summary.shiny_encounters):,}"
+    else:
+        return "N/A"
+
+
+def number(value) -> str:
+    return f"{int(value):,}" if value is not None else "-"
+
+
+def percentage(value, total) -> str:
+    return f"{100*value/total:0.2f}%" if value is not None and total is not None and total > 0 else "-"
+
+
 def print_stats(stats: "GlobalStats", encounter: "EncounterInfo") -> None:
     pokemon = encounter.pokemon
     type_colour = pokemon.species.types[0].name.lower()
-    rich_name = f"[{type_colour}]{pokemon.species_name_for_stats}[/]"
+    if pokemon.gender is not None and not pokemon.species.name.startswith("Nidoran"):
+        gender_code = "♂" if pokemon.gender == "male" else "♀"
+        gender_label = "[cyan]Male ♂[/]" if pokemon.gender == "male" else "[pink]Female ♀[/]"
+    else:
+        gender_code = ""
+        gender_label = "-"
+    rich_name = f"[{type_colour}][bold]{pokemon.species_name_for_stats}{gender_code}[/bold][/{type_colour}]"
 
-    match context.config.logging.console.encounter_data:
-        case "verbose":
-            console.rule(f"\n{rich_name} {encounter.type.verb} at {pokemon.location_met}", style=type_colour)
-            pokemon_table = Table()
-            pokemon_table.add_column("PID", justify="center", width=10)
-            pokemon_table.add_column("Level", justify="center")
-            pokemon_table.add_column("Item", justify="center", width=10)
-            pokemon_table.add_column("Nature", justify="center", width=10)
-            pokemon_table.add_column("Ability", justify="center", width=15)
-            pokemon_table.add_column(
-                "Hidden Power", justify="center", width=15, style=pokemon.hidden_power_type.name.lower()
-            )
-            pokemon_table.add_column("Shiny Value", justify="center", style=sv_colour(pokemon.shiny_value), width=10)
-            pokemon_table.add_row(
-                str(hex(pokemon.personality_value)[2:]).upper(),
-                str(pokemon.level),
-                pokemon.held_item.name if pokemon.held_item else "-",
-                pokemon.nature.name,
-                pokemon.ability.name,
-                f"{pokemon.hidden_power_type.name} ({pokemon.hidden_power_damage})",
-                f"{pokemon.shiny_value:,}",
-            )
-            console.print(pokemon_table)
-        case "basic":
-            console.rule(f"\n{rich_name} {encounter.type.verb} at {pokemon.location_met}", style=type_colour)
-            console.print(
-                f"{rich_name}: PID: {str(hex(pokemon.personality_value)[2:]).upper()} | "
-                f"Lv: {pokemon.level:,} | "
-                f"Item: {pokemon.held_item.name if pokemon.held_item else '-'} | "
-                f"Nature: {pokemon.nature.name} | "
-                f"Ability: {pokemon.ability.name} | "
-                f"Shiny Value: {pokemon.shiny_value:,}"
-            )
+    # General Information table
+    pokemon_table = Table(show_header=False, border_style="#888888")
+    pokemon_table.add_column("Key", justify="right")
+    pokemon_table.add_column("Value", justify="left")
 
-    match context.config.logging.console.encounter_ivs:
-        case "verbose":
-            iv_table = Table(title=f"{pokemon.species.name} IVs")
-            iv_table.add_column("HP", justify="center", style=iv_colour(pokemon.ivs.hp))
-            iv_table.add_column("ATK", justify="center", style=iv_colour(pokemon.ivs.attack))
-            iv_table.add_column("DEF", justify="center", style=iv_colour(pokemon.ivs.defence))
-            iv_table.add_column("SPATK", justify="center", style=iv_colour(pokemon.ivs.special_attack))
-            iv_table.add_column("SPDEF", justify="center", style=iv_colour(pokemon.ivs.special_defence))
-            iv_table.add_column("SPD", justify="center", style=iv_colour(pokemon.ivs.speed))
-            iv_table.add_column("Total", justify="right", style=iv_sum_colour(pokemon.ivs.sum()))
-            iv_table.add_row(
-                f"{pokemon.ivs.hp}",
-                f"{pokemon.ivs.attack}",
-                f"{pokemon.ivs.defence}",
-                f"{pokemon.ivs.special_attack}",
-                f"{pokemon.ivs.special_defence}",
-                f"{pokemon.ivs.speed}",
-                f"{pokemon.ivs.sum()}",
-            )
-            console.print(iv_table)
-        case "basic":
-            console.print(
-                f"IVs: HP: [{iv_colour(pokemon.ivs.hp)}]{pokemon.ivs.hp}[/] | "
-                f"ATK: [{iv_colour(pokemon.ivs.attack)}]{pokemon.ivs.attack}[/] | "
-                f"DEF: [{iv_colour(pokemon.ivs.defence)}]{pokemon.ivs.defence}[/] | "
-                f"SPATK: [{iv_colour(pokemon.ivs.special_attack)}]{pokemon.ivs.special_attack}[/] | "
-                f"SPDEF: [{iv_colour(pokemon.ivs.special_defence)}]{pokemon.ivs.special_defence}[/] | "
-                f"SPD: [{iv_colour(pokemon.ivs.speed)}]{pokemon.ivs.speed}[/] | "
-                f"Sum: [{iv_sum_colour(pokemon.ivs.sum())}]{pokemon.ivs.sum()}[/]"
-            )
+    pokemon_table.add_row("[bold]PID[/]", f"{pokemon.personality_value:08X}")
+    pokemon_table.add_row("[bold]Level[/]", str(pokemon.level))
+    pokemon_table.add_row("[bold]Gender[/]", gender_label)
+    pokemon_table.add_row("[bold]Item[/]", "-" if pokemon.held_item is None else pokemon.held_item.name)
+    pokemon_table.add_row("[bold]Nature[/]", pokemon.nature.name)
+    pokemon_table.add_row("[bold]Ability[/]", pokemon.ability.name)
+    pokemon_table.add_row(
+        "[bold]Hidden Power[/]",
+        f"[{pokemon.hidden_power_type.name.lower()}]{pokemon.hidden_power_type.name} ({pokemon.hidden_power_damage})[/]",
+    )
+    pokemon_table.add_row("[bold]Shiny Value[/]", f"[{sv_colour(pokemon.shiny_value)}]{pokemon.shiny_value:,}[/]")
+    if pokemon.species.name == "Wurmple":
+        pokemon_table.add_row("[bold]Evolution[/]", pokemon.wurmple_evolution.title())
 
-    def format_shiny_average(encounter_summary: "EncounterSummary | EncounterTotals") -> str:
-        if encounter_summary.shiny_encounters > 0:
-            return f"1/{int(encounter_summary.total_encounters / encounter_summary.shiny_encounters)}"
-        else:
-            return "N/A"
+    # IVs table
+    iv_table = Table(title="IVs", border_style="#888888")
+    iv_table.add_column("HP", justify="center", style=iv_colour(pokemon.ivs.hp))
+    iv_table.add_column("ATK", justify="center", style=iv_colour(pokemon.ivs.attack))
+    iv_table.add_column("DEF", justify="center", style=iv_colour(pokemon.ivs.defence))
+    iv_table.add_column("SPATK", justify="center", style=iv_colour(pokemon.ivs.special_attack))
+    iv_table.add_column("SPDEF", justify="center", style=iv_colour(pokemon.ivs.special_defence))
+    iv_table.add_column("SPD", justify="center", style=iv_colour(pokemon.ivs.speed))
+    iv_table.add_column("Total", justify="right", style=iv_sum_colour(pokemon.ivs.sum()))
+    iv_table.add_row(
+        iv_value(pokemon, "hp"),
+        iv_value(pokemon, "attack"),
+        iv_value(pokemon, "defence"),
+        iv_value(pokemon, "special_attack"),
+        iv_value(pokemon, "special_defence"),
+        iv_value(pokemon, "speed"),
+        f"[bold {iv_sum_colour(pokemon.ivs.sum())}]{pokemon.ivs.sum()}[/]",
+    )
 
-    match context.config.logging.console.encounter_moves:
-        case "verbose":
-            move_table = Table(title=f"{pokemon.species.name} Moves")
-            move_table.add_column("Name", justify="left", width=20)
-            move_table.add_column("Kind", justify="center", width=10)
-            move_table.add_column("Type", justify="center", width=10)
-            move_table.add_column("Power", justify="center", width=10)
-            move_table.add_column("Accuracy", justify="center", width=10)
-            move_table.add_column("PP", justify="center", width=5)
-            for i in range(4):
-                learned_move = pokemon.move(i)
-                if learned_move is not None:
-                    move = learned_move.move
-                    move_table.add_row(
-                        move.name,
-                        move.type.kind,
-                        move.type.name,
-                        str(move.base_power),
-                        str(move.accuracy),
-                        str(learned_move.pp),
-                    )
-            console.print(move_table)
-        case "basic":
-            for i in range(4):
-                learned_move = pokemon.move(i)
-                if learned_move is not None:
-                    move = learned_move.move
-                    move_colour = move.type.name.lower()
-                    if move_colour == "???":
-                        move_colour = "question_marks"
-                    console.print(
-                        f"[{move_colour}]Move {i + 1}[/]: {move.name} | "
-                        f"{move.type.kind} | "
-                        f"[{move_colour}]{move.type.name}[/] | "
-                        f"Pwr: {move.base_power} | "
-                        f"Acc: {move.accuracy} | "
-                        f"PP: {learned_move.pp}"
-                    )
+    # Moves
+    move_list = []
+    for learned_move in pokemon.moves:
+        if learned_move is not None:
+            move = learned_move.move
+            move_list.append(f"[{move.type.name.lower()}]{move.name}[/]")
+    move_list = f"\n[bold]Moves:[/] {', '.join(move_list)}"
 
-    number = lambda x: f"{int(x):,}" if x is not None else "-"
-    percentage = lambda x, y: f"{100*x/y:0.2f}%" if x is not None and y is not None and y > 0 else "-"
+    ev_yields = []
+    for stat in ("hp", "attack", "defence", "speed", "special_attack", "special_defence"):
+        if pokemon.species.ev_yield[stat] > 0:
+            stat_name = "HP" if stat == "hp" else stat.replace("_", " ").title()
+            ev_yields.append(f"{pokemon.species.ev_yield[stat]} {stat_name}")
+    ev_yields = f"[bold]EV Yield:[/] {', '.join(ev_yields)}"
 
-    match context.config.logging.console.statistics:
-        case "verbose":
-            stats_table = Table(title="Statistics")
-            stats_table.add_column("", justify="left", width=10)
-            stats_table.add_column("Phase IV Records", justify="center", width=10)
-            stats_table.add_column("Phase SV Records", justify="center", width=15)
-            stats_table.add_column("Phase Encounters", justify="right", width=10)
-            stats_table.add_column("Phase %", justify="right", width=10)
-            stats_table.add_column("Shiny Encounters", justify="right", width=10)
-            stats_table.add_column("Total Encounters", justify="right", width=10)
-            stats_table.add_column("Shiny Average", justify="right", width=10)
+    # Statistics table
+    stats_table = Table(title="Statistics", border_style="#888888")
+    stats_table.add_column("", justify="left", width=10)
+    stats_table.add_column("Phase IV Records", justify="center", width=10)
+    stats_table.add_column("Phase SV Records", justify="center", width=15)
+    stats_table.add_column("Phase Encounters", justify="right", width=10)
+    stats_table.add_column("Phase %", justify="right", width=10)
+    stats_table.add_column("Shiny Encounters", justify="right", width=10)
+    stats_table.add_column("Total Encounters", justify="right", width=10)
+    stats_table.add_column("Shiny Average", justify="right", width=10)
 
-            encounter_summaries: list["EncounterSummary"] = list(
-                filter(lambda e: e.phase_encounters > 0, stats.encounter_summaries.values())
-            )
-            encounter_summaries.sort(key=lambda e: e.species_name)
-            for summary in encounter_summaries:
-                stats_table.add_row(
-                    summary.species_name,
-                    f"[red]{number(summary.phase_lowest_iv_sum)}[/] / [green]{number(summary.phase_highest_iv_sum)}",
-                    f"[green]{number(summary.phase_lowest_sv)}[/] / [{sv_colour(summary.phase_highest_sv)}]{number(summary.phase_highest_sv)}",
-                    f"{number(summary.phase_encounters)}",
-                    f"{percentage(summary.phase_encounters, stats.totals.phase_encounters)}",
-                    f"{number(summary.shiny_encounters)}",
-                    f"{number(summary.total_encounters)}",
-                    format_shiny_average(summary),
-                )
-            stats_table.add_row(
-                "[bold yellow]Total",
-                f"[red]{number(stats.totals.phase_lowest_iv_sum)}[/] / [green]{number(stats.totals.phase_highest_iv_sum)}",
-                f"[green]{number(stats.totals.phase_lowest_sv)}[/] / [{sv_colour(stats.totals.phase_highest_sv)}]{number(stats.totals.phase_highest_sv)}",
-                f"[bold yellow]{number(stats.totals.phase_encounters)}",
-                "[bold yellow]100%",
-                f"[bold yellow]{number(stats.totals.shiny_encounters)}",
-                f"[bold yellow]{number(stats.totals.total_encounters)}",
-                format_shiny_average(stats.totals),
-            )
-            console.print(stats_table)
-        case "basic":
-            console.print(
-                f"{rich_name} Phase Encounters: {number(stats.encounter_summaries[pokemon.species.index].phase_encounters)} | "
-                f"{rich_name} Total Encounters: {number(stats.encounter_summaries[pokemon.species.index].total_encounters)} | "
-                f"{rich_name} Shiny Encounters: {number(stats.encounter_summaries[pokemon.species.index].shiny_encounters)}"
-            )
-            console.print(
-                f"{rich_name} Phase IV Records [red]{number(stats.encounter_summaries[pokemon.species.index].phase_lowest_iv_sum)}[/]/[green]{number(stats.encounter_summaries[pokemon.species.index].phase_highest_iv_sum)}[/] | "
-                f"{rich_name} Phase SV Records [green]{number(stats.encounter_summaries[pokemon.species.index].phase_lowest_sv)}[/]/[{sv_colour(stats.encounter_summaries[pokemon.species.index].phase_highest_sv)}]{number(stats.encounter_summaries[pokemon.species.index].phase_highest_sv)}[/] | "
-                f"{rich_name} Shiny Average: {format_shiny_average(stats.encounter_summaries[pokemon.species.index])}"
-            )
-            console.print(
-                f"Phase Encounters: {number(stats.totals.phase_encounters)} | "
-                f"Phase IV Records [red]{number(stats.totals.phase_lowest_iv_sum)}[/]/[green]{number(stats.totals.phase_highest_iv_sum)}[/] | "
-                f"Phase SV Records [green]{number(stats.totals.phase_lowest_sv)}[/]/[{sv_colour(stats.totals.phase_highest_sv)}]{number(stats.totals.phase_highest_sv)}[/]"
-            )
-            console.print(
-                f"Total Shinies: {number(stats.totals.shiny_encounters)} | "
-                f"Total Encounters: {number(stats.totals.total_encounters)} | "
-                f"Total Shiny Average: {format_shiny_average(stats.totals)})"
-            )
+    encounter_summaries: list["EncounterSummary"] = list(
+        filter(lambda e: e.phase_encounters > 0, stats.encounter_summaries.values())
+    )
+    encounter_summaries.sort(key=lambda e: e.species_name)
+    for summary in encounter_summaries:
+        stats_table.add_row(
+            summary.species_name,
+            f"[red]{number(summary.phase_lowest_iv_sum)}[/] / [green]{number(summary.phase_highest_iv_sum)}",
+            f"[green]{number(summary.phase_lowest_sv)}[/] / [{sv_colour(summary.phase_highest_sv)}]{number(summary.phase_highest_sv)}",
+            f"{number(summary.phase_encounters)}",
+            f"{percentage(summary.phase_encounters, stats.totals.phase_encounters)}",
+            f"{number(summary.shiny_encounters)}",
+            f"{number(summary.total_encounters)}",
+            format_shiny_average(summary),
+        )
+    stats_table.add_row(
+        "[bold yellow]Total",
+        f"[red]{number(stats.totals.phase_lowest_iv_sum)}[/] / [green]{number(stats.totals.phase_highest_iv_sum)}",
+        f"[green]{number(stats.totals.phase_lowest_sv)}[/] / [{sv_colour(stats.totals.phase_highest_sv)}]{number(stats.totals.phase_highest_sv)}",
+        f"[bold yellow]{number(stats.totals.phase_encounters)}",
+        "[bold yellow]100%",
+        f"[bold yellow]{number(stats.totals.shiny_encounters)}",
+        f"[bold yellow]{number(stats.totals.total_encounters)}",
+        format_shiny_average(stats.totals),
+    )
+
+    grid = Table.grid(expand=True)
+    grid.add_column()
+    grid.add_column()
+    grid.add_row(pokemon_table, Group(iv_table, move_list, ev_yields))
+
+    console.print(
+        Panel.fit(
+            Group(grid, "\n", stats_table),
+            border_style=type_colour,
+            title=f"{rich_name} [default]{encounter.type.verb} at [bold]{pokemon.location_met}[/bold][/default]",
+        )
+    )
 
 
 console = Console(theme=theme)

--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -146,13 +146,11 @@ def log_encounter(encounter_info: EncounterInfo) -> None:
         return
 
     log_entry = context.stats.log_encounter(encounter_info)
-    print_stats(context.stats.get_global_stats(), encounter_info)
+    if context.config.logging.log_encounters_to_console:
+        print_stats(context.stats.get_global_stats(), encounter_info)
     plugin_logging_encounter(encounter_info)
     if encounter_info.is_shiny:
         context.stats.reset_shiny_phase(log_entry)
-
-    if context.config.logging.save_pk3.all:
-        save_pk3(pokemon)
 
     # Generate the bot message shown below the video
     fun_facts = [
@@ -201,7 +199,7 @@ def handle_encounter(
         case EncounterValue.Shiny:
             console.print(f"[bold yellow]Shiny {pokemon.species.name} found![/]")
             alert = "Shiny found!", f"Found a ✨shiny {pokemon.species.name}✨! 🥳"
-            if not context.config.logging.save_pk3.all and context.config.logging.save_pk3.shiny:
+            if context.config.logging.save_pk3.shiny:
                 save_pk3(pokemon)
             is_of_interest = True
 
@@ -209,7 +207,7 @@ def handle_encounter(
             filter_result = encounter_info.catch_filters_result
             console.print(f"[pink green]Custom filter triggered for {pokemon.species.name}: '{filter_result}'[/]")
             alert = "Custom filter triggered!", f"Found a {pokemon.species.name} that matched one of your filters."
-            if not context.config.logging.save_pk3.all and context.config.logging.save_pk3.custom:
+            if context.config.logging.save_pk3.custom:
                 save_pk3(pokemon)
             is_of_interest = True
 
@@ -217,22 +215,23 @@ def handle_encounter(
             console.print(f"[pink yellow]Roaming {pokemon.species.name} found![/]")
             alert = "Roaming Pokémon found!", f"Encountered a roaming {pokemon.species.name}."
             # If this is the first time the Roamer is encountered
-            if pokemon.species not in get_pokedex().seen_species and (
-                not context.config.logging.save_pk3.all and context.config.logging.save_pk3.roamer
-            ):
+            if pokemon.species not in get_pokedex().seen_species and context.config.logging.save_pk3.roamer:
                 save_pk3(pokemon)
             is_of_interest = True
 
         case EncounterValue.ShinyOnBlockList:
             console.print(f"[bold yellow]{pokemon.species.name} is on the catch block list, skipping encounter...[/]")
             alert = None
-            if not context.config.logging.save_pk3.all and context.config.logging.save_pk3.shiny:
+            if context.config.logging.save_pk3.shiny:
                 save_pk3(pokemon)
             is_of_interest = False
 
         case EncounterValue.RoamerOnBlockList:
             console.print(f"[bold yellow]{pokemon.species.name} is on the catch block list, skipping encounter...[/]")
             alert = None
+            # If this is the first time the Roamer is encountered
+            if pokemon.species not in get_pokedex().seen_species and context.config.logging.save_pk3.roamer:
+                save_pk3(pokemon)
             is_of_interest = False
 
         case EncounterValue.Trash | _:

--- a/wiki/pages/Configuration - Discord.md
+++ b/wiki/pages/Configuration - Discord.md
@@ -16,18 +16,6 @@ For privacy reasons, rich presence and webhooks are all **disabled** by default.
 - Generate a new webhook: **Edit Channel** > **Integrations** > **Webhooks** > **New Webhook** > **Give it any name such as `PokéBot` and a picture** > **Copy Webhook URL**
 - ⚠ **Warning**: this webhook is considered sensitive! If you leak your webhook, anyone will be able to post in your channel
 
-`iv_format` - changes IV formatting displayed in messages, set to `basic` or `formatted`
-- `basic`: <br>`HP: 31 | ATK: 31 | DEF: 31  | SPA: 31  | SPD: 31  | SPE: 31`
-
-- `formatted`:
-  ```
-  ╔═══╤═══╤═══╤═══╤═══╤═══╗
-  ║HP │ATK│DEF│SPA│SPD│SPE║
-  ╠═══╪═══╪═══╪═══╪═══╪═══╣
-  ║31 │31 │31 │31 │31 │31 ║
-  ╚═══╧═══╧═══╧═══╧═══╧═══╝
-  ```
-
 `delay` - seconds (`int`) to delay Discord webhooks before posting (useful to prevent livestream spoilers)
 
 `bot_id` - set to any string you want, this string is added to the footer of all Discord messages, it can be useful to identify bots if multiple are set to post in the same channel
@@ -51,6 +39,10 @@ Each webhook type also supports pinging @users or @roles.
 `shiny_pokemon_encounter` - Post shiny Pokémon encounters
 
 ![image](../images/discord_config_shiny_encounter.png)
+
+***
+
+`blocked_shiny_encounter` - Post encounters that are shiny, but have not been caught because they're on the block list
 
 ***
 

--- a/wiki/pages/Console, Logging and Image Config.md
+++ b/wiki/pages/Console, Logging and Image Config.md
@@ -7,20 +7,18 @@
 This file allows you to enable or disable features of the bot that may generate data or images, such as .csv data logging, .pk3 dumping or shiny GIFs.
 
 ## Logging
+
 ### Options
-`log_encounters` - log all encounters to .csv (`./profile/<profile_name>/stats/encounters/` folder), each phase is logged to a separate file
+`log_encounters` - (Can be `true` or `false`.)   
+Log _all_ encounters (and not just shiny ones) to the stats database.  
+This doesn't impact performance much, but it means that the database file (`profiles/<profile name>/stats.db`) will grow much quicker.   
+It adds about 200 byte for each encounter. So for each 1 million encounters, the database would have a size of about 190 MB.
 
-`desktop_notifications` - Show a desktop notification if a shiny, roamer, or Pokémon matching your
-Custom Catch Filters is encountered, or the bot is switched to manual mode.
+`desktop_notifications` - (Can be `true` or `false`.)   
+Show a desktop notification if a shiny, roamer, or Pokémon matching your  Custom Catch Filters is encountered, or the bot is switched to manual mode.
 
-### Console output
-Console options will control how much data is displayed in the Python terminal/console, valid options are `verbose`, `basic` or `disable`.
-
-`console`:
-- `encounter_data`
-- `encounter_ivs`
-- `encounter_moves`
-- `statistics`
+`log_encounters_to_console` - (Can be `true` or `false`.)   
+Display information about wild encounters (and gift Pokémon) as well as your current phase statistics to the console.
 
 ## Save raw Pokémon data (.pk3)
 The bot can dump individual Pokémon files (.pk3 format) to be managed/transferred in the [PKHeX save editor](https://github.com/kwsch/PKHeX).
@@ -30,12 +28,10 @@ The Pokémon are dumped to the `./profile/<profile_name>/stats/pokemon/` folder,
 `273 ★ - SEEDOT - Modest [180] - C88CF14B19C6.pk3` (`<nat_dex_num> <shiny ★> - <mon_name> - <nature> [<IV sum>] - <pid>.pk3`)
 
 ### Options
-`save_pk3`:
-- `all` - dump all encounters
-- `shiny` - dump shiny encounters
-- `custom` - dump custom catch filter encounters
-- `roamer` - dump (non-shiny) roamers (Latias, Latios, Entei, Suicune, Raikou) -- this will only be done
-  if the Pokémon is not yet marked as 'seen' in the Pokédex
+`save_pk3`: (each option can be either `true` or `false`.)
+- `shiny` - Create .pk3 files for Shiny encounters
+- `custom` - Create .pk3 files for Pokémon that match your custom catch filters.
+- `roamer` - Create .pk3 files for the Roaming Pokémon (Latias/Latios on R/S/E, Entei/Raikou/Suicine on FR/LG) the first time it is encountered.
 
 Feel free to share any rare/interesting .pk3 files in [#pkhexchange💱](https://discord.com/channels/1057088810950860850/1123523909745135616)!
 
@@ -44,8 +40,7 @@ Capture and save a GIF of shiny encounters, example GIF below. If shiny [Discord
 
 Shiny GIFs are saved to the `./profile/<profile_name>/screenshots/gif/` folder.
 
-### Options
-`shiny_gifs` - capture and save a GIF of shiny encounters
+`shiny_gifs` - (Can be `true` or `false`.)
 
 ![image](../images/shiny.gif)
 
@@ -65,7 +60,6 @@ TCG cards are saved to the `./profile/<profile_name>/screenshots/cards/` folder.
 - National dex number (`004 / 386`) is bottom right of portrait
 - The cyan exp bar is based on the encounter's % of max IV sum (186)
 
-### Options
-`tcg_cards` - Create TCG cards for shiny encounters
+`tcg_cards` - (Can be `true` or `false`.)
 
 ![image](../images/tcg_example.png)


### PR DESCRIPTION
### Description

This removes most configuration options for logging so that it can essentially only be turned on or off. This simplifies both the code and testing.

Since console logging can now only be turned on or off, it will always display _all_ available information. To save space, I've updated the output format a bit:

- Moves are colour-coded by type, but there is no more additional information such as type name, PP, accuracy etc. People can look that up on Bulbapedia if they're interested, no value in displaying that here.
- EV Yield is displayed (could also be looked up, but might at least be vaguely useful here.)
- The IVs table contains and up/down arrow behind the stat that is increased/decreased by the Pokémon's nature.
- Gender and, for Wurmple only, the evolution is displayed

![image](https://github.com/user-attachments/assets/412e920e-03fb-466d-99b1-7b3db492cecb)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
