### PR TITLE
Fix cost calculation in pathfinding

### DIFF
--- a/modules/map_path.py
+++ b/modules/map_path.py
@@ -666,7 +666,7 @@ def calculate_path(
             if neighbour.warps_to is not None:
                 cost = 1000000
             else:
-                cost = 1
+                cost = node.current_cost + 1
 
             # This handles the case where beginning to surf is required. The dialogue and animation
             # take around 267 frames (depending on the length of the Pokémon's name), whereas a


### PR DESCRIPTION
### Description

The latest improvements to the pathfinding algorithm (Surf, Waterfall, and Acro Bike support) have introduced a bug where the cost of a route wasn't properly calculated.

Instead of accumulating the cost of the entire route, for each tile the cost would be reset to 1 again.

The pathfinding would still _work_, but it would no longer consistently find the most optimal route and instead go on extended sightseeing trips through towns and routes.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
