### PR TITLE
Fire Red : Support SGR for EU languages

### DIFF
--- a/modules/data/symbols/patches/language/pokefirered.json
+++ b/modules/data/symbols/patches/language/pokefirered.json
@@ -506,6 +506,12 @@
     "I":"81a6685",
     "S":"81a88c6"
   },
+  "Std_MsgboxDefault":{
+    "D":"81a7b08",
+    "F":"81a39b9",
+    "I":"81a27f1",
+    "S":"81a496a"
+  },
   "Route19_Text_LucRematchIntro":{
     "D":"0"
   },

--- a/wiki/pages/Mode - Rock Smash.md
+++ b/wiki/pages/Mode - Rock Smash.md
@@ -51,14 +51,14 @@ The mode will continuously try to enter the Safari Zone, so make sure you have s
 
 
 ## Game Support
-|          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
-|:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
-| English  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
-| Japanese |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
-| German   |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
-| Spanish  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
-| French   |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
-| Italian  |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+|          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald |
+|:---------|:-------:|:-----------:|:----------:|
+| English  |    ❌    |      ❌      |     ✅      |
+| Japanese |    ❌    |      ❌      |     ✅      |
+| German   |    ❌    |      ❌      |     ✅      |
+| Spanish  |    ❌    |      ❌      |     ✅      |
+| French   |    ❌    |      ❌      |     ✅      |
+| Italian  |    ❌    |      ❌      |     ✅      |
 
 ✅ Tested, working
 

--- a/wiki/pages/Mode - Static Gift Resets.md
+++ b/wiki/pages/Mode - Static Gift Resets.md
@@ -136,10 +136,10 @@ Soft reset for a static gift Pokémon that are directly added to your party with
 | :------- | :-----: | :---------: | :--------: | :--------: | :----------: |
 | English  |   🟨    |     🟨      |     ✅     |     ✅     |      ✅      |
 | Japanese |   ❌    |     ❌      |     ✅     |     ❌     |      ❌      |
-| German   |   ❌    |     ❌      |     ✅     |     ❌     |      ❌      |
-| Spanish  |   ❌    |     ❌      |     ✅     |     ❌     |      ❌      |
-| French   |   ❌    |     ❌      |     ✅     |     ❌     |      ❌      |
-| Italian  |   ❌    |     ❌      |     ✅     |     ❌     |      ❌      |
+| German   |   ❌    |     ❌      |     ✅     |     ✅     |      ❌      |
+| Spanish  |   ❌    |     ❌      |     ✅     |     ✅     |      ❌      |
+| French   |   ❌    |     ❌      |     ✅     |     ✅     |      ❌      |
+| Italian  |   ❌    |     ❌      |     ✅     |     ✅     |      ❌      |
 
 ✅ Tested, working
 


### PR DESCRIPTION
### Description

- Tested all SGR targets on Fire Red
- Fixed Togepi SGR not working on FR, IT, DE, SP languages
- Remove confusing game support for FR/LG for rock smash mode

### Changes

Update Fire Red symbol mapping

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
