### PR TITLE
Fix game corner choice selection loop

### DIFF
--- a/modules/modes/game_corner.py
+++ b/modules/modes/game_corner.py
@@ -64,6 +64,8 @@ class GameCornerMode(BotMode):
             window_title="Select which one to buy...",
         )
         if game_corner_choice is None:
+            context.set_manual_mode()
+            yield
             return
 
         assert_saved_on_map(


### PR DESCRIPTION
### Description

When starting game corner mode, the bot will ask for the Pokémon to reset, but if you close the window it asks infinitely which force the player to close the bot to get unstuck.

### Changes

Switch the bot to manual mode when we close the selection window

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
