### PR TITLE
Add debug tools for adding a test party and test item bag

### DIFF
--- a/modules/data/extract.py
+++ b/modules/data/extract.py
@@ -225,6 +225,14 @@ def extract_items(english_rom: ROM, localised_roms: dict[str, ROM]) -> list[dict
                 pretty_name = pretty_name[:2].upper() + pretty_name[2:]
             if pretty_name.startswith("S.s."):
                 pretty_name = f"S.S.{pretty_name[4:]}"
+            if pretty_name == "Tri-pass":
+                pretty_name = "Tri-Pass"
+            if pretty_name == "Teachy Tv":
+                pretty_name = "Teachy TV"
+            if pretty_name == "Go-goggles":
+                pretty_name = "Go-Goggles"
+            if pretty_name.endswith("ticket"):
+                pretty_name = pretty_name[:-6] + "Ticket"
 
             pocket = int.from_bytes(item_data[26:27], byteorder="little")
 

--- a/modules/data/items.json
+++ b/modules/data/items.json
@@ -8092,7 +8092,7 @@
     },
     {
         "index": 279,
-        "name": "Go-goggles",
+        "name": "Go-Goggles",
         "price": 0,
         "type": "use_and_stay_in_item_menu",
         "battle_use": null,
@@ -10615,7 +10615,7 @@
     },
     {
         "index": 366,
-        "name": "Teachy Tv",
+        "name": "Teachy TV",
         "price": 0,
         "type": "use_and_return_to_overworld",
         "battle_use": null,
@@ -10644,7 +10644,7 @@
     },
     {
         "index": 367,
-        "name": "Tri-pass",
+        "name": "Tri-Pass",
         "price": 0,
         "type": "use_and_stay_in_item_menu",
         "battle_use": null,
@@ -10731,7 +10731,7 @@
     },
     {
         "index": 370,
-        "name": "Mysticticket",
+        "name": "MysticTicket",
         "price": 0,
         "type": "use_and_stay_in_item_menu",
         "battle_use": null,
@@ -10760,7 +10760,7 @@
     },
     {
         "index": 371,
-        "name": "Auroraticket",
+        "name": "AuroraTicket",
         "price": 0,
         "type": "use_and_stay_in_item_menu",
         "battle_use": null,

--- a/modules/game_stats.py
+++ b/modules/game_stats.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 from modules.context import context
-from modules.memory import get_save_block, unpack_uint32
+from modules.memory import get_save_block, unpack_uint32, decrypt32
 
 
 class GameStat(Enum):
@@ -62,17 +62,13 @@ class GameStat(Enum):
 def get_game_stat(game_stat: GameStat) -> int:
     if context.rom.is_rs:
         game_stats_offset = 0x1540
-        encryption_key_offset = 0xAC
     elif context.rom.is_emerald:
         game_stats_offset = 0x159C
-        encryption_key_offset = 0xAC
     else:
         game_stats_offset = 0x1200
-        encryption_key_offset = 0xF20
 
     game_stats_offset += game_stat.value * 4
-    encryption_key = unpack_uint32(get_save_block(2, encryption_key_offset, size=4))
-    return unpack_uint32(get_save_block(1, game_stats_offset, size=4)) ^ encryption_key
+    return decrypt32(unpack_uint32(get_save_block(1, game_stats_offset, size=4)))
 
 
 def get_total_number_of_battles() -> int:

--- a/modules/gui/emulator_controls.py
+++ b/modules/gui/emulator_controls.py
@@ -8,12 +8,19 @@ from showinfm import show_in_file_manager
 
 from modules.console import console
 from modules.context import context
-from modules.debug_utilities import export_flags_and_vars, import_flags_and_vars
+from modules.debug_utilities import (
+    export_flags_and_vars,
+    import_flags_and_vars,
+    debug_give_test_item_pack,
+    debug_give_test_party,
+    debug_give_max_coins_and_money,
+)
 from modules.gui.debug_edit_party import run_edit_party_screen
 from modules.gui.multi_select_window import ask_for_confirmation
 from modules.libmgba import LibmgbaEmulator
 from modules.memory import GameState, get_game_state
 from modules.modes import get_bot_modes
+from modules.pokemon import get_party
 from modules.version import pokebot_name, pokebot_version
 
 
@@ -89,6 +96,9 @@ class EmulatorControls:
             self.debug_menu.add_separator()
             self.debug_menu.add_command(label="Edit Party", command=run_edit_party_screen)
             self.debug_menu.add_separator()
+            self.debug_menu.add_command(label="Test Item Pack", command=self._give_test_item_pack)
+            self.debug_menu.add_command(label="Test Party", command=self._give_test_party)
+            self.debug_menu.add_separator()
             self.debug_menu.add_command(
                 label="Help",
                 command=lambda: webbrowser.open_new_tab(
@@ -148,6 +158,22 @@ class EmulatorControls:
         file_name = target_path[0].replace("\\", "/").split("/")[-1]
         affected_flags_and_vars = import_flags_and_vars(target_path[0])
         context.message = f"✅ Imported {affected_flags_and_vars:,} flags and vars from {file_name}"
+
+    def _give_test_party(self) -> None:
+        if len(get_party()) > 3:
+            sure = ask_for_confirmation("This will overwrite the last 3 slots of your party. Are you sure?")
+            if not sure:
+                return
+        debug_give_test_party()
+        context.message = "✅ Added a very strong Mewtwo, a Lotad for catching, and two HM slaves to your party."
+
+    def _give_test_item_pack(self) -> None:
+        sure = ask_for_confirmation("This will overwrite your existing item bag. Are you sure that's what you want?")
+        if not sure:
+            return
+        debug_give_test_item_pack()
+        debug_give_max_coins_and_money()
+        context.message = "✅ Added some goodies to your item bag."
 
     def remove_from_window(self) -> None:
         if self.frame:

--- a/modules/save_data.py
+++ b/modules/save_data.py
@@ -33,7 +33,7 @@ class SaveData:
         save_block_2 = self.get_save_block(2, size=0x0E)
         encryption_key = self.get_save_block(2, encryption_key_offset, 4)
 
-        return Player(save_block_1, save_block_2, encryption_key)
+        return Player(save_block_1, save_block_2, unpack_uint32(encryption_key))
 
     def get_player_map_object(self) -> ObjectEvent | None:
         if context.rom.is_rs:
@@ -105,7 +105,7 @@ class SaveData:
             tms_hms_count = 58
             berries_count = 43
             offset = 0x310
-            encryption_key = self.sections[1][0xF20:0xF24]
+            encryption_key = unpack_uint32(self.sections[1][0xF20:0xF24])
         elif context.rom.is_emerald:
             items_count = 30
             key_items_count = 30
@@ -113,7 +113,7 @@ class SaveData:
             tms_hms_count = 64
             berries_count = 46
             offset = 0x560
-            encryption_key = self.sections[0][0xAC:0xB0]
+            encryption_key = unpack_uint32(self.sections[0][0xAC:0xB0])
         else:
             items_count = 20
             key_items_count = 20
@@ -121,7 +121,7 @@ class SaveData:
             tms_hms_count = 64
             berries_count = 46
             offset = 0x560
-            encryption_key = b"\x00\x00\x00\x00"
+            encryption_key = 0
 
         data_size = 4 * (items_count + key_items_count + poke_balls_count + tms_hms_count + berries_count)
         data = self.sections[1][offset : offset + data_size]


### PR DESCRIPTION
### Description

This adds two more items to the `Debug` menu, one for overwriting the current item bag with a 'testing toolkit' that contains most items that could become useful at some point.

It adds:
- 99× of each Poké ball (999× on FR/LG)
- 1× of each TM and HM
- 999× of each berry
- 99× each of Full Restore, Max Revive, Max Elixir, Max Repel, Escape Rope, Rare Candy (999× on FR/LG)
- most key items (no fossils, no temporary items like Devon Goods or Oak's Parcel, and Acro Bike instead of Mach Bike -- the item pocket does not have capacity for _all_ key items, so...)

The other one adds three Pokémon to the party: A strong Mewtwo for battling everything, a Lotad that knows moves useful for catching, and two 'HM slaves' that know all the HM moves.

![debug-01-mewtwo](https://github.com/user-attachments/assets/970642a8-17dd-452b-a317-43a29a5898a8)

![catcher](https://github.com/user-attachments/assets/1b48135c-8f94-4ecc-b4c6-1dcef431a6d9)

![debug-02-magikarp](https://github.com/user-attachments/assets/4d9d882c-b623-4395-9591-52f6d64ec65c)

![debug-03-chimecho](https://github.com/user-attachments/assets/e2fe9b53-acbd-41ec-9bab-80d4d1d8dfc7)


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
