### PR TITLE
Fire Red : Support Roamer mode for JP language

### DIFF
--- a/modules/data/symbols/patches/language/pokefirered.yml
+++ b/modules/data/symbols/patches/language/pokefirered.yml
@@ -90,7 +90,7 @@ gPlayerPartyCount:
 gPlayerParty:
   J: 0x20241e4
 sMapCursor:
-  J: 0x2039930
+  J: 0x203995c
 #----------------#
 
 #--------------------#

--- a/wiki/pages/Mode - Roamer Resets.md
+++ b/wiki/pages/Mode - Roamer Resets.md
@@ -57,7 +57,7 @@ Unlike Emerald version, Ruby and Sapphire are not restricted by the sequence tha
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ✅    |      ✅      |     ✅      |     ✅      |      ✅       |
-| Japanese |    ❌    |      ❌      |     ✅      |     ❌      |      ❌       |
+| Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
 | German   |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
 | Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
 | French   |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |


### PR DESCRIPTION
### Description

## Fire Red Japanese

Add support for :
- Roamer mode

### Changes

Updated Fire Red YML mapping for JP language

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

Debug states PR is [here](https://github.com/johnnieb333/Pokebot-Profiles/pull/17)
