### PR TITLE
Init lg jp mapping

### DIFF
--- a/modules/data/symbols/patches/language/pokefirered.yml
+++ b/modules/data/symbols/patches/language/pokefirered.yml
@@ -297,6 +297,8 @@ gBattleWeather:
   J: 0x2023e7c
 sTextPrinters:
   J: 0x2020030
+gNumSafariBalls:
+  J: 0x203990c
 #--------------------#
 
 #----------------#

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -6,7 +6,7 @@ CB2_OVERWORLD:
   D: 0x80565d4
   F: 0x8056694
   I: 0x80565c0
-  J: ~
+  J: 0x8055e74
   S: 0x80566a8
 Task_YesNoMenu_HandleInput:
   D: 0x809cf0c
@@ -18,7 +18,7 @@ Task_FlyIntoMap:
   D: 0x8084330
   F: ~
   I: ~
-  J: ~
+  J: 0x80c60c0
   S: ~
 Task_ExitDoor:
   D: 0x807def4
@@ -47,31 +47,31 @@ gMapGroups:
   D: 0x83525ac
   F: 0x834cad8
   I: 0x834b768
-  J: ~
+  J: 0x8316738
   S: 0x834de50
 sMapNames:
   D: 0x83f1340
   F: 0x83ea0a0
   I: 0x83e8da0
-  J: ~
+  J: 0x83b86a4
   S: 0x83ebdb8
 gWildMonHeaders:
   D: 0x83c9940
   F: 0x83c3e6c
   I: 0x83c2afc
-  J: ~
+  J: 0x83909a4
   S: 0x83c51e4
 gSaveBlock1Ptr:
   D: 0x3004f58
   F: 0x3004f58
   I: 0x3004f58
-  J: ~
+  J: 0x3005048
   S: 0x3004f58
 gSaveBlock2Ptr:
   D: 0x3004f5c
   F: 0x3004f5c
   I: 0x3004f5c
-  J: ~
+  J: 0x300504c
   S: 0x3004f5c
 CB2_RegionMap:
   D: 0x80c0a58
@@ -80,17 +80,17 @@ CB2_RegionMap:
   J: ~
   S: ~
 gMapHeader:
-  J: ~
+  J: 0x2036d30
 gObjectEvents:
-  J: ~
+  J: 0x2036d6c
 gPlayerAvatar:
-  J: ~
+  J: 0x2036fac
 gPlayerPartyCount:
-  J: ~
+  J: 0x2023f89
 gPlayerParty:
-  J: ~
+  J: 0x20241e4
 sMapCursor:
-  J: ~
+  J: 0x203995c
 #----------------#
 
 #--------------------#
@@ -130,37 +130,37 @@ gMain:
   D: 0x3003040
   F: 0x3003040
   I: 0x3003040
-  J: ~
+  J: 0x3003130
   S: 0x3003040
 gBattleMainFunc:
   D: 0x3004ed4
   F: 0x3004ed4
   I: 0x3004ed4
-  J: ~
+  J: 0x3004fc4
   S: 0x3004ed4
 gBattlerControllerFuncs:
   D: 0x3004f30
   F: 0x3004f30
   I: 0x3004f30
-  J: ~
+  J: 0x3005020
   S: 0x3004f30
 GTASKS:
   D: 0x3004fe0
   F: 0x3004fe0
   I: 0x3004fe0
-  J: ~
+  J: 0x30050d0
   S: 0x3004fe0
 BattleMainCB1:
   D: 0x8012368
   F: 0x8012354
   I: 0x8012368
-  J: ~
+  J: 0x8011c34
   S: 0x8012354
 BattleMainCB2:
   D: 0x8011084
   F: 0x8011070
   I: 0x8011084
-  J: ~
+  J: 0x80109c0
   S: 0x8011070
 HandleTurnActionSelectionState:
   D: 0x8013fc4
@@ -505,6 +505,10 @@ Task_SlideSelectedSlotsOnscreen:
   I: ~
   J: ~
   S: ~
+gPartyMenu:
+  J: 0x203b014
+sPartyMenuInternal:
+  J: 0x203b010
 #----------------#
 
 #-------------------------#
@@ -526,7 +530,7 @@ gPokemonStoragePtr:
   D: 0x3004f60
   F: 0x3004f60
   I: 0x3004f60
