### PR TITLE
Fire Red : Support Nugget Bridge and Puzzle solver modes for JP language

### DIFF
--- a/modules/data/symbols/patches/language/pokefirered.yml
+++ b/modules/data/symbols/patches/language/pokefirered.yml
@@ -36,7 +36,7 @@ EventScript_UseStrength:
   D: 0x81c1be8
   F: 0x81bcafd
   I: 0x81bb77a
-  J: ~
+  J: 0x81a490e
   S: 0x81bde41
 #-------------------------------#
 
@@ -375,7 +375,7 @@ SevenIsland_SevaultCanyon_TanobyKey_EventScript_PuzzleSolved:
   D: 0x8164f01
   F: 0x8164fb8
   I: 0x8164f39
-  J: ~
+  J: 0x816eecb
   S: 0x816502d
 #-------------------------#
 

--- a/wiki/pages/Mode - Nugget Bridge.md
+++ b/wiki/pages/Mode - Nugget Bridge.md
@@ -28,7 +28,7 @@ The bot will repeatedly battle and white-out to the Rocket trainer, so any money
 |          | 🔥 Fire Red | 🌿 Leaf Green |
 |:---------|-------------|---------------|
 | English  | ✅           | ✅             |
-| Japanese | ❌           | ❌             |
+| Japanese | ✅           | ❌             |
 | German   | 🚫          | ❌             |
 | Spanish  | 🚫          | ❌             |
 | French   | 🚫          | ❌             |

--- a/wiki/pages/Mode - Puzzle Solver.md
+++ b/wiki/pages/Mode - Puzzle Solver.md
@@ -133,7 +133,7 @@ Start mode inside Tanoby Key.
 | **Deoxys**     | 🟥 Ruby      |   ✅    |    ❌    |   ❌   |   ❌    |   ❌   |   ❌    |
 |                | 🔷 Sapphire  |   ✅    |    ❌    |   ❌   |   ❌    |   ❌   |   ❌    |
 |                | 🟢 Emerald   |   ✅    |    ❌    |   ❌   |   ❌    |   ❌   |   ❌    |
-|                | 🔥 Fire Red  |   ✅    |    ❌    |   ✅   |   ✅   |   ✅   |   ✅    |
+|                | 🔥 Fire Red  |   ✅    |    ✅    |   ✅   |   ✅   |   ✅   |   ✅    |
 |                | 🌿 LeafGreen |   ✅    |    ❌    |   ❌   |   ❌    |   ❌   |   ❌    |
 | **Regice**     | 🟥 Ruby      |   ✅    |    ❌    |   ❌   |   ❌    |   ❌   |   ❌    |
 |                | 🔷 Sapphire  |   ✅    |    ❌    |   ❌   |   ❌    |   ❌   |   ❌    |
@@ -144,7 +144,7 @@ Start mode inside Tanoby Key.
 | **Registeel**  | 🟥 Ruby      |   ✅    |    ❌    |   ❌   |   ❌    |   ❌   |   ❌    |
 |                | 🔷 Sapphire  |   ✅    |    ❌    |   ❌   |   ❌    |   ❌   |   ❌    |
 |                | 🟢 Emerald   |   ✅    |    ❌    |   ❌   |   ❌    |   ❌   |   ❌    |
-| **Tanoby Key** | 🔥 Fire Red  |   ✅    |    ❌    |   ✅   |   ✅    |   ✅   |   ✅    |
+| **Tanoby Key** | 🔥 Fire Red  |   ✅    |    ✅    |   ✅   |   ✅    |   ✅   |   ✅    |
 |                | 🌿 LeafGreen |   ✅    |    ❌    |   ❌   |   ❌    |   ❌   |   ❌    |
 
 ✅ Tested, working


### PR DESCRIPTION
### Description

## Fire Red Japanese

Add support for :
- Nugget Bridge mode
- Puzzle solver mode

### Changes

Updated Fire Red YML mapping for JP language

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

Debug states PR is [here](https://github.com/johnnieb333/Pokebot-Profiles/pull/18)
