### PR TITLE
Take abilities into account when calculating effective encounter rates

### DIFF
--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -1,6 +1,6 @@
 import importlib
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum, auto
 from pathlib import Path
 from typing import Callable, TYPE_CHECKING
@@ -52,7 +52,7 @@ class EncounterInfo:
         local_coordinates = player_avatar.local_coordinates
         return cls(
             pokemon=pokemon,
-            encounter_time=datetime.now(),
+            encounter_time=datetime.now(timezone.utc),
             type=type if type is not None else get_encounter_type(),
             value=judge_encounter(pokemon),
             map=map_enum,

--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -1410,9 +1410,9 @@ class MapTab(DebugTab):
             result = {}
             value = []
             for encounter in encounters:
-                percentage = round(100 * encounter.encounter_rate)
-                value.append(f"{percentage}% {encounter.species.name}")
-                result[encounter.species.name] = f"{percentage}%; Lvl. {encounter.min_level}-{encounter.max_level}"
+                percentage = 100 * encounter.encounter_rate
+                value.append(f"{percentage:.1f}% {encounter.species.name}")
+                result[encounter.species.name] = f"{percentage:.1f}%; Lvl. {encounter.min_level}-{encounter.max_level}"
             result["__value"] = ", ".join(value)
             effective_encounters[label] = result
 
@@ -1431,12 +1431,15 @@ class MapTab(DebugTab):
         if "__value" not in effective_encounters:
             effective_encounters["__value"] = ""
 
-        if get_party_repel_level() > 0:
-            effective_encounters["__value"] = (
-                f"(Repel Lvl. {get_party_repel_level()}) {effective_encounters['__value']}"
-            )
+        encounter_modifiers = []
+        if effective_encounter_data.repel_level > 0:
+            encounter_modifiers.append(f"Repel Lvl. {effective_encounter_data.repel_level}")
         else:
-            effective_encounters["__value"] = f"(no Repel) {effective_encounters['__value']}"
+            encounter_modifiers.append("no Repel")
+        if effective_encounter_data.active_ability is not None:
+            encounter_modifiers.append(effective_encounter_data.active_ability.name)
+
+        effective_encounters["__value"] = f"({', '.join(encounter_modifiers)}) {effective_encounters['__value']}"
 
         if context.rom.is_rse:
             map_enum = MapRSE(map_data.map_group_and_number)

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -531,7 +531,7 @@ class GlobalStats:
                 phase_lowest_iv_sum=0,
                 phase_highest_sv=0,
                 phase_lowest_sv=0,
-                last_encounter_time=datetime.now(),
+                last_encounter_time=datetime.now(timezone.utc),
             )
 
     def to_dict(self):

--- a/modules/web/static/css/stream-overlay.css
+++ b/modules/web/static/css/stream-overlay.css
@@ -302,6 +302,19 @@ table.sv_hud {
     padding: 0 15px;
 }
 
+.info-bubbles-bottom-right .icon-pokemon.mirrored {
+    transform: scale(-4, 4) translateY(-5px) translateX(-3px) scaleX(-1);
+}
+
+.info-bubbles-bottom-right > .info-bubble.icon-right .icon-pokemon {
+    float: right;
+    transform: scale(4) translateY(-5px) scaleX(-1);
+}
+
+.info-bubbles-bottom-right > .info-bubble.icon-right .icon-pokemon.mirrored {
+    transform: scale(-4, 4) translateY(-5px) scaleX(-1);
+}
+
 .info-bubbles-bottom-right .icon-item {
     transform: scale(2.5) translateY(-2px) translateX(-3px);
     image-rendering: optimizespeed;

--- a/modules/web/static/js/stream-overlay.js
+++ b/modules/web/static/js/stream-overlay.js
@@ -9,8 +9,8 @@ time_zone = "Australia/Sydney" // "Australia/Sydney"
 override_display_timezone = "AEST" // "AEST"
 
 // Name of Pokemon for the "timers since last encounter" for a Pokemon to display on screen
-target_timer_1 = "Aron" // "Seedot"
-target_timer_2 = ""
+target_timer_1 = "Minun" // "Seedot"
+target_timer_2 = "Plusle"
 
 // Pokemon to display on the checklist (possible encounters via current bot mode are appended to top of list)
 // Leave it empty to only show encounters on the current route
@@ -252,8 +252,14 @@ async function handleStats(data) {
     state.stats = data
 
     if (target_timer_1 !== "" && data.pokemon[target_timer_1]) {
-        $("#target_1_sprite").attr("src", pokemonSprite(target_timer_1, false, false, true))
+        const sprite = $("#target_1_sprite")
+        sprite.attr("src", pokemonSprite(target_timer_1, false, false, true))
         $("#target_1").css("display", "inline-block")
+        if (target_timer_2 !== "" && data.pokemon[target_timer_2] && !sprite.hasClass("mirrored")) {
+            sprite.addClass("mirrored");
+        } else if ((target_timer_2 === "" || !data.pokemon[target_timer_2]) && sprite.hasClass("mirrored")) {
+            sprite.removeClass("mirrored");
+        }
     }
 
     if (target_timer_2 !== "" && data.pokemon[target_timer_2]) {
@@ -433,6 +439,15 @@ function handleMapEncounters(data) {
         $("#repel_info").css("display", "inline-block");
     } else {
         $("#repel_info").css("display", "none");
+    }
+
+    const abilityInfo = $("#ability_info");
+
+    if (data.active_ability) {
+        abilityInfo.css("display", "inline-block");
+        $("#ability_name").text(data.active_ability);
+    } else {
+        abilityInfo.css("display", "none");
     }
 
     refreshchecklist();

--- a/modules/web/static/stream-overlay.html
+++ b/modules/web/static/stream-overlay.html
@@ -151,6 +151,10 @@
     </table>
 
     <div class="info-bubbles-bottom-right">
+        <div class="info-bubble" id="ability_info">
+            <span class="time_unit" id="ability_name"></span>
+        </div>
+
         <div class="info-bubble" id="repel_info">
             <img src="sprites/items/Repel.png" class="icon-item"/>
 
@@ -158,7 +162,7 @@
             <span id="repel_level">77</span>
         </div>
 
-        <div class="info-bubble" id="target_2">
+        <div class="info-bubble icon-right" id="target_2">
             <img id="target_2_sprite" src="sprites/items/None.png" class="icon-pokemon"/>
 
             <span id="target_2_timer_hrs"></span>

--- a/modules/web/static/stream_events.d.ts
+++ b/modules/web/static/stream_events.d.ts
@@ -48,6 +48,7 @@ declare module StreamEvents {
 
     export type MapEncounters = {
         repel_level: number;
+        active_ability: string | null;
         regular: RegularEncounterList;
         effective: EffectiveEncounterList;
     };


### PR DESCRIPTION
### Description

When calculating effective encounter rates on a map, this will check whether the abilities Static, Magnet Pull, Intimidate or Keen Eye are active, all of which may modify the proportion of encounters.

I've also added an info bubble about encounter-relevant abilities to the stream overlay and fixed some timezone-related issues.

(This bubble will also appear for other abilities such as Suction Cups, Illuminate etc. that do not change the proportion of encounter rates, but affect encounter rates in general.)

![image](https://github.com/user-attachments/assets/00b8bd59-fa95-4183-8233-ce2ad2ac0e79)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
