### PR TITLE
Add a debug menu for editing the item bag

### DIFF
--- a/modules/debug_utilities.py
+++ b/modules/debug_utilities.py
@@ -356,43 +356,19 @@ def debug_write_item_bag(
     tms_hms: list[ItemSlot],
     berries: list[ItemSlot],
 ) -> None:
-    bags: dict[str, list[ItemSlot]] = {
-        "items": items,
-        "key_items": key_items,
-        "poke_balls": poke_balls,
-        "tms_hms": tms_hms,
-        "berries": berries,
+    bags: dict[str, tuple[list[ItemSlot], int]] = {
+        "items": (items, ItemPocket.Items.capacity),
+        "key_items": (key_items, ItemPocket.KeyItems.capacity),
+        "poke_balls": (poke_balls, ItemPocket.PokeBalls.capacity),
+        "tms_hms": (tms_hms, ItemPocket.TmsAndHms.capacity),
+        "berries": (berries, ItemPocket.Berries.capacity),
     }
-    counts = {}
-    if context.rom.is_frlg:
-        counts["items"] = 42
-        counts["key_items"] = 30
-        counts["poke_balls"] = 13
-        counts["tms_hms"] = 58
-        counts["berries"] = 43
-        item_bag_offset = 0x310
-        registered_item_offset = 0x296
-    elif context.rom.is_emerald:
-        counts["items"] = 30
-        counts["key_items"] = 30
-        counts["poke_balls"] = 16
-        counts["tms_hms"] = 64
-        counts["berries"] = 46
-        item_bag_offset = 0x560
-        registered_item_offset = 0x496
-    else:
-        counts["items"] = 20
-        counts["key_items"] = 20
-        counts["poke_balls"] = 16
-        counts["tms_hms"] = 64
-        counts["berries"] = 46
-        item_bag_offset = 0x560
-        registered_item_offset = 0x496
+    item_bag_offset = 0x310 if context.rom.is_frlg else 0x560
+    registered_item_offset = 0x296 if context.rom.is_frlg else 0x496
 
     data = b""
     for bag_name in bags:
-        bag = bags[bag_name]
-        count = counts[bag_name]
+        bag, count = bags[bag_name]
         if len(bag) > count:
             raise ValueError(f"Bag '{bag}' only fits {count} items, but {len(bag)} were provided.")
         bag_data = b""
@@ -488,13 +464,6 @@ def debug_give_test_item_pack(rse_bicycle: Literal["Acro Bike", "Mach Bike"] = "
     key_item_names.append("Itemfinder")
     key_item_names.append("S.S. Ticket")
 
-    if context.rom.is_rs:
-        item_count = 20
-    elif context.rom.is_emerald:
-        item_count = 30
-    else:
-        item_count = 42
-
     items_to_give = [
         "Full Restore",
         "Max Revive",
@@ -510,7 +479,7 @@ def debug_give_test_item_pack(rse_bicycle: Literal["Acro Bike", "Mach Bike"] = "
     ]
 
     debug_write_item_bag(
-        items=items[:item_count],
+        items=items[: ItemPocket.Items.capacity],
         key_items=[ItemSlot(get_item_by_name(name), 1) for name in sorted(key_item_names)],
         poke_balls=all_the_balls,
         tms_hms=all_the_tms_hms,

--- a/modules/debug_utilities.py
+++ b/modules/debug_utilities.py
@@ -36,7 +36,6 @@ from modules.pokemon import (
     get_nature_by_index,
     get_move_by_name,
     get_nature_by_name,
-    get_party,
 )
 from modules.roms import ROMLanguage
 
@@ -487,8 +486,8 @@ def debug_give_test_item_pack(rse_bicycle: Literal["Acro Bike", "Mach Bike"] = "
     )
 
 
-def debug_give_test_party() -> None:
-    pokemon_to_give = [
+def debug_get_test_party() -> list[Pokemon]:
+    return [
         debug_create_pokemon(
             original_pokemon=None,
             is_egg=False,
@@ -586,8 +585,6 @@ def debug_give_test_party() -> None:
             status_condition=StatusCondition.Healthy,
         ),
     ]
-
-    debug_write_party([*get_party()[:3], *pokemon_to_give])
 
 
 def debug_give_max_coins_and_money() -> None:

--- a/modules/gui/debug_edit_item_bag.py
+++ b/modules/gui/debug_edit_item_bag.py
@@ -1,0 +1,137 @@
+import time
+from tkinter import ttk, Tk, Toplevel, StringVar, IntVar, Canvas
+
+from modules.context import context
+from modules.debug_utilities import debug_write_item_bag
+from modules.items import ItemPocket, get_item_bag, _items_by_index, get_item_by_name, ItemSlot
+
+
+class ItemBagEditMenu:
+    def __init__(self, main_window: Tk):
+        self._main_window = main_window
+        self.window: Toplevel | None = Toplevel(main_window)
+
+        self.window.title("Edit Item Bag")
+        self.window.geometry("425x640")
+        self.window.protocol("WM_DELETE_WINDOW", self._remove_window)
+        self.window.bind("<Escape>", self._remove_window)
+        self.window.rowconfigure(0, weight=1)
+        self.window.columnconfigure(0, weight=1)
+
+        self.notebook = ttk.Notebook(self.window)
+        self.notebook.grid(sticky="NWES", padx=5, pady=5)
+
+        self.save_button = ttk.Button(self.window, text="Save Item Bag", command=self._save, style="Accent.TButton")
+        self.save_button.grid(sticky="NE", row=1, column=0, padx=5, pady=5)
+
+        self._frames: dict[ItemPocket, ItemPocketFrame] = {}
+        for pocket in ItemPocket:
+            frame = ItemPocketFrame(self.window, self.notebook, pocket)
+            self._frames[pocket] = frame
+            self.notebook.add(frame.frame, text=pocket.name)
+
+    def loop(self) -> None:
+        while self.window is not None:
+            self.window.update_idletasks()
+            self.window.update()
+            time.sleep(1 / 60)
+
+    def close_window(self) -> None:
+        if self.window is not None:
+            self.window.after(50, self._remove_window)
+
+    def _remove_window(self, event=None) -> None:
+        self.window.destroy()
+        self.window = None
+
+    def _save(self) -> None:
+        debug_write_item_bag(
+            items=self._frames[ItemPocket.Items].to_list(),
+            key_items=self._frames[ItemPocket.KeyItems].to_list(),
+            poke_balls=self._frames[ItemPocket.PokeBalls].to_list(),
+            tms_hms=self._frames[ItemPocket.TmsAndHms].to_list(),
+            berries=self._frames[ItemPocket.Berries].to_list(),
+        )
+        self.close_window()
+
+
+class ItemPocketFrame:
+    def __init__(self, window: Toplevel, parent: ttk.Widget, pocket: ItemPocket) -> None:
+        self._window = window
+        self._parent = parent
+        self._pocket = pocket
+
+        match pocket:
+            case ItemPocket.Items:
+                slots = get_item_bag().items
+            case ItemPocket.KeyItems:
+                slots = get_item_bag().key_items
+            case ItemPocket.PokeBalls:
+                slots = get_item_bag().poke_balls
+            case ItemPocket.TmsAndHms:
+                slots = get_item_bag().tms_hms
+            case ItemPocket.Berries | _:
+                slots = get_item_bag().berries
+
+        self._slot_size = 999 if pocket is ItemPocket.Berries or context.rom.is_frlg else 99
+        self._item_vars: list[StringVar] = []
+        self._quantity_vars: list[IntVar] = []
+
+        for n in range(pocket.capacity):
+            self._item_vars.append(StringVar(value=slots[n].item.name if n < len(slots) else "(Empty)"))
+            self._quantity_vars.append(IntVar(value=slots[n].quantity if n < len(slots) else 0))
+
+        self.frame = self._build_frame()
+
+    def to_list(self) -> list[ItemSlot]:
+        result = []
+        for n in range(self._pocket.capacity):
+            item_name = self._item_vars[n].get()
+            quantity = self._quantity_vars[n].get()
+            if item_name != "(Empty)" and quantity > 0:
+                result.append(ItemSlot(get_item_by_name(item_name), quantity))
+        return result
+
+    def _build_frame(self) -> ttk.Frame:
+        frame = ttk.Frame(self._parent)
+
+        canvas = Canvas(frame)
+        canvas.pack(side="left", fill="both", expand=True)
+
+        scrollbar = ttk.Scrollbar(frame, orient="vertical", command=canvas.yview)
+        scrollbar.pack(side="right", fill="y")
+
+        canvas.configure(yscrollcommand=scrollbar.set)
+        canvas.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
+
+        inner_frame = ttk.Frame(canvas, width=400)
+        inner_frame.columnconfigure(0, weight=1)
+        inner_frame.columnconfigure(1, weight=1)
+        canvas.create_window((0, 0), window=inner_frame, anchor="nw")
+
+        item_names = [
+            "(Empty)",
+            *[
+                item.name
+                for item in _items_by_index
+                if item.pocket is self._pocket and item.index > 0 and not item.name.startswith("?")
+            ],
+        ]
+        item_names.sort()
+        for n in range(self._pocket.capacity):
+            label = ttk.Label(inner_frame, text=f"#{n + 1}")
+            label.grid(sticky="e", row=n, column=0, padx=5, pady=5)
+
+            combobox = ttk.Combobox(inner_frame, values=item_names, state="readonly", textvariable=self._item_vars[n])
+            combobox.grid(sticky="e", row=n, column=1, padx=5, pady=5)
+
+            spinbox = ttk.Spinbox(
+                inner_frame, from_=0, to=self._slot_size, textvariable=self._quantity_vars[n], width=4
+            )
+            spinbox.grid(sticky="w", row=n, column=2, padx=5, pady=5)
+
+        return frame
+
+
+def run_edit_item_bag_screen():
+    ItemBagEditMenu(context.gui.window).loop()

--- a/modules/gui/debug_menu.py
+++ b/modules/gui/debug_menu.py
@@ -5,11 +5,12 @@ import plyer
 
 from modules.context import context
 from modules.debug_utilities import (
-    debug_give_test_party,
     debug_give_test_item_pack,
     debug_give_max_coins_and_money,
     import_flags_and_vars,
     export_flags_and_vars,
+    debug_get_test_party,
+    debug_write_party,
 )
 from modules.gui.debug_edit_item_bag import run_edit_item_bag_screen
 from modules.gui.debug_edit_party import run_edit_party_screen
@@ -42,11 +43,15 @@ def _import_flags_and_vars() -> None:
 
 
 def _give_test_party() -> None:
-    if len(get_party()) > 3:
-        sure = ask_for_confirmation("This will overwrite the last 3 slots of your party. Are you sure?")
+    pokemon_to_give = debug_get_test_party()
+
+    if len(get_party()) > (6 - len(pokemon_to_give)):
+        sure = ask_for_confirmation(
+            f"This will overwrite the last {len(pokemon_to_give)} slots of your party. Are you sure?"
+        )
         if not sure:
             return
-    debug_give_test_party()
+    debug_write_party([*get_party()[: (6 - len(pokemon_to_give))], *pokemon_to_give])
     context.message = "✅ Added a very strong Mewtwo, a Lotad for catching, and two HM slaves to your party."
 
 

--- a/modules/gui/debug_menu.py
+++ b/modules/gui/debug_menu.py
@@ -1,0 +1,113 @@
+import webbrowser
+from tkinter import Tk, Menu
+
+import plyer
+
+from modules.context import context
+from modules.debug_utilities import (
+    debug_give_test_party,
+    debug_give_test_item_pack,
+    debug_give_max_coins_and_money,
+    import_flags_and_vars,
+    export_flags_and_vars,
+)
+from modules.gui.debug_edit_item_bag import run_edit_item_bag_screen
+from modules.gui.debug_edit_party import run_edit_party_screen
+from modules.gui.multi_select_window import ask_for_confirmation, ask_for_choice, Selection
+from modules.pokemon import get_party
+from modules.runtime import get_sprites_path
+
+
+def _import_flags_and_vars() -> None:
+    write_confirmation = ask_for_confirmation(
+        "Warning: This action will overwrite the current event flags and variables with the data from your local flags and vars text files. To apply these changes, make sure to save your game and reset the bot. Are you sure you want to proceed?"
+    )
+
+    if not write_confirmation:
+        return
+
+    target_path = plyer.filechooser.open_file(
+        path=str(context.profile.path / "event_vars_and_flags.txt"),
+        filters=[
+            ["Text Files", "*.txt", "*.ini"],
+            ["All Files", "*"],
+        ],
+    )
+    if target_path is None or len(target_path) != 1:
+        return
+
+    file_name = target_path[0].replace("\\", "/").split("/")[-1]
+    affected_flags_and_vars = import_flags_and_vars(target_path[0])
+    context.message = f"✅ Imported {affected_flags_and_vars:,} flags and vars from {file_name}"
+
+
+def _give_test_party() -> None:
+    if len(get_party()) > 3:
+        sure = ask_for_confirmation("This will overwrite the last 3 slots of your party. Are you sure?")
+        if not sure:
+            return
+    debug_give_test_party()
+    context.message = "✅ Added a very strong Mewtwo, a Lotad for catching, and two HM slaves to your party."
+
+
+def _give_test_item_pack() -> None:
+    sure = ask_for_confirmation("This will overwrite your existing item bag. Are you sure that's what you want?")
+    if not sure:
+        return
+    if context.rom.is_rse:
+        rse_bicycle = ask_for_choice(
+            [
+                Selection("Acro Bike", get_sprites_path() / "items" / f"Acro Bike.png"),
+                Selection("Mach Bike", get_sprites_path() / "items" / f"Mach Bike.png"),
+            ],
+            "Which bicycle do you want?",
+        )
+    else:
+        rse_bicycle = None
+    debug_give_test_item_pack(rse_bicycle)
+    debug_give_max_coins_and_money()
+    context.message = "✅ Added some goodies to your item bag."
+
+
+def _export_flags_and_vars() -> None:
+    target_path = plyer.filechooser.save_file(
+        path=str(context.profile.path / "event_vars_and_flags.txt"),
+        filters=[
+            ["Text Files", "*.txt", "*.ini"],
+            ["All Files", "*"],
+        ],
+    )
+    if target_path is None or len(target_path) != 1:
+        return
+
+    export_flags_and_vars(target_path[0])
+    context.message = f"✅ Exported flags and vars to {target_path[0].replace('\\', '/').split('/')[-1]}"
+
+
+def _edit_party() -> None:
+    run_edit_party_screen()
+
+
+def _edit_item_bag() -> None:
+    run_edit_item_bag_screen()
+
+
+class DebugMenu(Menu):
+    def __init__(self, window: Tk):
+        super().__init__(window, tearoff=0)
+
+        self.add_command(label="Export events and vars", command=_export_flags_and_vars)
+        self.add_command(label="Import events and vars", command=_import_flags_and_vars)
+        self.add_separator()
+        self.add_command(label="Edit Party", command=_edit_party)
+        self.add_command(label="Edit Item Bag", command=_edit_item_bag)
+        self.add_separator()
+        self.add_command(label="Test Item Pack", command=_give_test_item_pack)
+        self.add_command(label="Test Party", command=_give_test_party)
+        self.add_separator()
+        self.add_command(
+            label="Help",
+            command=lambda: webbrowser.open_new_tab(
+                "https://github.com/40Cakes/pokebot-gen3/blob/main/wiki/pages/Data%20Manipulation%20-%20Save%20Modification.md"
+            ),
+        )

--- a/modules/items.py
+++ b/modules/items.py
@@ -45,8 +45,28 @@ class ItemPocket(Enum):
     def index(self) -> int:
         return self.rse_index if context.rom.is_rse else self.frlg_index
 
+    @property
+    def capacity(self) -> int:
+        sizes = {
+            ItemPocket.Items: {"rs": 20, "e": 30, "frlg": 42},
+            ItemPocket.KeyItems: {"rs": 20, "e": 30, "frlg": 30},
+            ItemPocket.PokeBalls: {"rs": 16, "e": 16, "frlg": 13},
+            ItemPocket.TmsAndHms: {"rs": 64, "e": 64, "frlg": 58},
+            ItemPocket.Berries: {"rs": 46, "e": 46, "frlg": 43},
+        }
+
+        if context.rom.is_rs:
+            return sizes[self]["rs"]
+        elif context.rom.is_emerald:
+            return sizes[self]["e"]
+        else:
+            return sizes[self]["frlg"]
+
     def __str__(self):
         return self.value
+
+    def __hash__(self):
+        return hash(self.value)
 
 
 class ItemBattleUse(Enum):
@@ -481,27 +501,12 @@ def get_item_bag() -> ItemBag:
     if state_cache.item_bag.age_in_frames == 0:
         return state_cache.item_bag.value
 
-    if context.rom.is_frlg:
-        items_count = 42
-        key_items_count = 30
-        poke_balls_count = 13
-        tms_hms_count = 58
-        berries_count = 43
-        offset = 0x310
-    elif context.rom.is_emerald:
-        items_count = 30
-        key_items_count = 30
-        poke_balls_count = 16
-        tms_hms_count = 64
-        berries_count = 46
-        offset = 0x560
-    else:
-        items_count = 20
-        key_items_count = 20
-        poke_balls_count = 16
-        tms_hms_count = 64
-        berries_count = 46
-        offset = 0x560
+    offset = 0x310 if context.rom.is_frlg else 0x560
+    items_count = ItemPocket.Items.capacity
+    key_items_count = ItemPocket.KeyItems.capacity
+    poke_balls_count = ItemPocket.PokeBalls.capacity
+    tms_hms_count = ItemPocket.TmsAndHms.capacity
+    berries_count = ItemPocket.Berries.capacity
 
     data_size = 4 * (items_count + key_items_count + poke_balls_count + tms_hms_count + berries_count)
     data = get_save_block(1, offset=offset, size=data_size)


### PR DESCRIPTION
### Description

This adds an edit menu for the item bag, similar to the party-editing one.

Not too pretty, but gets the job done.

![image](https://github.com/user-attachments/assets/f4602756-540a-4683-8a17-1dab28d2cda4)


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