-  J: ~
+  J: 0x3005050
   S: 0x3004f60
 #-------------------------#
 

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -165,8 +165,8 @@ BattleMainCB2:
 HandleTurnActionSelectionState:
   D: 0x8013fc4
   F: 0x8013fb0
-  I: 0x8013fc5
-  J: ~
+  I: 0x8013fc4
+  J: 0x8013860
   S: 0x8013fb0
 HandleInputChooseAction:
   D:
@@ -178,7 +178,8 @@ HandleInputChooseAction:
   I:
     - 0x802e3bc
     - 0x80dd7a0
-  J: ~
+  J:
+    - 0x802dc14
   S:
     - 0x802e3bc
     - 0x80dd888
@@ -186,7 +187,7 @@ HandleInputChooseMove:
   D: 0x802e9a8
   F: 0x802e980
   I: 0x802e994
-  J: ~
+  J: 0x802e1ec
   S: 0x802e994
 Task_DuckBGMForPokemonCry:
   D: 0x8072198
@@ -198,7 +199,7 @@ BattleScript_HandleFaintedMon:
   D: 0x81dc944
   F: 0x81d6e80
   I: 0x81d5b18
-  J: ~
+  J: 0x81bc635
   S: 0x81d81e0
 Task_BattleStart:
   D: 0x807f558
@@ -222,19 +223,19 @@ Task_HandleChooseMonInput:
   D: 0x811fb34
   F: 0x811fbf4
   I: 0x811fb78
-  J: ~
+  J: 0x81202f0
   S: 0x811fc60
 Task_RushInjuredPokemonToCenter:
   D: 0x807f394
   F: 0x807f454
   I: 0x807f380
-  J: ~
+  J: 0x807eb58
   S: 0x807f468
 EventScript_AfterWhiteOutHeal:
   D: 0x81abba5
   F: 0x81a779c
   I: 0x81a65fb
-  J: ~
+  J: 0x819631a
   S: 0x81a883c
 BattleScript_AskToLearnMove:
   D: 0x81dcc8d
@@ -249,42 +250,47 @@ BattleScript_ForgotAndLearnedNewMove:
   I: 0x81d5e8e
   J: ~
   S: 0x81d8556
+sMoveSelectionCursorPos:
+  J: 0x203b0e1
 gMoveSelectionCursor:
-  J: ~
+  J: 0x2023f5c
+# gBattleWeather + 92
 gBattleOutcome:
-  J: ~
+  J: 0x2023dea
 gActionSelectionCursor:
-  J: ~
+  J: 0x2023f58
 gEnemyParty:
-  J: ~
+  J: 0x2023f8c
 gBattlescriptCurrInstr:
-  J: ~
+  J: 0x2023cd4
 gBattleTypeFlags:
-  J: ~
+  J: 0x2022aac
 gSideTimers:
-  J: ~
+  J: 0x2023d44
 gBattlerPartyIndexes:
-  J: ~
+  J: 0x2023b2e
 gBattlePartyCurrentOrder:
-  J: ~
+  J: 0x203b050
 gBattlersCount:
-  J: ~
+  J: 0x2023b2c
 gBattleMons:
-  J: ~
+  J: 0x2023b44
 gStatuses3:
-  J: ~
+  J: 0x2023d5c
 gDisableStructs:
-  J: ~
+  J: 0x2023d6c
 gAbsentBattlerFlags:
-  J: ~
+  J: 0x2023cd0
 gBattleResults:
   D: 0x3004ee0
   F: 0x3004ee0
   I: 0x3004ee0
-  J: ~
+  J: 0x3004fd0
   S: 0x3004ee0
 gBattleWeather:
-  J: ~
+  J: 0x2023e7c
+sTextPrinters:
+  J: 0x2020030
 #--------------------#
 
 #----------------#
@@ -340,7 +346,7 @@ Std_MsgboxDefault:
   D: 0x81a7ae4
   F: ~
   I: ~
-  J: ~
+  J: 0x8192d81
   S: ~
 #---------------------------#
 
@@ -452,7 +458,7 @@ CB2_BAGMENURUN:
   D: 0x8107f34
   F: 0x8107ff4
   I: 0x8107f78
