### PR TITLE
Support battling lg eu languages

### DIFF
--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -152,16 +152,16 @@ GTASKS:
   S: 0x3004fe0
 BattleMainCB1:
   D: 0x8012368
-  F: ~
-  I: ~
+  F: 0x8012354
+  I: 0x8012368
   J: ~
-  S: ~
+  S: 0x8012354
 BattleMainCB2:
   D: 0x8011084
-  F: ~
-  I: ~
+  F: 0x8011070
+  I: 0x8011084
   J: ~
-  S: ~
+  S: 0x8011070
 HandleTurnActionSelectionState:
   D: 0x8013fc4
   F: ~
@@ -270,10 +270,10 @@ gAbsentBattlerFlags:
   J: ~
 gBattleResults:
   D: 0x3004ee0
-  F: ~
-  I: ~
+  F: 0x3004ee0
+  I: 0x3004ee0
   J: ~
-  S: ~
+  S: 0x3004ee0
 gBattleWeather:
   J: ~
 #--------------------#
@@ -410,7 +410,7 @@ CB2_RETURNTOFIELDLOCAL:
   J: ~
   S: ~
 MAINCB2:
-  D: 0x8011084
+  D: ~
   F: ~
   I: ~
   J: ~

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -164,22 +164,30 @@ BattleMainCB2:
   S: 0x8011070
 HandleTurnActionSelectionState:
   D: 0x8013fc4
-  F: ~
-  I: ~
+  F: 0x8013fb0
+  I: 0x8013fc5
   J: ~
-  S: ~
+  S: 0x8013fb0
 HandleInputChooseAction:
-  D: 0x802e3d0
-  F: ~
-  I: ~
+  D:
+    - 0x802e3d0
+    - 0x80dd7a0
+  F:
+    - 0x802e3a8
+    - 0x80dd860
+  I:
+    - 0x802e3bc
+    - 0x80dd7a0
   J: ~
-  S: ~
+  S:
+    - 0x802e3bc
+    - 0x80dd888
 HandleInputChooseMove:
   D: 0x802e9a8
-  F: ~
-  I: ~
+  F: 0x802e980
+  I: 0x802e994
   J: ~
-  S: ~
+  S: 0x802e994
 Task_DuckBGMForPokemonCry:
   D: 0x8072198
   F: ~
@@ -187,11 +195,11 @@ Task_DuckBGMForPokemonCry:
   J: ~
   S: ~
 BattleScript_HandleFaintedMon:
-  D: 0x81dcd45
-  F: ~
-  I: ~
+  D: 0x81dc944
+  F: 0x81d6e80
+  I: 0x81d5b18
   J: ~
-  S: ~
+  S: 0x81d81e0
 Task_BattleStart:
   D: 0x807f558
   F: ~
@@ -212,10 +220,10 @@ Task_InputHandler_SelectOrForgetMove:
   S: ~
 Task_HandleChooseMonInput:
   D: 0x811fb34
-  F: ~
-  I: ~
+  F: 0x811fbf4
+  I: 0x811fb78
   J: ~
-  S: ~
+  S: 0x811fc60
 Task_RushInjuredPokemonToCenter:
   D: 0x807f394
   F: ~
@@ -340,10 +348,10 @@ Std_MsgboxDefault:
 #-------------------#
 Task_Fishing:
   D: ~
-  F: ~
-  I: ~
+  F: 0x805d3c4
+  I: 0x805d2f0
   J: ~
-  S: ~
+  S: 0x805d3d8
 #-------------------#
 
 #-------------------------#
@@ -440,23 +448,23 @@ sStartMenuOrder:
 #   Bag Menu   #
 #--------------#
 CB2_BAGMENURUN:
-  D: ~
-  F: ~
-  I: ~
+  D: 0x8107f34
+  F: 0x8107ff4
+  I: 0x8107f78
   J: ~
-  S: ~
+  S: 0x8108060
 Task_BagMenu_HandleInput:
-  D: ~
-  F: ~
-  I: ~
+  D: 0x8108f60
+  F: 0x8109020
+  I: 0x8108fa4
   J: ~
