### PR TITLE
Fire Red : Fix poison listener for EU languages

### DIFF
--- a/modules/data/symbols/patches/language/pokefirered.json
+++ b/modules/data/symbols/patches/language/pokefirered.json
@@ -500,6 +500,12 @@
     "I":"8164f39",
     "S":"816502d"
   },
+  "EventScript_FieldPoison":{
+    "D":"81abc2f",
+    "F":"81a7826",
+    "I":"81a6685",
+    "S":"81a88c6"
+  },
   "Route19_Text_LucRematchIntro":{
     "D":"0"
   },


### PR DESCRIPTION
### Description

Bot stopped when Pokémon died by poison on overworld on EU languages

### Changes

Update symbol mapping to handle this case

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
