### PR TITLE
Fix Map tab when player has no Pokémon

### DIFF
--- a/modules/map.py
+++ b/modules/map.py
@@ -1978,7 +1978,7 @@ def get_effective_encounter_rates_for_current_map() -> EffectiveWildEncounterLis
     from modules.player import get_player_avatar
 
     player = get_player_avatar()
-    if player is None:
+    if player is None or not get_party():
         return EffectiveWildEncounterList(0, 0, 0, None, [], WildEncounterList.empty(), [], [], [], [], [], [])
 
     map_group, map_number = player.map_group_and_number


### PR DESCRIPTION
### Description

Fixed an issue where debug Map tab would crash when you have no Pokémon in your party

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
