### PR TITLE
Take previously fainted party members into account when rotating lead

### DIFF
--- a/modules/battle_strategies/default.py
+++ b/modules/battle_strategies/default.py
@@ -6,6 +6,13 @@ from ._util import BattleStrategyUtil
 
 
 class DefaultBattleStrategy(BattleStrategy):
+    def __init__(self):
+        self._first_non_fainted_party_index_before_battle = 0
+        for index, pokemon in enumerate(get_party()):
+            if not pokemon.is_egg and pokemon.current_hp > 0:
+                self._first_non_fainted_party_index_before_battle = index
+                break
+
     def party_can_battle(self) -> bool:
         return any(self.pokemon_can_battle(pokemon) for pokemon in get_party())
 
@@ -132,7 +139,7 @@ class DefaultBattleStrategy(BattleStrategy):
 
     def choose_new_lead_after_battle(self) -> int | None:
         party = get_party()
-        if not self.pokemon_can_battle(party[0]):
+        if not self.pokemon_can_battle(party[self._first_non_fainted_party_index_before_battle]):
             return self._select_rotation_target()
 
         return None


### PR DESCRIPTION
### Description

The default battle handler would, until now, always check the first Pokémon in the party when deciding whether to rotate the lead after a battle -- even if that first Pokémon was unable to battle (fainted, egg) before the battle already.

This means that when having a fainted Pokémon in that first slot on purpose (in order to make use of its ability), the bot would still rotate the lead and thus disable the ability.

This change makes it so the bot remembers the first non-fainted lead before a battle, and ignores any party slots before that.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
