### PR TITLE
Fix 'Total Encounters' value in Discord messages

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -7,7 +7,7 @@ from modules.console import console
 from modules.context import context
 from modules.memory import get_game_state
 from modules.modes import BotMode, BotModeError, FrameInfo, get_bot_listeners, get_bot_mode_by_name
-from modules.plugins import plugin_profile_loaded
+from modules.plugins import plugin_profile_loaded, load_plugins
 from modules.stats import StatsDatabase
 from modules.tasks import get_global_script_context, get_tasks
 
@@ -37,6 +37,7 @@ def main_loop() -> None:
     This function is run after the user has selected a profile and the emulator has been started.
     """
     try:
+        load_plugins()
         plugin_profile_loaded(context.profile)
 
         context.stats = StatsDatabase(context.profile)

--- a/pokebot.py
+++ b/pokebot.py
@@ -112,12 +112,10 @@ if __name__ == "__main__":
     from modules.exceptions_hook import register_exception_hook
     from modules.main import main_loop
     from modules.modes import get_bot_mode_names
-    from modules.plugins import load_plugins
     from modules.profiles import Profile, profile_directory_exists, load_profile_by_name
     from updater import run_updater
 
     register_exception_hook()
-    load_plugins()
 
     # This catches the signal Windows emits when the underlying console window is closed
     # by the user. We still want to save the emulator state in that case, which would not


### PR DESCRIPTION
### Description

Changes the Discord integration plugin so it uses the `GlobalStats` object rather than the current phase's snapshot values (which are only available when there's a Shiny encounter.)

I also moved where the plugins are loaded to the main loop, because at that point the selected `Profile` is available.

This is relevant because the built-in plugins (Discord, OBS, GIF/TCG Generator) only load if configuration actually uses it. So if these things were disabled globally and only enabled in the profile-specific config, they wouldn't load.

![image](https://github.com/user-attachments/assets/3748bbb0-265d-4eef-9bfe-4d226b119c15)


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
