### PR TITLE
Fix Rock Smash still getting stuck on R/S

### DIFF
--- a/wiki/pages/Mode - Rock Smash.md
+++ b/wiki/pages/Mode - Rock Smash.md
@@ -51,6 +51,8 @@ If you have any Repel items in your inventory, the game will offer you this choi
 ## Safari Zone
 ![](../../modules/web/static/sprites/pokemon/shiny/Shuckle.png)
 
+(This area only exists in Emerald.)
+
 The mode will continuously try to enter the Safari Zone, so make sure you have some cash. The bot will use up to ₽25,000 and then soft reset to start over. If you have less cash than that, it will soft-reset when money runs out.
 
 - Go to the _entrance_ of the Safari Zone (see image below)
@@ -65,7 +67,7 @@ The mode will continuously try to enter the Safari Zone, so make sure you have s
 ## Game Support
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald |
 |:---------|:-------:|:-----------:|:----------:|
-| English  |    ❌    |      ❌      |     ✅      |
+| English  |    ✅    |      ✅      |     ✅      |
 | Japanese |    ❌    |      ❌      |     ✅      |
 | German   |    ❌    |      ❌      |     ✅      |
 | Spanish  |    ❌    |      ❌      |     ✅      |


### PR DESCRIPTION
### Description

When getting an encounter through Rock Smash on R/S, the script context never turns off -- which means that the mode gets stuck waiting for exactly that to happen.

This changes the exit condition to the rock's flag changing, which worked reliably for me throughout an in-game hour of running the test.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
