### PR TITLE
Fix JP version fading menus

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.yml
+++ b/modules/data/symbols/patches/language/pokeemerald.yml
@@ -509,6 +509,8 @@ gBattlescriptCurrInstr:
   J: 0x2023eb8
 gRngValue:
   J: 0x3005ae0
+gPaletteFade:
+  J: 0x2037c74
 ITEMSTORAGE_HANDLEREMOVEITEM:
   I: 0x0
 Route120_Text_RileyIntro:


### PR DESCRIPTION
### Description

In the Japanese versions, the bot wasn’t waiting for menus to fully open before attempting to select items. The first time it worked, since the bot would change menus—for example, to throw a Poké Ball. However, on subsequent attempts, if the bot was already on the Poké Ball menu, it wouldn’t wait for the menu to fully appear, causing it to get stuck.

### Changes

Mapped the Fading symbol to make the bot wait before selecting an item

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