-  J: ~
+  J: 0x81089bc
   S: 0x8108060
 Task_BagMenu_HandleInput:
   D: 0x8108f60
@@ -464,12 +470,12 @@ Task_FieldItemContextMenuHandleInput:
   D: 0x8109c14
   F: 0x8109cd4
   I: 0x8109c58
-  J: ~
+  J: 0x810a6b8
   S: 0x8109d40
 gBagMenuState:
-  J: ~
+  J: 0x203ac74
 gPaletteFade:
-  J: ~
+  J: 0x20379ec
 #---------------#
 
 #----------------#
@@ -479,7 +485,7 @@ CB2_UPDATEPARTYMENU:
   D: 0x811ebac
   F: 0x811ec6c
   I: 0x811ebf0
-  J: ~
+  J: 0x811f380
   S: 0x811ecd8
 Task_PrintAndWaitForText:
   D: 0x8120334
@@ -491,13 +497,13 @@ Task_HandleInput:
   D: 0x809f328
   F: ~
   I: ~
-  J: ~
+  J: 0x809eca4
   S: ~
 Task_HandleSelectionMenuInput:
   D: 0x8122c6c
   F: 0x8122d28
   I: 0x8122cac
-  J: ~
+  J: 0x8123410
   S: 0x8122d98
 Task_SlideSelectedSlotsOnscreen:
   D: 0x8123398
@@ -575,6 +581,48 @@ EventScript_FieldPoison:
   S: ~
 #---------------#
 
+#---------------------#
+#   Pokemon renaming  #
+#---------------------#
+# 0xa
+BattleScript_CaughtPokemonSkipNewDex:
+  D: 0x81ddcd7
+  F: 0x81d8213
+  I: 0x81d6eab
+  J: 0x81bd9fb
+  S: 0x81d9573
+CB2_NamingScreen:
+  D: 0x809fc38
+  F: 0x809fcf8
+  I: 0x809fc18
+  J: 0x809fa24
+  S: 0x809fd00
+# 0x6
+BattleScript_CaughtPokemonDone:
+  D: 0x81ddcf5
+  F: 0x81d8231
+  I: 0x81d6ec9
+  J: 0x81bda19
+  S: 0x81d9591
+# 0x6
+BattleScript_GotAwaySafely:
+  D: 0x81dcb88
+  F: 0x81d70c4
+  I: 0x81d5d5c
+  J: 0x81bc8ae
+  S: 0x81d842b
+Task_NamingScreen:
+  D: 0x809de40
+  F: 0x809df00
+  I: 0x809de2c
+  J: 0x809d794
+  S: 0x809df14
+sNamingScreen:
+  J: 0x20398d8
+gSprites:
+  J: 0x20205bc
+#---------------------#
+
 # Ununsed symbols that were conflicting with currently used symbols
 # We set them to 0x0 to 'get them out of our way' and correctly target the desired symbol
 EventScript_CutTree:
@@ -605,3 +653,7 @@ EventScript_PkmnCenterNurse_PlayerWaitingInUionRoom:
   I: 0x0
 EventScript_Open9FDoor3:
   S: 0x0
+CeladonCity_Condominiums_3F_Text_ImGameDesignerShowMeFinishedPokedex:
+  J: 0x0
+CableClub_Text_PleaseVisitAgain:
+  J: 0x0

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -291,6 +291,8 @@ gBattleWeather:
   J: 0x2023e7c
 sTextPrinters:
   J: 0x2020030
+gNumSafariBalls:
+  J: 0x203990c
 #--------------------#
 
 #----------------#

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -562,7 +562,7 @@ EventScript_RepelWoreOff:
   D: 0x81c368c
   F: 0x81be5b0
   I: 0x81bd0f7
-  J: ~
+  J: 0x81a5d60
   S: 0x81bf7d0
 EventScript_DoTrainerBattle:
   D: ~
@@ -580,7 +580,7 @@ EventScript_FieldPoison:
   D: ~
   F: ~
   I: ~
-  J: ~
+  J: 0x819637f
   S: ~
 #---------------#
 

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -180,6 +180,7 @@ HandleInputChooseAction:
     - 0x80dd7a0
   J:
     - 0x802dc14
+    - 0x80de564
   S:
     - 0x802e3bc
     - 0x80dd888
