### PR TITLE
Use Filechooser for import/export of event flags/vars

### DIFF
--- a/modules/debug_utilities.py
+++ b/modules/debug_utilities.py
@@ -1,58 +1,63 @@
-from modules.memory import get_event_flag, get_event_var, set_event_flag, set_event_var
+from datetime import datetime
+from pathlib import Path
+
+from modules.context import context
 from modules.game import _event_flags, _event_vars
-from modules.runtime import get_base_path
-
-PROFILES_DIRECTORY = get_base_path() / "profiles"
-EVENT_FLAGS_FILE_PATH = PROFILES_DIRECTORY / "event_flags.txt"
-EVENT_VARS_FILE_PATH = PROFILES_DIRECTORY / "event_vars.txt"
+from modules.memory import get_event_flag, get_event_var, set_event_flag, set_event_var
 
 
-def export_flags_and_vars() -> None:
-    def reset_and_write(file_name: str, lines: list[str]) -> None:
-        with open(file_name, "w") as file:
-            file.write("\n".join(lines) + "\n")
-
-    event_flag_lines = [f"{flag_name} = {'1' if get_event_flag(flag_name) else '0'}" for flag_name in _event_flags]
-    event_var_lines = [f"{var_name} = {get_event_var(var_name)}" for var_name in _event_vars]
-
-    reset_and_write(EVENT_FLAGS_FILE_PATH, event_flag_lines)
-    reset_and_write(EVENT_VARS_FILE_PATH, event_var_lines)
-
-
-def write_flags_and_vars() -> None:
+def export_flags_and_vars(file_path: Path) -> None:
     """
-    Reads event flags and variables from their respective files and updates them.
+    Exports event flags and event vars into a file, using an INI-like format.
+    :param file_path: Path to the target file that flags and vars should be written to.
     """
+    with open(file_path, "w") as file:
+        file.writelines(
+            [
+                f"# Exported on {datetime.now().isoformat()}\n",
+                f"# Game: {context.rom.game_name} ({context.rom.language.name})\n"
+                f"# Profile: {context.profile.path.name}\n"
+                "\n[flags]\n",
+                *[f"{flag_name} = {'1' if get_event_flag(flag_name) else '0'}\n" for flag_name in _event_flags],
+                "\n[vars]\n",
+                *[f"{var_name} = {get_event_var(var_name)}\n" for var_name in _event_vars],
+            ]
+        )
 
-    def process_line(line: str, is_boolean_value: bool) -> None:
-        if "=" in line:
-            name, value = line.strip().split(" = ")
-            if is_boolean_value:
-                set_event_flag(name, value == "1")
+
+def import_flags_and_vars(file_path: Path) -> None:
+    """
+    Reads event flags and variables from a file and updates them.
+    :param file_path: Path to the file to read from.
+    """
+    in_flags_section = True
+    with open(file_path, "r") as file:
+        line_number = 0
+        for line in file.readlines():
+            line_number += 1
+            line = line.split("#", 1)[0].strip()
+            if line.lower() == "[flags]":
+                in_flags_section = True
+                continue
+            elif line.lower() == "[vars]":
+                in_flags_section = False
+                continue
+            elif line == "":
+                continue
+            elif "=" not in line:
+                raise SyntaxError(f"Error in line #{line_number}: Missing a `=` character.")
             else:
-                set_event_var(name, int(value))
-
-    def read_file(file_path: str, is_boolean_value: bool) -> None:
-        try:
-            with open(file_path, "r") as file:
-                for line in file:
-                    process_line(line, is_boolean_value)
-        except FileNotFoundError:
-            context.message = f"File '{file_path}' not found."
-            context.set_manual_mode()
-        except IOError as e:
-            context.message(f"An error occurred while reading '{file_path}': {e}")
-            context.set_manual_mode()
-
-    def reset_and_write(file_name: str, lines: list[str]) -> None:
-        with open(file_name, "w") as file:
-            file.write("\n".join(lines) + "\n")
-
-    read_file(EVENT_FLAGS_FILE_PATH, is_boolean_value=True)
-    read_file(EVENT_VARS_FILE_PATH, is_boolean_value=False)
-
-    event_flag_lines = [f"{flag_name} = {'1' if get_event_flag(flag_name) else '0'}" for flag_name in _event_flags]
-    event_var_lines = [f"{var_name} = {get_event_var(var_name)}" for var_name in _event_vars]
-
-    reset_and_write(EVENT_FLAGS_FILE_PATH, event_flag_lines)
-    reset_and_write(EVENT_VARS_FILE_PATH, event_var_lines)
+                key, value = line.split("=", 1)
+                key = key.strip()
+                value = value.strip()
+                if in_flags_section:
+                    if value == "1":
+                        set_event_flag(key, True)
+                    elif value == "0":
+                        set_event_flag(key, False)
+                    else:
+                        raise ValueError(
+                            f"Error in line #{line_number}: Invalid value '{value}' for event flag '{key}'."
+                        )
+                else:
+                    set_event_var(key, int(value))

--- a/modules/gui/multi_select_window.py
+++ b/modules/gui/multi_select_window.py
@@ -145,9 +145,18 @@ def ask_for_confirmation(message: str, window_title: str = "Confirmation") -> bo
     no_button = ttk.Button(button_frame, text="No", command=on_no)
     no_button.grid(row=0, column=1, padx=10)
 
+    checked_window_height = False
     while window is not None:
         window.update_idletasks()
         window.update()
+
+        # Scale the window to fit the label.
+        if not checked_window_height:
+            checked_window_height = True
+            window_height = label.winfo_height() + 100
+            if window_height > 180:
+                window.geometry(f"400x{window_height}")
+
         time.sleep(1 / 60)
 
     return user_choice


### PR DESCRIPTION
### Description

This updates the debug utilities for exporting/importing event flags and event vars:

1. Instead of writing to a hardcoded location, it uses the Filechooser component to let the user choose a destination/source file for these actions. This would allow exporting different sets of flags and vars.
2. Both flags and vars are written to the same file, in an INI-like format.
3. I renamed the 'Data Manipulation' to 'Debug', just for consistency with naming (such as 'Debug Tabs' or the `--debug` command-line flag.)

Also, I updated the `ask_for_confirmation()` function to automatically adjust the window size to match the label. This fixes my issue where the buttons get pushed out of the frame.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
