### PR TITLE
Fix plugin loading again

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -7,7 +7,7 @@ from modules.console import console
 from modules.context import context
 from modules.memory import get_game_state
 from modules.modes import BotMode, BotModeError, FrameInfo, get_bot_listeners, get_bot_mode_by_name
-from modules.plugins import plugin_profile_loaded, load_plugins
+from modules.plugins import plugin_profile_loaded, load_built_in_plugins
 from modules.stats import StatsDatabase
 from modules.tasks import get_global_script_context, get_tasks
 
@@ -37,7 +37,14 @@ def main_loop() -> None:
     This function is run after the user has selected a profile and the emulator has been started.
     """
     try:
-        load_plugins()
+        # Built-in plugins are only loaded if some bot configuration actually requires them.
+        # Since profile configuration can override global configuration, they can only be
+        # loaded at this point where the profile has been loaded and so the full config is
+        # available.
+        #
+        # Regular (user-provided) plugins need to be loaded in `pokebot.py` as early as possible
+        # because they might add bot modes.
+        load_built_in_plugins()
         plugin_profile_loaded(context.profile)
 
         context.stats = StatsDatabase(context.profile)

--- a/modules/plugins.py
+++ b/modules/plugins.py
@@ -22,24 +22,6 @@ def load_plugins():
     if not plugins_dir.exists():
         return
 
-    # This plugin needs to be loaded first so that is executed first. That's because it is supposed
-    # to set the `gif_path` and `tcg_card_path` properties on wild encounters so that other plugins
-    # can use them.
-    if context.config.logging.shiny_gifs or context.config.logging.tcg_cards:
-        from modules.built_in_plugins.generate_encounter_media import GenerateEncounterMediaPlugin
-
-        plugins.append(GenerateEncounterMediaPlugin())
-
-    if context.config.obs.screenshot or context.config.obs.replay_buffer:
-        from modules.built_in_plugins.obs import OBSPlugin
-
-        plugins.append(OBSPlugin())
-
-    if context.config.discord.is_anything_enabled():
-        from modules.built_in_plugins.discord_integration import DiscordPlugin
-
-        plugins.append(DiscordPlugin())
-
     for file in plugins_dir.iterdir():
         if file.name.endswith(".py"):
             module_name = file.name[:-3]
@@ -56,6 +38,29 @@ def load_plugins():
 
             for class_name, plugin_class in classes:
                 plugins.append(plugin_class())
+
+
+def load_built_in_plugins():
+    # This plugin needs to be loaded first so that is executed first. That's because it is supposed
+    # to set the `gif_path` and `tcg_card_path` properties on wild encounters so that other plugins
+    # can use them.
+    if context.config.logging.shiny_gifs or context.config.logging.tcg_cards:
+        from modules.built_in_plugins.generate_encounter_media import GenerateEncounterMediaPlugin
+
+        plugins.insert(0, GenerateEncounterMediaPlugin())
+
+    if context.config.obs.screenshot or context.config.obs.replay_buffer:
+        from modules.built_in_plugins.obs import OBSPlugin
+
+        plugins.insert(1, OBSPlugin())
+
+    if context.config.discord.is_anything_enabled():
+        from modules.built_in_plugins.discord_integration import DiscordPlugin
+
+        plugins.insert(1, DiscordPlugin())
+
+    for plugin in plugins:
+        print(plugin)
 
 
 def plugin_get_additional_bot_modes() -> Iterable["BotMode"]:

--- a/pokebot.py
+++ b/pokebot.py
@@ -112,10 +112,12 @@ if __name__ == "__main__":
     from modules.exceptions_hook import register_exception_hook
     from modules.main import main_loop
     from modules.modes import get_bot_mode_names
+    from modules.plugins import load_plugins
     from modules.profiles import Profile, profile_directory_exists, load_profile_by_name
     from updater import run_updater
 
     register_exception_hook()
+    load_plugins()
 
     # This catches the signal Windows emits when the underlying console window is closed
     # by the user. We still want to save the emulator state in that case, which would not


### PR DESCRIPTION
### Description

I found out the reason why `load_plugins()` was called very early on in `pokebot.py`: Because that's the point where the bot mode list is queried.

So right now, a mode added through a plugin would never show up in the list because it's being loaded too late.

I've split up loading user-provided plugins (early) and built-in plugins (only after profile selection so that profile config is available.)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
