### PR TITLE
Rock Smash: Check correct party member for Repel level, describe better strategy in Wiki

### DIFF
--- a/modules/modes/roamer_reset.py
+++ b/modules/modes/roamer_reset.py
@@ -101,18 +101,17 @@ class RoamerResetMode(BotMode):
 
         save_data = get_save_data()
         saved_party = save_data.get_party()
+        first_pokemon = next((p for p in saved_party if not p.is_egg and p.current_hp > 0), None)
 
-        if saved_party[0].is_egg:
-            raise BotModeError("The first Pokémon in your party must not be an egg in order for Repel to work.")
-
-        if saved_party[0].level > roamer_level:
+        if first_pokemon.level > roamer_level:
             raise BotModeError(
-                f"The first Pokémon in your party has to be level {roamer_level} or lower in order for Repel to work."
+                f"The first non-fainted Pokémon in your party has to be level "
+                f"{roamer_level} or lower in order for Repel to work."
             )
 
-        if saved_party[0].level <= highest_encounter_level:
+        if first_pokemon.level <= highest_encounter_level:
             raise BotModeError(
-                "The first Pokémon in your party has to be at least level "
+                "The first non-fainted Pokémon in your party has to be at least level "
                 f"{highest_encounter_level + 1} in order for Repel to work."
             )
 

--- a/wiki/pages/Mode - Rock Smash.md
+++ b/wiki/pages/Mode - Rock Smash.md
@@ -10,8 +10,19 @@ Rock smash mode will continuously farm Rock Smash encounters in Granite Cave (No
 You can use this mode either with or without Repel.  
 If using Repel, the bot will use up any Repel items in your inventory and then reset once it ran out.
 
-Using Repel on its own give a minor boost to encounter rates (around +5%), but if you have a **White Flute**
-in your inventory, the bot will use that as well and in combination that can boost encounters by **up to 40%**.
+Using Repel on its own give a minor boost to encounter rates (around +5%), but there are two ways to
+boost encounter rates significantly (that both require Repel to be used):
+
+1. If you have a **White Flute** in your inventory, the bot will use that as well and in combination
+   that can boost encounters by **up to 40%**.
+2. If you have a Pokémon with the ability **Vital Spirit** or **Pressure** as the first Pokémon in
+   your party, that can give you **another 35% boost** to Nosepass encounters.
+
+A good candidate for a Pokémon with such an ability would be Vigoroth -- which you can get by catching
+a Slakoth in Petalburg Woods and evolving it at level 18. Because that level would be too high for the
+Repel strategy, you should _make it faint_ (its ability will still work) and put it in the first slot
+of your party, and then put a non-fainted level-13 Pokémon in the second slot (because Repel works with
+the level of the first _non-fainted_ Pokémon.)
 
 If you have any Repel items in your inventory, the game will offer you this choice:
 
@@ -27,8 +38,9 @@ If you have any Repel items in your inventory, the game will offer you this choi
 - Make sure you have some Repel in your inventory (Max Repel works best, but Super Repel or Repel will do.)  
   While the bot can work with as few as 1 Repel, having a few dozen will improve rates by spending less time resetting.
 - Optional, but highly recommended: Get the White Flute.
-- Make sure the first Pokémon in your party has level 13. The bot will accept Pokémon up to level 16, but 13 gives you
-  the best rates.
+- Optional, but highly recommended: Get a Pokémon with the ability Vital Spirit or Pressure as the first Pokémon.
+- Make sure the first non-fainted Pokémon in your party has level 13. The bot will accept Pokémon up to level 16, but
+  13 gives you the best rates.
 - Go to the bottom floor of Granite Cave (B2F)
 - **Save the game**
 - Start mode and select 'Use Repel'


### PR DESCRIPTION
### Description

Repel works by using the level of the first **non-fainted, non-egg** Pokémon in the player's party.

But both Rock Smash and Roamer Reset modes just checked the first party slot. So if the first Pokémon in the party was fainted, it would erroneously still use that for the repel level check.

Also, I have updated Rock Smash's Wiki page to advise users to use a Pokémon with the Vital Spirit or Pressure abilities as their first party member, as that gives another +35% boost to encounter rates.

This possibility was found by **14flash** on the Discord server and verified through benchmarking.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
