### PR TITLE
Fix regi puzzle solver for RSE

### DIFF
--- a/modules/modes/puzzle_solver.py
+++ b/modules/modes/puzzle_solver.py
@@ -144,6 +144,7 @@ class PuzzleSolverMode(BotMode):
 
                 def path():
                     yield from navigate_to(MapRSE.DESERT_RUINS, (8, 21))
+                    yield from ensure_facing_direction("Up")
                     context.emulator.press_button("A")
                     yield from wait_for_n_frames(5)
                     context.emulator.press_button("B")
@@ -187,6 +188,7 @@ class PuzzleSolverMode(BotMode):
 
                 def path():
                     yield from navigate_to(MapRSE.ISLAND_CAVE, (8, 21))
+                    yield from ensure_facing_direction("Up")
                     context.emulator.press_button("A")
                     yield from wait_for_n_frames(5)
                     context.emulator.press_button("B")
@@ -234,6 +236,7 @@ class PuzzleSolverMode(BotMode):
 
                 def path():
                     yield from navigate_to(MapRSE.ANCIENT_TOMB, (8, 21))
+                    yield from ensure_facing_direction("Up")
                     context.emulator.press_button("A")
                     yield from wait_for_n_frames(5)
                     context.emulator.press_button("B")
@@ -255,7 +258,7 @@ class PuzzleSolverMode(BotMode):
 
                     if context.rom.is_rs:
                         assert_has_pokemon_with_any_move(
-                            ["Fly"], "Regirock Puzzle (Ruby/Sapphire) requires Pokémon with Fly."
+                            ["Fly"], "Registeel Puzzle (Ruby/Sapphire) requires Pokémon with Fly."
                         )
                         yield from navigate_to(MapRSE.ANCIENT_TOMB, (8, 25))
                         yield from use_party_hm_move("Fly")


### PR DESCRIPTION
### Description

- Fix an issue where the bot would press `A` while not in front of the tomb resulting bot being stuck on Regice Puzzle
- Fixed a typo when player doesn't have Fly on Registeel puzzle

### Changes

- Updated Puzzle Solver file with an ensure direction up

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
