### PR TITLE
Leaf Green : Support soft reset mode

### DIFF
--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -325,7 +325,7 @@ Task_EndQuestLog:
   D: 0x8112148
   F: 0x8112208
   I: 0x811218c
-  J: ~
+  J: 0x8112bcc
   S: 0x8112274
 Task_DrawFieldMessageBox:
   D: 0x8069360
@@ -383,19 +383,19 @@ CB2_InitCopyrightScreenAfterBootup:
   D: 0x80eca1c
   F: 0x80ecadc
   I: 0x80eca1c
-  J: ~
+  J: 0x80ed6f4
   S: 0x80ecb04
 CB2_TitleScreenRun:
   D: 0x8078b00
   F: 0x8078bc0
   I: 0x8078aec
-  J: ~
+  J: 0x8078334
   S: 0x8078bd4
 CB2_Intro:
   D: 0x80ecbd0
   F: 0x80ecc90
   I: 0x80ecbd0
-  J: ~
+  J: 0x80ed8a8
   S: 0x80eccb8
 CB2_INITTITLESCREEN:
   D: 0x8078878

--- a/wiki/pages/Mode - Game Corner.md
+++ b/wiki/pages/Mode - Game Corner.md
@@ -31,7 +31,7 @@ Soft resets for a Pokémon purchased from the [Celadon Game Corner](https://bulb
 |          | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:----------:|:------------:|
 | English  |     ✅      |      ✅       |
-| Japanese |     ✅      |      ❌       |
+| Japanese |     ✅      |      ✅       |
 | German   |     ✅      |      ✅       |
 | Spanish  |     ✅      |      ✅       |
 | French   |     ✅      |      ✅       |

--- a/wiki/pages/Mode - Static Gift Resets.md
+++ b/wiki/pages/Mode - Static Gift Resets.md
@@ -133,13 +133,13 @@ Soft reset for a static gift Pokémon that are directly added to your party with
 ## Game Support
 
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
-| :------- | :-----: | :---------: | :--------: | :--------: | :----------: |
-| English  |   🟨    |     🟨      |     ✅     |     ✅     |      ✅      |
-| Japanese |   ❌    |     ❌      |     ✅     |     ✅     |      ❌      |
-| German   |   ❌    |     ❌      |     ✅     |     ✅     |      ❌      |
-| Spanish  |   ❌    |     ❌      |     ✅     |     ✅     |      ❌      |
-| French   |   ❌    |     ❌      |     ✅     |     ✅     |      ❌      |
-| Italian  |   ❌    |     ❌      |     ✅     |     ✅     |      ❌      |
+|:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
+| English  |   🟨    |     🟨      |     ✅      |     ✅      |      ✅       |
+| Japanese |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| German   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| Spanish  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| French   |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| Italian  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
 
 ✅ Tested, working
 

--- a/wiki/pages/Mode - Static Run Aways.md
+++ b/wiki/pages/Mode - Static Run Aways.md
@@ -105,7 +105,7 @@ You must set `pickup: false` in `battle.yml` to use this mode. See [⚔ Battling
 |          | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:----------:|:----------:|:------------:|
 | English  |     ✅      |     ✅      |      ✅       |
-| Japanese |     ✅      |     ✅      |      ❌       |
+| Japanese |     ✅      |     ✅      |      ✅       |
 | German   |     ✅      |     ✅      |      ✅       |
 | Spanish  |     ✅      |     ✅      |      ✅       |
 | French   |     ✅      |     ✅      |      ✅       |

--- a/wiki/pages/Mode - Static Soft Resets.md
+++ b/wiki/pages/Mode - Static Soft Resets.md
@@ -46,7 +46,7 @@ Static soft reset mode targets static Pokémon by simply spamming the A button u
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald | 🔥 FireRed | 🌿 LeafGreen |
 |:---------|:-------:|:-----------:|:----------:|:----------:|:------------:|
 | English  |   🟨    |     🟨      |     ✅      |     ✅      |      ✅       |
-| Japanese |    ❌    |      ❌      |     ❌      |     ✅      |      ❌       |
+| Japanese |    ❌    |      ❌      |     ❌      |     ✅      |      ✅       |
 | German   |    ❌    |      ❌      |     ❌      |     ✅      |      ✅       |
 | Spanish  |    ❌    |      ❌      |     ❌      |     ✅      |      ✅       |
 | French   |    ❌    |      ❌      |     ❌      |     ✅      |      ✅       |


### PR DESCRIPTION
### Description

Added support for modes in LG JP : 

- Game Corner
- SRA
- SSR
- SGR

### Changes

Update Leaf Green symbol mapping to support Game Corner and Reset modes

### Notes

Updated the state repo with this [PR](https://github.com/johnnieb333/Pokebot-Profiles/pull/21)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
