### PR TITLE
Allow specifying the spin direction

### DIFF
--- a/modules/modes/util/higher_level_actions.py
+++ b/modules/modes/util/higher_level_actions.py
@@ -134,8 +134,8 @@ def fish() -> Generator:
     yield
 
 
-def spin(stop_condition: Callable[[], bool] | None = None):
-    directions = ["Up", "Right", "Down", "Left"]
+def spin(stop_condition: Callable[[], bool] | None = None, counter_clockwise: bool = False):
+    directions = ["Up", "Left", "Down", "Right"] if counter_clockwise else ["Up", "Right", "Down", "Left"]
     while True:
         avatar = get_player_avatar()
         if (


### PR DESCRIPTION
### Description

This adds a parameter to the `spin()` utility function that controls whether we're spinning clockwise (default and the way it previously worked) or counter-clockwise.

This is not used by the bot as is, but can be used by plugins -- planning to use this as a very low-key easter egg in the Stream plugin.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
