### PR TITLE
Fix bot being stuck because of missing battle ending symbol traduction

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.yml
+++ b/modules/data/symbols/patches/language/pokeemerald.yml
@@ -718,6 +718,12 @@ Task_SurfFieldEffect:
   I: 0x80b8d98
   J: 0x80b84dc
   S: 0x80b8d98
+HandleEndTurn_FinishBattle:
+  D: ~ # No need mapping
+  F: ~ # No need mapping
+  I: ~ # No need mapping
+  J: 0x803d918
+  S: ~ # No need mapping
 
 #---------------------#
 #   Pokemon renaming  #

--- a/modules/data/symbols/patches/language/pokefirered.yml
+++ b/modules/data/symbols/patches/language/pokefirered.yml
@@ -256,6 +256,12 @@ BattleScript_ForgotAndLearnedNewMove:
   I: 0x81d5eb2
   J: 0x81bca04
   S: 0x81d857a
+HandleEndTurn_FinishBattle:
+  D: 0x8015894
+  F: 0x8015880
+  I: 0x8015894
+  J: 0x8015128
+  S: 0x8015894
 sMoveSelectionCursorPos:
   J: 0x203b0e1
 gMoveSelectionCursor:

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -251,6 +251,12 @@ BattleScript_ForgotAndLearnedNewMove:
   I: 0x81d5e8e
   J: 0x81bc9e0
   S: 0x81d8556
+HandleEndTurn_FinishBattle:
+  D: 0x8015894
+  F: 0x8015880
+  I: 0x8015894
+  J: 0x8015128
+  S: 0x8015880
 sMoveSelectionCursorPos:
   J: 0x203b0e1
 gMoveSelectionCursor:


### PR DESCRIPTION
### Description

Fixing an issue where handling fainted Pokémon was not functioning correctly due to a missing symbol mapping. This occurred when a battle ended after running away with the lead Pokémon fainted on non english version of the games.

### Changes

- Updating Emerald / FR / LG mapping to support that symbol

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
