### PR TITLE
Fix datetime import in OBS plugin

### DIFF
--- a/modules/built_in_plugins/obs.py
+++ b/modules/built_in_plugins/obs.py
@@ -11,7 +11,7 @@ from threading import Thread
 from typing import TYPE_CHECKING, Generator
 
 import obsws_python as obs
-from black import datetime
+from datetime import datetime
 
 from modules.console import console
 from modules.context import context


### PR DESCRIPTION
### Description

Linters doesn't provide DateTimes 🤓 

### Changes

Fix OBS DateTime import

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
