### PR TITLE
Improve multiple choice dialogue for headless mode

### DIFF
--- a/modules/gui/multi_select_window.py
+++ b/modules/gui/multi_select_window.py
@@ -5,6 +5,7 @@ from tkinter import Canvas, PhotoImage, Toplevel, ttk
 
 from rich.prompt import Prompt
 
+from modules.console import console
 from modules.context import context
 
 
@@ -17,7 +18,13 @@ class Selection:
 
 def ask_for_choice(choices: list[Selection], window_title: str = "Choose...") -> str | None:
     if context.gui.is_headless:
-        return Prompt.ask(window_title, choices=[choice.button_label for choice in choices])
+        console.print(f"\n[bold]{window_title}[/]")
+        for index, choice in enumerate(choices):
+            console.print(f"  [bold magenta]\\[{index + 1}][/] {choice.button_label.replace('\n', ' ')}")
+        chosen_index = Prompt.ask(
+            "Choose option (number)", show_choices=False, choices=[str(n + 1) for n in range(len(choices))]
+        )
+        return choices[int(chosen_index) - 1].button_label
 
     window = Toplevel(context.gui.window)
     selected_value: str | None = None


### PR DESCRIPTION
### Description

In headless mode, the multiple choice dialogue would require the user to type in the full label of an option.

That was either annoying, or outright impossible (if the label contained a newline character.)

This replaces the default `Prompt.ask()` layout with an index-based prompt.

**Before**   
![image](https://github.com/user-attachments/assets/f1cbeaad-1fd0-4e25-83f7-d8e103bc1f7f)

**After**   
![image](https://github.com/user-attachments/assets/43b86d53-08ec-42ae-b950-e2aa0ba00b6e)


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