@@ -211,13 +212,13 @@ Task_EvolutionScene:
   D: 0x80cea50
   F: 0x80ceb10
   I: 0x80cea30
-  J: ~
+  J: 0x80cf9cc
   S: 0x80ceb18
 Task_InputHandler_SelectOrForgetMove:
   D: 0x8139448
   F: 0x8139504
   I: 0x8139488
-  J: ~
+  J: 0x8139b80
   S: 0x8139574
 Task_HandleChooseMonInput:
   D: 0x811fb34
@@ -241,14 +242,14 @@ BattleScript_AskToLearnMove:
   D: 0x81dcc8d
   F: 0x81d71c9
   I: 0x81d5e61
-  J: ~
+  J: 0x81bc9b3
   S: 0x81d8529
 # BattleScript_AskToLearnMove + 2d
 BattleScript_ForgotAndLearnedNewMove:
   D: 0x81dccba
   F: 0x81d71f6
   I: 0x81d5e8e
-  J: ~
+  J: 0x81bc9e0
   S: 0x81d8556
 sMoveSelectionCursorPos:
   J: 0x203b0e1
@@ -336,7 +337,7 @@ Task_MultichoiceMenu_HandleInput:
   D: 0x809cd50
   F: 0x809ce10
   I: 0x809cd3c
-  J: ~
+  J: 0x809c6a0
   S: 0x809ce24
 gRngValue:
   D: 0x3004f50
@@ -356,10 +357,10 @@ Std_MsgboxDefault:
 #   Fishing Mode    #
 #-------------------#
 Task_Fishing:
-  D: ~
+  D: ~ # Doesn't need mapping
   F: 0x805d3c4
   I: 0x805d2f0
-  J: ~
+  J: 0x805cbc0
   S: 0x805d3d8
 #-------------------#
 
@@ -441,16 +442,16 @@ Task_StartMenuHandleInput:
   D: 0x806f154
   F: 0x806f214
   I: 0x806f140
-  J: ~
+  J: 0x806e9e4
   S: 0x806f228
 sMenu:
-  J: ~
+  J: 0x203ad5c
 sStartMenuCursorPos:
-  J: ~
+  J: 0x2037028
 sNumStartMenuItems:
-  J: ~
+  J: 0x2037029
 sStartMenuOrder:
-  J: ~
+  J: 0x203702a
 #-----------------#
 
 #--------------#
@@ -466,7 +467,7 @@ Task_BagMenu_HandleInput:
   D: 0x8108f60
   F: 0x8109020
   I: 0x8108fa4
-  J: ~
+  J: 0x81099dc
   S: 0x8133d44
 Task_FieldItemContextMenuHandleInput:
   D: 0x8109c14
@@ -588,37 +589,37 @@ EventScript_FieldPoison:
 #---------------------#
 # 0xa
 BattleScript_CaughtPokemonSkipNewDex:
-  D: 0x81ddcd7
-  F: 0x81d8213
-  I: 0x81d6eab
+  D: ~
+  F: ~
+  I: ~
   J: 0x81bd9fb
-  S: 0x81d9573
+  S: ~
 CB2_NamingScreen:
-  D: 0x809fc38
-  F: 0x809fcf8
-  I: 0x809fc18
+  D: ~
+  F: ~
+  I: ~
   J: 0x809fa24
-  S: 0x809fd00
+  S: ~
 # 0x6
 BattleScript_CaughtPokemonDone:
-  D: 0x81ddcf5
-  F: 0x81d8231
-  I: 0x81d6ec9
+  D: ~
+  F: ~
+  I: ~
   J: 0x81bda19
-  S: 0x81d9591
+  S: ~
 # 0x6
 BattleScript_GotAwaySafely:
-  D: 0x81dcb88
-  F: 0x81d70c4
-  I: 0x81d5d5c
+  D: ~
+  F: ~
+  I: ~
   J: 0x81bc8ae
-  S: 0x81d842b
+  S: ~
 Task_NamingScreen:
-  D: 0x809de40
-  F: 0x809df00
-  I: 0x809de2c
+  D: ~
+  F: ~
+  I: ~
   J: 0x809d794
-  S: 0x809df14
+  S: ~
 sNamingScreen:
   J: 0x20398d8
 gSprites:
