### PR TITLE
Add support for Surf and Waterfall in pathfinding

### DIFF
--- a/modules/modes/level_grind.py
+++ b/modules/modes/level_grind.py
@@ -24,14 +24,50 @@ closest_pokemon_centers: dict[MapFRLG | MapRSE, list[PokemonCenter]] = {
     MapRSE.ROUTE102: [PokemonCenter.OldaleTown, PokemonCenter.PetalburgCity],
     MapRSE.ROUTE103: [PokemonCenter.OldaleTown],
     MapRSE.ROUTE104: [PokemonCenter.PetalburgCity, PokemonCenter.RustboroCity],
-    MapRSE.ROUTE116: [PokemonCenter.RustboroCity],
+    MapRSE.ROUTE105: [PokemonCenter.PetalburgCity, PokemonCenter.DewfordTown],
+    MapRSE.ROUTE106: [PokemonCenter.DewfordTown],
+    MapRSE.ROUTE107: [PokemonCenter.DewfordTown],
+    MapRSE.ROUTE108: [PokemonCenter.DewfordTown],
+    MapRSE.ROUTE109: [PokemonCenter.SlateportCity],
     MapRSE.ROUTE110: [PokemonCenter.SlateportCity, PokemonCenter.MauvilleCity],
-    MapRSE.ROUTE117: [PokemonCenter.MauvilleCity, PokemonCenter.VerdanturfTown],
+    MapRSE.ROUTE111: [PokemonCenter.MauvilleCity, PokemonCenter.MauvilleCity, PokemonCenter.FallarborTown],
+    MapRSE.ROUTE112: [PokemonCenter.LavaridgeTown, PokemonCenter.MauvilleCity, PokemonCenter.FallarborTown],
     MapRSE.ROUTE113: [PokemonCenter.FallarborTown],
     MapRSE.ROUTE114: [PokemonCenter.FallarborTown],
-    MapRSE.ROUTE119: [PokemonCenter.FortreeCity],
+    MapRSE.ROUTE115: [PokemonCenter.RustboroCity],
+    MapRSE.ROUTE116: [PokemonCenter.RustboroCity],
+    MapRSE.ROUTE117: [PokemonCenter.MauvilleCity, PokemonCenter.VerdanturfTown],
+    MapRSE.ROUTE118: [PokemonCenter.MauvilleCity],
+    MapRSE.ROUTE119: [PokemonCenter.FortreeCity, PokemonCenter.MauvilleCity],
     MapRSE.ROUTE120: [PokemonCenter.FortreeCity],
     MapRSE.ROUTE121: [PokemonCenter.LilycoveCity],
+    MapRSE.ROUTE122: [PokemonCenter.LilycoveCity],
+    MapRSE.ROUTE123: [PokemonCenter.LilycoveCity, PokemonCenter.MauvilleCity],
+    MapRSE.ROUTE124: [PokemonCenter.LilycoveCity, PokemonCenter.MossdeepCity],
+    MapRSE.ROUTE125: [PokemonCenter.MossdeepCity],
+    MapRSE.ROUTE126: [PokemonCenter.MossdeepCity],
+    MapRSE.ROUTE127: [PokemonCenter.MossdeepCity],
+    MapRSE.ROUTE128: [PokemonCenter.EvergrandeCity],
+    MapRSE.ROUTE129: [PokemonCenter.EvergrandeCity],
+    MapRSE.ROUTE130: [PokemonCenter.PacifidlogTown],
+    MapRSE.ROUTE131: [PokemonCenter.PacifidlogTown],
+    MapRSE.ROUTE132: [PokemonCenter.PacifidlogTown],
+    MapRSE.ROUTE133: [PokemonCenter.PacifidlogTown, PokemonCenter.SlateportCity],
+    MapRSE.ROUTE134: [PokemonCenter.SlateportCity],
+    MapRSE.PETALBURG_CITY: [PokemonCenter.PetalburgCity],
+    MapRSE.SLATEPORT_CITY: [PokemonCenter.SlateportCity],
+    MapRSE.MAUVILLE_CITY: [PokemonCenter.MauvilleCity],
+    MapRSE.RUSTBORO_CITY: [PokemonCenter.RustboroCity],
+    MapRSE.FORTREE_CITY: [PokemonCenter.FortreeCity],
+    MapRSE.LILYCOVE_CITY: [PokemonCenter.LilycoveCity],
+    MapRSE.MOSSDEEP_CITY: [PokemonCenter.MossdeepCity],
+    MapRSE.EVER_GRANDE_CITY: [PokemonCenter.EvergrandeCity],
+    MapRSE.OLDALE_TOWN: [PokemonCenter.OldaleTown],
+    MapRSE.DEWFORD_TOWN: [PokemonCenter.DewfordTown],
+    MapRSE.LAVARIDGE_TOWN: [PokemonCenter.LavaridgeTown],
+    MapRSE.FALLARBOR_TOWN: [PokemonCenter.FallarborTown],
+    MapRSE.VERDANTURF_TOWN: [PokemonCenter.VerdanturfTown],
+    MapRSE.PACIFIDLOG_TOWN: [PokemonCenter.PacifidlogTown],
     # Kanto
     MapFRLG.ROUTE1: [PokemonCenter.ViridianCity],
     MapFRLG.ROUTE22: [PokemonCenter.ViridianCity],
@@ -45,6 +81,19 @@ closest_pokemon_centers: dict[MapFRLG | MapRSE, list[PokemonCenter]] = {
     MapFRLG.ROUTE10: [PokemonCenter.Route10],
     MapFRLG.ROUTE7: [PokemonCenter.CeladonCity],
     MapFRLG.ROUTE18: [PokemonCenter.FuchsiaCity],
+    MapFRLG.ROUTE21_NORTH: [PokemonCenter.CinnabarIsland],
+    MapFRLG.ROUTE21_SOUTH: [PokemonCenter.CinnabarIsland],
+    MapFRLG.ROUTE20: [PokemonCenter.CinnabarIsland, PokemonCenter.FuchsiaCity],
+    MapFRLG.ROUTE19: [PokemonCenter.FuchsiaCity],
+    MapFRLG.VIRIDIAN_CITY: [PokemonCenter.ViridianCity],
+    MapFRLG.PEWTER_CITY: [PokemonCenter.PewterCity],
+    MapFRLG.CERULEAN_CITY: [PokemonCenter.CeruleanCity],
+    MapFRLG.LAVENDER_TOWN: [PokemonCenter.LavenderTown],
+    MapFRLG.VERMILION_CITY: [PokemonCenter.VermilionCity],
+    MapFRLG.CELADON_CITY: [PokemonCenter.CeladonCity],
+    MapFRLG.FUCHSIA_CITY: [PokemonCenter.FuchsiaCity],
+    MapFRLG.CINNABAR_ISLAND: [PokemonCenter.CinnabarIsland],
+    MapFRLG.SAFFRON_CITY: [PokemonCenter.SaffronCity],
 }
 
 
@@ -64,11 +113,7 @@ class LevelGrindMode(BotMode):
         if current_location is None:
             return False
 
-        return (
-            current_location.has_encounters
-            and not current_location.is_surfable
-            and current_location.map_group_and_number in closest_pokemon_centers
-        )
+        return current_location.has_encounters and current_location.map_group_and_number in closest_pokemon_centers
 
     def __init__(self):
         super().__init__()
@@ -102,8 +147,6 @@ class LevelGrindMode(BotMode):
         training_spot = get_map_data_for_current_position()
         if not training_spot.has_encounters:
             raise BotModeError("There are no encounters on this tile.")
-        if training_spot.is_surfable:
-            raise BotModeError("This mode does not work when surfing.")
 
         # The first member of the party might be an egg, in which case we want to use the
         # first available Pokémon as lead instead.

--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -947,6 +947,14 @@ class Pokemon:
     def moves(self) -> tuple[LearnedMove | None, LearnedMove | None, LearnedMove | None, LearnedMove | None]:
         return self.move(0), self.move(1), self.move(2), self.move(3)
 
+    def knows_move(self, move: str | Move):
+        if isinstance(move, Move):
+            move = move.name
+        for learned_move in self.moves:
+            if learned_move is not None and learned_move.move.name == move:
+                return True
+        return False
+
     @property
     def evs(self) -> StatsValues:
         return StatsValues(


### PR DESCRIPTION
### Description

This updates the `calculate_path()` function as well as `navigate_to()` to be able to start/stop surfing, as well as climb and swim down waterfalls.

As a proof of concept, I have updated the Level Grind mode to support grind spots on water. This is probably not all that useful, but it served as a nice test case.

[Screencast from 2024-11-25 14-26-55.webm](https://github.com/user-attachments/assets/70880ba0-1af3-45b6-8c38-19ab31450eb4)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
