### PR TITLE
Fix nidoran gender being displayed twice

### DIFF
--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -164,10 +164,11 @@ def log_encounter(encounter_info: EncounterInfo) -> None:
     species_name = pokemon.species.name
     if pokemon.is_shiny:
         species_name = f"Shiny {species_name}"
-    if pokemon.gender == "male":
-        species_name += " ♂"
-    elif pokemon.gender == "female":
-        species_name += " ♀"
+    if not pokemon.species.name.startswith("Nidoran"):
+        if pokemon.gender == "male":
+            species_name += " ♂"
+        elif pokemon.gender == "female":
+            species_name += " ♀"
     if pokemon.species.name == "Unown":
         species_name += f" ({pokemon.unown_letter})"
     if pokemon.species.name == "Wurmple":


### PR DESCRIPTION
### Description

On the bot GUI console we were displaying Nidorans gender twice

### Changes

Check if the Pokémon species is a Nidoran before adding the gender

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