@@ -658,4 +659,6 @@ EventScript_Open9FDoor3:
 CeladonCity_Condominiums_3F_Text_ImGameDesignerShowMeFinishedPokedex:
   J: 0x0
 CableClub_Text_PleaseVisitAgain:
+  J: 0x0
+CableClub_Text_YouHaveAMonThatCantBeTaken:
   J: 0x0

--- a/modules/safari_strategy.py
+++ b/modules/safari_strategy.py
@@ -4,6 +4,7 @@ from modules.context import context
 from modules.battle_strategies import SafariTurnAction
 from modules.pokemon import Pokemon
 from modules.runtime import get_data_path
+from modules.memory import read_symbol
 
 
 class FRLGSafariStrategy:
@@ -117,4 +118,4 @@ def is_watching_carefully() -> bool:
 
 
 def get_safari_balls_left() -> int:
-    return context.emulator.read_bytes(0x02039994, length=1)[0]
+    return read_symbol("gNumSafariBalls")[0]

--- a/wiki/pages/Mode - Fishing.md
+++ b/wiki/pages/Mode - Fishing.md
@@ -34,7 +34,7 @@ if your Safari Ball count drops below `15`.
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ✅    |      ✅      |     ✅      |     ✅      |      ✅       |
-| Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
+| Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 | German   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 | Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 | French   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |

--- a/wiki/pages/Mode - Level Grind.md
+++ b/wiki/pages/Mode - Level Grind.md
@@ -69,7 +69,7 @@ The following routes are supported:
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ✅    |      ✅      |     ✅      |     ✅      |      ✅       |
-| Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
+| Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 | German   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 | Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 | French   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |

--- a/wiki/pages/Mode - Spin.md
+++ b/wiki/pages/Mode - Spin.md
@@ -30,7 +30,7 @@ if your Safari Ball count drops below `15`.
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |    ✅    |      ✅      |     ✅      |     ✅      |      ✅       |
-| Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ❌       |
+| Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 | German   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 | Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 | French   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |

--- a/wiki/pages/Mode - Sweet Scent.md
+++ b/wiki/pages/Mode - Sweet Scent.md
@@ -11,13 +11,13 @@ Start the mode while in the overworld, in any patch of grass/water/cave with enc
 ## Game Support
 
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
-| :------- | :-----: | :---------: | :--------: | :--------: | :----------: |
-| English  |   🟨    |     🟨      |     ✅     |     ✅     |      ✅      |
-| Japanese |   ❌    |     ❌      |     ✅     |     ✅     |      ❌      |
-| German   |   ❌    |     ❌      |     🟨     |     ✅     |      ✅      |
-| Spanish  |   ❌    |     ❌      |     🟨     |     ✅     |      ✅      |
-| French   |   ❌    |     ❌      |     🟨     |     ✅     |      ✅      |
-| Italian  |   ❌    |     ❌      |     🟨     |     ✅     |      ✅      |
+|:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
+| English  |   🟨    |     🟨      |     ✅      |     ✅      |      ✅       |
+| Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| German   |    ❌    |      ❌      |     🟨     |     ✅      |      ✅       |
+| Spanish  |    ❌    |      ❌      |     🟨     |     ✅      |      ✅       |
+| French   |    ❌    |      ❌      |     🟨     |     ✅      |      ✅       |
+| Italian  |    ❌    |      ❌      |     🟨     |     ✅      |      ✅       |
 
 ✅ Tested, working
 


### PR DESCRIPTION
### Description

This PR implements support for all supported combat logic in the Japanese version of Leaf Green. Each feature has been tested manually.

#### Mode Supported:
- **Sweet Scent Mode**
- **Spin Mode** (Overworld & Safari)
- **Fishing** (Overworld & Safari)
- **Level Grind**

#### Fixes:
- Resolves an issue where the Safari auto-catching mode was non-functional in the Japanese versions of FireRed/LeafGreen.

#### Features supported :
- Handles Pokémon swapping on faint or reaching the HP threshold.
- Supports learning new moves.
- Manages flee, catch, stop, and battling.
- Supports evolution.
- Handles in-game notifications such as:
  - **Repel wearing off**
  - **Poison faint**
- Handle whiteouts.
- Handle Pokémon renaming.

### Changes

- Update Leaf Green symbol mapping
- Get safari ball number via a symbol and map the symbol for JP FR/LG

### Notes

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
