### PR TITLE
Init ruby symbol mapping and fix German Ruby/Sapphire symbol loading

### DIFF
--- a/modules/data/symbols/patches/language/pokeruby_de_rev1.yml
+++ b/modules/data/symbols/patches/language/pokeruby_de_rev1.yml
@@ -1,0 +1,18 @@
+---
+
+#--------------------#
+#    Map Symbols     #
+#--------------------#
+gMapGroups:
+  D: ~
+gRegionMapEntries:
+  D: ~
+gWildMonHeaders:
+  D: ~
+gObjectEvents:
+  D: ~
+gPlayerPartyCount:
+  D: ~
+gPlayerParty:
+  D: ~
+#----------------#

--- a/modules/data/symbols/patches/language/pokeruby_rev1.yml
+++ b/modules/data/symbols/patches/language/pokeruby_rev1.yml
@@ -4,38 +4,17 @@
 #    Map Symbols     #
 #--------------------#
 gMapGroups:
-  D: ~
   F: 0x830f1ec
   I: ~
   J: ~
   S: ~
 gRegionMapEntries:
-  D: ~
   F: 0x83ef168
   I: ~
   J: ~
   S: ~
 gWildMonHeaders:
-  D: ~
   F: 0x83a40d4
-  I: ~
-  J: ~
-  S: ~
-gSaveBlock1:
-  D: ~
-  F: ~
-  I: ~
-  J: ~
-  S: ~
-gSaveBlock2:
-  D: ~
-  F: ~
-  I: ~
-  J: ~
-  S: ~
-CB2_RegionMap:
-  D: ~
-  F: ~
   I: ~
   J: ~
   S: ~
@@ -55,5 +34,9 @@ gPlayerParty:
   F: 0x3004370
   J: ~
 sMapCursor:
+  J: ~
+gSaveBlock1:
+  J: ~
+gSaveBlock2:
   J: ~
 #----------------#

--- a/modules/data/symbols/patches/language/pokeruby_rev1.yml
+++ b/modules/data/symbols/patches/language/pokeruby_rev1.yml
@@ -1,0 +1,59 @@
+---
+
+#--------------------#
+#    Map Symbols     #
+#--------------------#
+gMapGroups:
+  D: ~
+  F: 0x830f1ec
+  I: ~
+  J: ~
+  S: ~
+gRegionMapEntries:
+  D: ~
+  F: 0x83ef168
+  I: ~
+  J: ~
+  S: ~
+gWildMonHeaders:
+  D: ~
+  F: 0x83a40d4
+  I: ~
+  J: ~
+  S: ~
+gSaveBlock1:
+  D: ~
+  F: ~
+  I: ~
+  J: ~
+  S: ~
+gSaveBlock2:
+  D: ~
+  F: ~
+  I: ~
+  J: ~
+  S: ~
+CB2_RegionMap:
+  D: ~
+  F: ~
+  I: ~
+  J: ~
+  S: ~
+gMapHeader:
+  J: ~
+gObjectEvents:
+  F: 0x30048b0
+  J: ~
+gPlayerAvatar:
+  J: ~
+# English rev 2 + 10
+gPlayerPartyCount:
+  F: 0x3004360
+  J: ~
+# English rev 2 + 10
+gPlayerParty:
+  F: 0x3004370
+  J: ~
+sMapCursor:
+  J: ~
+#----------------#

--- a/modules/game.py
+++ b/modules/game.py
@@ -160,13 +160,13 @@ def set_rom(rom: ROM) -> None:
         case "AXV":
             match rom.revision:
                 case 0:
-                    match rom.language:
+                    match rom.language.value:
                         case "D":
                             _load_symbols("pokeruby_de.sym", rom.language)
                         case _:
                             _load_symbols("pokeruby.sym", rom.language)
                 case 1:
-                    match rom.language:
+                    match rom.language.value:
                         case "D":
                             _load_symbols("pokeruby_de_rev1.sym", rom.language)
                         case _:
@@ -178,13 +178,13 @@ def set_rom(rom: ROM) -> None:
         case "AXP":
             match rom.revision:
                 case 0:
-                    match rom.language:
+                    match rom.language.value:
                         case "D":
                             _load_symbols("pokesapphire_de.sym", rom.language)
                         case _:
                             _load_symbols("pokesapphire.sym", rom.language)
                 case 1:
-                    match rom.language:
+                    match rom.language.value:
                         case "D":
                             _load_symbols("pokesapphire_de_rev1.sym", rom.language)
                         case _:


### PR DESCRIPTION
### Description

This PR initializes Ruby symbol mapping to support multiple languages.  
The Ruby Map debug tab has been fixed for the French version.

I identified an issue with the German symbols loading for Ruby/Sapphire, which has now been corrected. Other games are not affected by this problem. 

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been run, using the `--line-length 120` argument.
- [X] Wiki has been updated (if relevant).

<!-- Any further information can be added below here such as images/videos -->
