### PR TITLE
Fire red : Support roamer reset mode for IT, SP, FR, GR languages

### DIFF
--- a/modules/data/symbols/patches/language/pokefirered.json
+++ b/modules/data/symbols/patches/language/pokefirered.json
@@ -446,6 +446,7 @@
     "S":"802e994"
   },
   "Task_DuckBGMForPokemonCry":{
+    "D":"8072198",
     "F":"8072258",
     "I":"8072184",
     "J":"80719d8",
@@ -480,6 +481,12 @@
     "F":"81d721a",
     "I":"81d5eb2",
     "S":"81d857a"
+  },
+  "EventScript_RepelWoreOff":{
+    "D":"81c36a8",
+    "F":"81be5d1",
+    "I":"81bd118",
+    "S":"81bf7f1"
   },
   "Route19_Text_LucRematchIntro":{
     "D":"0"

--- a/wiki/pages/Mode - Roamer Resets.md
+++ b/wiki/pages/Mode - Roamer Resets.md
@@ -58,10 +58,10 @@ Unlike Emerald version, Ruby and Sapphire are not restricted by the sequence tha
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ✅    |      ✅      |     ✅      |     ✅      |      ✅       |
 | Japanese |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
-| German   |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
-| Spanish  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
-| French   |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
-| Italian  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| German   |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
+| Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
+| French   |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
+| Italian  |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
 
 ✅ Tested, working
 


### PR DESCRIPTION
### Description

Add support for Roamer Reset mode

Supported games and languages : 
|          | 🔥 FireRed
| :------- | :-----: |
| English|   Already supported✅    |
| German   |   Supported now ✅    |
| Spanish  |   Supported now ✅    |
| French   |   Supported now ✅    |
| Italian  |   Supported now ✅    |
| Japanese|   Unsupported ❌    |

### Changes

Update Fire Red symbol mapping to support Roamer Reset mode

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
