### PR TITLE
Add plugin hook for config reload

### DIFF
--- a/modules/context.py
+++ b/modules/context.py
@@ -63,11 +63,13 @@ class BotContext:
         Triggers a config reload, reload the global config then specific profile config.
         """
         from modules.console import console
+        from modules.plugins import plugin_config_reloaded
 
         try:
             new_config = Config()
             new_config.load(self.config.config_dir, strict=False)
             self.config = new_config
+            plugin_config_reloaded()
             console.print("[cyan]Profile settings loaded.[/]")
         except Exception as error:
             if self.debug:

--- a/modules/plugin_interface.py
+++ b/modules/plugin_interface.py
@@ -51,6 +51,13 @@ class BotPlugin:
         """
         pass
 
+    def on_config_reload(self) -> None:
+        """
+        This is called when a reload of the bot's configuration is triggered (e.g. by
+        pressing Ctrl+C.)
+        """
+        pass
+
     def on_battle_started(self, encounter: "EncounterInfo | None") -> Generator | None:
         """
         This is called once the game entered battle mode, so when the screen has faded

--- a/modules/plugins.py
+++ b/modules/plugins.py
@@ -75,6 +75,11 @@ def plugin_profile_loaded(profile: "Profile") -> None:
         plugin.on_profile_loaded(profile)
 
 
+def plugin_config_reloaded() -> None:
+    for plugin in plugins:
+        plugin.on_config_reload()
+
+
 def plugin_battle_started(encounter: "EncounterInfo | None") -> Generator:
     for plugin in plugins:
         result = plugin.on_battle_started(encounter)


### PR DESCRIPTION
### Description

This allows plugins to be notified when the bot config is reloaded (`Ctrl+C`.)

Might be useful if plugins calculate some stuff based on configuration but do not always want to check whether that config has changed.

But I need it specifically to allow the Stream Plugin to have its own configuration and also reload that on demand.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
