### PR TITLE
Fix Rock Smash for R/S

### DIFF
--- a/modules/modes/rock_smash.py
+++ b/modules/modes/rock_smash.py
@@ -222,7 +222,8 @@ class RockSmashMode(BotMode):
     @debug.track
     def smash(flag_name):
         if not get_event_flag(flag_name):
-            yield from wait_for_script_to_start_and_finish("EventScript_RockSmash", "A")
+            script_name = "EventScript_RockSmash" if not context.rom.is_rs else "DoRockSmashMovement"
+            yield from wait_for_script_to_start_and_finish(script_name, "A")
             while get_player_avatar().tile_transition_state != TileTransitionState.NOT_MOVING:
                 yield
             if task_is_active("Task_ReturnToFieldNoScript"):


### PR DESCRIPTION
### Description

This fixes the Rock Smash mode getting stuck waiting for a script that just has a different name in the R/S decompilation.

I've confirmed it to work in Granite Cave, but since I don't have a test profile for the Safari Zone I did not update the wiki yet to reflect that support.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
