### PR TITLE
FR/LG: Fix 'Map' debug tab crashing when on a map with a cloned object event template

### DIFF
--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -1448,7 +1448,12 @@ class MapTab(DebugTab):
             map_enum = MapFRLG(map_data.map_group_and_number)
             group_enum = MapGroupFRLG(map_data.map_group)
 
-        pt = _find_tile_by_local_coordinates(map_data.map_group_and_number, map_data.local_position)
+        # During warps (for example when entering/exiting a building) map data might not be loaded for a
+        # frame or so, in which case we just wait.
+        try:
+            pt = _find_tile_by_local_coordinates(map_data.map_group_and_number, map_data.local_position)
+        except IndexError:
+            return {}
 
         return {
             "Map": {

--- a/modules/map.py
+++ b/modules/map.py
@@ -1671,7 +1671,15 @@ class ObjectEventTemplate:
         return data
 
     def __str__(self) -> str:
-        if self.trainer_type != "None":
+        if self.kind == "clone":
+            from .map_data import MapRSE, MapFRLG
+
+            if context.rom.is_rse:
+                target_map = MapRSE((self.clone_target_map_group, self.clone_target_map_number))
+            else:
+                target_map = MapFRLG((self.clone_target_map_group, self.clone_target_map_number))
+            return f"Cloned object ({self.clone_target_local_id} @ {target_map.name})"
+        elif self.trainer_type != "None":
             defeated = "(defeated)" if self.is_trainer_defeated else "(will battle)"
             if self.trainer_type == "Buried":
                 return f"Buried Trainer {defeated} at {self.local_coordinates}"


### PR DESCRIPTION
### Description

FR/LG have a special ObjectEventTemplate type, the 'clone'.

From how I understand it, that's just a _reference_ to an object on an adjacent map which may have to be loaded when close to the border with that map. (Because it might already be visible even though the player is still on another map.)

This used the `struct ObjectEventTemplate` a bit differently (there's a union inside it on FR/LG) which we did not handle properly. So when ignoring the union and trying to handle it like a trainer, the values would be nonsensical.

When trying to display an ObjectEventTemplate like this, the 'Map' debug tab would crash.

Also, this PR fixes another bug where the Map debug tab would sometimes crash after a warp (like entering/leaving a building.)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