-  S: ~
+  S: 0x8133d44
 Task_FieldItemContextMenuHandleInput:
-  D: ~
-  F: ~
-  I: ~
+  D: 0x8109c14
+  F: 0x8109cd4
+  I: 0x8109c58
   J: ~
-  S: ~
+  S: 0x8109d40
 gBagMenuState:
   J: ~
 gPaletteFade:
@@ -468,10 +476,10 @@ gPaletteFade:
 #----------------#
 CB2_UPDATEPARTYMENU:
   D: 0x811ebac
-  F: ~
-  I: ~
+  F: 0x811ec6c
+  I: 0x811ebf0
   J: ~
-  S: ~
+  S: 0x811ecd8
 Task_PrintAndWaitForText:
   D: 0x8120334
   F: ~

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -546,11 +546,11 @@ CB2_EggHatch_1:
   J: ~
   S: ~
 EventScript_RepelWoreOff:
-  D: ~
-  F: ~
-  I: ~
+  D: 0x81c368c
+  F: 0x81be5b0
+  I: 0x81bd0f7
   J: ~
-  S: ~
+  S: 0x81bf7d0
 EventScript_DoTrainerBattle:
   D: ~
   F: ~

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -226,16 +226,16 @@ Task_HandleChooseMonInput:
   S: 0x811fc60
 Task_RushInjuredPokemonToCenter:
   D: 0x807f394
-  F: ~
-  I: ~
+  F: 0x807f454
+  I: 0x807f380
   J: ~
-  S: ~
+  S: 0x807f468
 EventScript_AfterWhiteOutHeal:
-  D: ~
-  F: ~
-  I: ~
+  D: 0x81abba5
+  F: 0x81a779c
+  I: 0x81a65fb
   J: ~
-  S: ~
+  S: 0x81a883c
 BattleScript_AskToLearnMove:
   D: 0x81dcc8d
   F: 0x81d71c9
@@ -589,3 +589,15 @@ TrackStop_3:
   D: 0x0
 ChnVolSetAsm:
   D: 0x0
+Route21_North_EventScript_IanRematch:
+  D: 0x0
+Route23_EventScript_MissingBoulderBadge:
+  F: 0x0
+EventScript_SetEnteringCyclingRoad:
+  F: 0x0
+Route23_EventScript_MissingBadge:
+  F: 0x0
+EventScript_PkmnCenterNurse_PlayerWaitingInUionRoom:
+  I: 0x0
+EventScript_Open9FDoor3:
+  S: 0x0

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -430,10 +430,10 @@ MAINCB2:
 #-----------------#
 Task_StartMenuHandleInput:
   D: 0x806f154
-  F: ~
-  I: ~
+  F: 0x806f214
+  I: 0x806f140
   J: ~
-  S: ~
+  S: 0x806f228
 sMenu:
   J: ~
 sStartMenuCursorPos:
@@ -494,10 +494,10 @@ Task_HandleInput:
   S: ~
 Task_HandleSelectionMenuInput:
   D: 0x8122c6c
-  F: ~
-  I: ~
+  F: 0x8122d28
+  I: 0x8122cac
   J: ~
-  S: ~
+  S: 0x8122d98
 Task_SlideSelectedSlotsOnscreen:
   D: 0x8123398
   F: ~

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -208,16 +208,16 @@ Task_BattleStart:
   S: ~
 Task_EvolutionScene:
   D: 0x80cea50
-  F: ~
-  I: ~
+  F: 0x80ceb10
+  I: 0x80cea30
   J: ~
-  S: ~
+  S: 0x80ceb18
 Task_InputHandler_SelectOrForgetMove:
   D: 0x8139448
-  F: ~
-  I: ~
+  F: 0x8139504
+  I: 0x8139488
   J: ~
-  S: ~
+  S: 0x8139574
 Task_HandleChooseMonInput:
   D: 0x811fb34
   F: 0x811fbf4
@@ -237,17 +237,18 @@ EventScript_AfterWhiteOutHeal:
   J: ~
   S: ~
 BattleScript_AskToLearnMove:
