### PR TITLE
Leaf Green : Support Puzzle Solver for JP

### DIFF
--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -36,7 +36,7 @@ EventScript_UseStrength:
   D: 0x81c1bc4
   F: 0x81bcae4
   I: 0x81bb76b
-  J: ~
+  J: 0x81a48f0
   S: 0x81bde2e
 #-------------------------------#
 
@@ -372,7 +372,7 @@ SevenIsland_SevaultCanyon_TanobyKey_EventScript_PuzzleSolved:
   D: 0x8164ed0
   F: 0x8164f94
   I: 0x8164f10
-  J: ~
+  J: 0x816eea7
   S: 0x8164ffc
 #-------------------------#
 

--- a/wiki/pages/Mode - Puzzle Solver.md
+++ b/wiki/pages/Mode - Puzzle Solver.md
@@ -149,7 +149,7 @@ Start bot mode anywhere inside the glass workshop.
 |                  | 🔷 Sapphire  |    ✅    |    ❌     |   ❌    |    ❌    |   ❌    |    ❌    |
 |                  | 🟢 Emerald   |    ✅    |    ❌     |   ❌    |    ❌    |   ❌    |    ❌    |
 |                  | 🔥 Fire Red  |    ✅    |    ✅     |   ✅    |    ✅    |   ✅    |    ✅    |
-|                  | 🌿 LeafGreen |    ✅    |    ❌     |   ✅    |    ✅    |   ✅    |    ✅    |
+|                  | 🌿 LeafGreen |    ✅    |    ✅     |   ✅    |    ✅    |   ✅    |    ✅    |
 | **Regice**       | 🟥 Ruby      |    ✅    |    ❌     |   ❌    |    ❌    |   ❌    |    ❌    |
 |                  | 🔷 Sapphire  |    ✅    |    ❌     |   ❌    |    ❌    |   ❌    |    ❌    |
 |                  | 🟢 Emerald   |    ✅    |    ❌     |   ❌    |    ❌    |   ❌    |    ❌    |
@@ -160,7 +160,7 @@ Start bot mode anywhere inside the glass workshop.
 |                  | 🔷 Sapphire  |    ✅    |    ❌     |   ❌    |    ❌    |   ❌    |    ❌    |
 |                  | 🟢 Emerald   |    ✅    |    ❌     |   ❌    |    ❌    |   ❌    |    ❌    |
 | **Tanoby Key**   | 🔥 Fire Red  |    ✅    |    ✅     |   ✅    |    ✅    |   ✅    |    ✅    |
-|                  | 🌿 LeafGreen |    ✅    |    ❌     |   ✅    |    ✅    |   ✅    |    ✅    |
+|                  | 🌿 LeafGreen |    ✅    |    ✅     |   ✅    |    ✅    |   ✅    |    ✅    |
 | **White Flute**  | 🟥 Ruby      |    ✅    |    ❌     |   ❌    |    ❌    |   ❌    |    ❌    |
 |                  | 🔷 Sapphire  |    ✅    |    ❌     |   ❌    |    ❌    |   ❌    |    ❌    |
 |                  | 🟢 Emerald   |    ✅    |    ❌     |   ❌    |    ❌    |   ❌    |    ❌    |


### PR DESCRIPTION
### Description

Add support for Puzzle Solver mode for LeafGreen Japanese

### Changes

- Updated LeafGreen yaml mapping file

### Notes

Updated the repo state [here](https://github.com/johnnieb333/Pokebot-Profiles/pull/25) with Tanoby JP state

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
