### PR TITLE
Fix in battle party indexes when replacing a move

### DIFF
--- a/modules/battle_move_replacing.py
+++ b/modules/battle_move_replacing.py
@@ -1,7 +1,7 @@
 from enum import Enum, auto
 from typing import Generator
 
-from modules.battle_state import battle_is_active
+from modules.battle_state import battle_is_active, get_battle_state
 from modules.battle_strategies import BattleStrategy
 from modules.context import context
 from modules.debug import debug
@@ -86,7 +86,8 @@ def handle_move_replacement_dialogue(strategy: BattleStrategy) -> Generator:
                     party_index = context.emulator.read_bytes(0x02016018, length=1)[0]
             else:
                 party_index = read_symbol("gBattleStruct", 16, 1)[0]
-            pokemon = get_party()[party_index]
+            in_battle_index = get_battle_state().map_battle_party_index(party_index)
+            pokemon = get_party()[in_battle_index]
             decision = strategy.which_move_should_be_replaced(pokemon, move_to_learn)
 
             if context.bot_mode == "Manual":


### PR DESCRIPTION
### Description

Fixing an error when attempting to replace a move in Level Grind mode. If the first Pokémon faints and a second one is sent in, the game would incorrectly target the index of the fainted Pokémon when trying to replace a move for the new one.

### Changes

Use in battle party index instead of overwold party indexes when replacing a move

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
