### PR TITLE
Fix zero pointer not being overrided

### DIFF
--- a/modules/game.py
+++ b/modules/game.py
@@ -44,7 +44,7 @@ def _load_symbols(symbols_file: str, language: ROMLanguage) -> None:
                 if language_code in addr_mapping:
                     addresses_list = addr_mapping[language_code]
 
-                    if not addresses_list:
+                    if addresses_list is None:
                         continue
 
                     if isinstance(addresses_list, int):


### PR DESCRIPTION
### Description

Oopsies, pointer that had `0x0` pointer were skipped

### Changes

Fix the YML parsing function

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