-  D: ~
-  F: ~
-  I: ~
+  D: 0x81dcc8d
+  F: 0x81d71c9
+  I: 0x81d5e61
   J: ~
-  S: ~
+  S: 0x81d8529
+# BattleScript_AskToLearnMove + 2d
 BattleScript_ForgotAndLearnedNewMove:
-  D: ~
-  F: ~
-  I: ~
+  D: 0x81dccba
+  F: 0x81d71f6
+  I: 0x81d5e8e
   J: ~
-  S: ~
+  S: 0x81d8556
 gMoveSelectionCursor:
   J: ~
 gBattleOutcome:
@@ -578,3 +579,13 @@ CableClub_Text_YouMayBattleHere:
   I: 0x0
 Text_DontBeLikeThat:
   S: 0x0
+TrackStop_1:
+  D: 0x0
+TrackStop_2:
+  D: 0x0
+TrackStop_Done:
+  D: 0x0
+TrackStop_3:
+  D: 0x0
+ChnVolSetAsm:
+  D: 0x0

--- a/wiki/pages/Mode - Fishing.md
+++ b/wiki/pages/Mode - Fishing.md
@@ -35,10 +35,10 @@ if your Safari Ball count drops below `15`.
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ✅    |      ✅      |     ✅      |     ✅      |      ✅       |
 | Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| German   |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| French   |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| Italian  |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
+| German   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| French   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| Italian  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 
 ✅ Tested, working
 

--- a/wiki/pages/Mode - Level Grind.md
+++ b/wiki/pages/Mode - Level Grind.md
@@ -70,10 +70,10 @@ The following routes are supported:
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ✅    |      ✅      |     ✅      |     ✅      |      ✅       |
 | Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| German   |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| French   |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| Italian  |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
+| German   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| French   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| Italian  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 
 ✅ Tested, working
 

--- a/wiki/pages/Mode - Spin.md
+++ b/wiki/pages/Mode - Spin.md
@@ -31,10 +31,10 @@ if your Safari Ball count drops below `15`.
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ✅    |      ✅      |     ✅      |     ✅      |      ✅       |
 | Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| German   |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| French   |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
-| Italian  |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
+| German   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| French   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| Italian  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 
 ✅ Tested, working
 

--- a/wiki/pages/Mode - Sweet Scent.md
+++ b/wiki/pages/Mode - Sweet Scent.md
@@ -14,10 +14,10 @@ Start the mode while in the overworld, in any patch of grass/water/cave with enc
 | :------- | :-----: | :---------: | :--------: | :--------: | :----------: |
 | English  |   🟨    |     🟨      |     ✅     |     ✅     |      ✅      |
 | Japanese |   ❌    |     ❌      |     ✅     |     ✅     |      ❌      |
-| German   |   ❌    |     ❌      |     🟨     |     ✅     |      ❌      |
-| Spanish  |   ❌    |     ❌      |     🟨     |     ✅     |      ❌      |
-| French   |   ❌    |     ❌      |     🟨     |     ✅     |      ❌      |
-| Italian  |   ❌    |     ❌      |     🟨     |     ✅     |      ❌      |
+| German   |   ❌    |     ❌      |     🟨     |     ✅     |      ✅      |
+| Spanish  |   ❌    |     ❌      |     🟨     |     ✅     |      ✅      |
+| French   |   ❌    |     ❌      |     🟨     |     ✅     |      ✅      |
+| Italian  |   ❌    |     ❌      |     🟨     |     ✅     |      ✅      |
 
 ✅ Tested, working
 


### PR DESCRIPTION
### Description

This PR handle every supported combat logic for Leaf Green (GR, FR, IT, SP)

I've tested every cases manually

Added support for modes : 
- Sweet Scent
- Spin (Overworld & Safari)
- Fishing (Overworld and Safari)
- Level grind

It handles support of : 
- Pokemon swap on faint / HP threshold
- Learning moves
- Flee / Catch / Stop / Battling
- Evolution
- Repel wereoff
- Whiteout

### Changes

Update Leeaf Green symbol mapping

### Notes

Updated the saves & states repo with the states I used to test : [PR](https://github.com/johnnieb333/Pokebot-Profiles/pull/19)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
