### PR TITLE
Fix bot crashing on keyboard import

### DIFF
--- a/modules/keyboard.py
+++ b/modules/keyboard.py
@@ -13,7 +13,7 @@ with open(f"{DATA_DIRECTORY}/keyboard.json", "r", encoding="utf-8") as f:
     key_layout = json.load(f)
 
 # Will have to add more languages later and detect it
-lang = context.rom.language.value
+lang = context.rom.language.value if context.rom.language.value in {"E", "F"} else "E"
 
 valid_characters = []
 for page in key_layout[lang]:


### PR DESCRIPTION
### Description

Unconfigured keyboard mapping make the bot crash on start when using non English or French version

### Changes

Fallback to english keyboard when keyboard mapping is not implemented

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
