### PR TITLE
Fix banned moves being used on battling

### DIFF
--- a/modules/battle_strategies/_util.py
+++ b/modules/battle_strategies/_util.py
@@ -234,6 +234,8 @@ class BattleStrategyUtil:
     def get_strongest_move_against(self, pokemon: "BattlePokemon", opponent: "BattlePokemon"):
         move_strengths = []
         for learned_move in pokemon.moves:
+            if learned_move.move.name in context.config.battle.banned_moves:
+                continue
             move = learned_move.move
             if learned_move.pp == 0 or pokemon.disabled_move is move:
                 move_strengths.append(-1)


### PR DESCRIPTION
### Description

Banned moves like False swipe, self destruct etc are being used when battling. This prevent modes like level grind to work properly.

### Changes

Skip banned moves when chosing strongest move against an opponent

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
