### PR TITLE
Refactor party code

### DIFF
--- a/modules/battle_action_selection.py
+++ b/modules/battle_action_selection.py
@@ -14,7 +14,7 @@ from modules.debug import debug
 from modules.items import Item, ItemBattleUse, get_pokeblocks
 from modules.memory import read_symbol, unpack_uint32, get_game_state, GameState, get_game_state_symbol, unpack_uint16
 from modules.menuing import scroll_to_item_in_bag, scroll_to_party_menu_index
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party, get_party_size
 
 
 @debug.track
@@ -85,9 +85,9 @@ def handle_battle_action_selection(strategy: BattleStrategy) -> Generator:
                 yield from battle_action_use_item(battle_state, index, target_index)
 
             case TurnAction.RotateLead:
-                if index >= len(get_party()):
+                if index >= get_party_size():
                     raise RuntimeError(
-                        f"Cannot switch in party slot #{index} because the party only has {len(get_party())} Pokémon."
+                        f"Cannot switch in party slot #{index} because the party only has {get_party_size()} Pokémon."
                     )
 
                 if index == battle_state.battling_pokemon[0].party_index or (

--- a/modules/battle_evolution_scene.py
+++ b/modules/battle_evolution_scene.py
@@ -9,7 +9,7 @@ from modules.battle_move_replacing import (
 from modules.battle_strategies import BattleStrategy
 from modules.context import context
 from modules.debug import debug
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party
 from modules.tasks import get_task, task_is_active
 
 

--- a/modules/battle_handler.py
+++ b/modules/battle_handler.py
@@ -17,8 +17,9 @@ from modules.keyboard import get_naming_screen_data, type_in_naming_screen
 from modules.memory import get_game_state, GameState
 from modules.menuing import scroll_to_party_menu_index
 from modules.plugins import plugin_should_nickname_pokemon
-from modules.pokemon import get_party, get_opponent
+from modules.pokemon import get_opponent
 from modules.pokemon_nicknaming import max_pokemon_name_length
+from modules.pokemon_party import get_party, get_party_size
 from modules.tasks import task_is_active
 
 
@@ -42,7 +43,7 @@ def handle_battle(strategy: BattleStrategy) -> Generator:
         elif (
             (instruction == "BattleScript_HandleFaintedMon" or task_is_active("Task_HandleChooseMonInput"))
             and get_battle_state().own_side.is_fainted
-            and any(not pokemon.is_egg and pokemon.current_hp > 0 for pokemon in get_party())
+            and len(get_party().non_fainted_pokemon) > 0
         ):
             yield from handle_fainted_pokemon(strategy)
         elif instruction in ("BattleScript_TryNicknameCaughtMon", "BattleScript_CaughtPokemonSkipNewDex"):
@@ -110,7 +111,7 @@ def handle_fainted_pokemon(strategy: BattleStrategy):
         yield
         return
 
-    if new_lead_index < 0 or new_lead_index >= len(get_party()):
+    if new_lead_index < 0 or new_lead_index >= get_party_size():
         raise RuntimeError(f"Cannot send out party index #{new_lead_index} because that does not exist.")
 
     new_lead = get_party()[new_lead_index]

--- a/modules/battle_move_replacing.py
+++ b/modules/battle_move_replacing.py
@@ -8,7 +8,8 @@ from modules.debug import debug
 from modules.game import get_symbol
 from modules.memory import read_symbol, unpack_uint32
 from modules.memory import unpack_uint16
-from modules.pokemon import get_move_by_index, get_party
+from modules.pokemon import get_move_by_index
+from modules.pokemon_party import get_party
 from modules.tasks import task_is_active, get_task, Task
 
 

--- a/modules/battle_strategies/_util.py
+++ b/modules/battle_strategies/_util.py
@@ -6,8 +6,8 @@ from modules.battle_strategies import TurnAction
 from modules.context import context
 from modules.items import ItemHoldEffect, get_item_bag, get_item_by_name
 from modules.memory import get_event_flag, read_symbol
-from modules.pokemon import StatusCondition, Pokemon, LearnedMove, get_type_by_name, get_ability_by_name, get_party
-from modules.modes._interface import BotModeError
+from modules.pokemon import StatusCondition, Pokemon, LearnedMove, get_type_by_name, get_ability_by_name
+from modules.pokemon_party import get_party
 
 if TYPE_CHECKING:
     from modules.pokemon import Move, Type

--- a/modules/battle_strategies/default.py
+++ b/modules/battle_strategies/default.py
@@ -1,19 +1,17 @@
-from modules.battle_state import BattleState, BattlePokemon, get_battle_state
-from modules.context import context
-from modules.pokemon import get_party, Pokemon, Move, LearnedMove, StatusCondition
-from modules.modes._interface import BotModeError
 from typing import Optional
+
+from modules.battle_state import BattleState, BattlePokemon
+from modules.context import context
+from modules.modes._interface import BotModeError
+from modules.pokemon import Pokemon, Move, LearnedMove
+from modules.pokemon_party import get_party
 from ._interface import BattleStrategy, TurnAction, SafariTurnAction
 from ._util import BattleStrategyUtil
 
 
 class DefaultBattleStrategy(BattleStrategy):
     def __init__(self):
-        self._first_non_fainted_party_index_before_battle = 0
-        for index, pokemon in enumerate(get_party()):
-            if not pokemon.is_egg and pokemon.current_hp > 0:
-                self._first_non_fainted_party_index_before_battle = index
-                break
+        self._first_non_fainted_party_index_before_battle = get_party().first_non_fainted.index
 
     def party_can_battle(self) -> bool:
         return any(self.pokemon_can_battle(pokemon) for pokemon in get_party())

--- a/modules/battle_strategies/level_balancing.py
+++ b/modules/battle_strategies/level_balancing.py
@@ -1,6 +1,6 @@
 from modules.battle_state import BattleState
 from modules.battle_strategies import DefaultBattleStrategy, TurnAction, BattleStrategyUtil
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party
 
 
 def _get_lowest_level_party_member_index(only_non_fainted: bool = False) -> int:

--- a/modules/battle_strategies/level_up.py
+++ b/modules/battle_strategies/level_up.py
@@ -1,8 +1,8 @@
 from modules.battle_state import BattleState
 from modules.battle_strategies import DefaultBattleStrategy, TurnAction, BattleStrategyUtil
 from modules.context import context
-from modules.pokemon import Pokemon, get_party, StatusCondition
-from modules.modes import BotModeError
+from modules.pokemon import Pokemon, StatusCondition
+from modules.pokemon_party import get_party
 
 
 class LevelUpLeadBattleStrategy(DefaultBattleStrategy):
@@ -54,10 +54,7 @@ class LevelUpLeadBattleStrategy(DefaultBattleStrategy):
     def party_can_battle(self) -> bool:
         party = get_party()
 
-        for pokemon in party:
-            if pokemon.is_egg or pokemon.is_empty:
-                continue
-
+        for pokemon in party.non_fainted_pokemon:
             if super()._pokemon_has_enough_hp(pokemon) and pokemon.status_condition is StatusCondition.Healthy:
                 for move in pokemon.moves:
                     if (

--- a/modules/battle_strategies/lose_on_purpose.py
+++ b/modules/battle_strategies/lose_on_purpose.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING
 
 from modules.battle_strategies import BattleStrategy, TurnAction, BattleStrategyUtil
-from modules.pokemon import get_party, StatusCondition
+from modules.pokemon import StatusCondition
+from modules.pokemon_party import get_party
 
 if TYPE_CHECKING:
     from modules.battle_state import BattleState, BattlePokemon, BattleType
@@ -26,10 +27,7 @@ def _get_weakest_move_against(battle_state: "BattleState", pokemon: "BattlePokem
 
         # If this is the last remaining non-fainted Pokémon in the party, using a
         # self-destructing move guarantees a loss.
-        if (
-            move.effect == "EXPLOSION"
-            and len([pokemon for pokemon in get_party() if not pokemon.is_egg and pokemon.current_hp > 0]) == 1
-        ):
+        if move.effect == "EXPLOSION" and len(get_party().non_fainted_pokemon) == 1:
             move_power = -2
 
         # Doing nothing is always the best idea.

--- a/modules/gui/debug_edit_party.py
+++ b/modules/gui/debug_edit_party.py
@@ -5,9 +5,7 @@ from tkinter import Tk, Toplevel, ttk
 from modules.context import context
 from modules.debug_utilities import debug_create_pokemon, debug_write_party
 from modules.items import get_item_by_index, get_item_by_name
-from modules.memory import write_symbol
 from modules.pokemon import (
-    get_party,
     Pokemon,
     get_species_by_national_dex,
     get_nature_by_index,
@@ -18,6 +16,7 @@ from modules.pokemon import (
     get_move_by_name,
     get_species_by_name,
 )
+from modules.pokemon_party import get_party
 
 status_name_map = {
     "Healthy": StatusCondition.Healthy,

--- a/modules/gui/debug_menu.py
+++ b/modules/gui/debug_menu.py
@@ -16,7 +16,7 @@ from modules.gui.debug_edit_item_bag import run_edit_item_bag_screen
 from modules.gui.debug_edit_party import run_edit_party_screen
 from modules.gui.debug_edit_pokedex import run_edit_pokedex_screen
 from modules.gui.multi_select_window import ask_for_confirmation, ask_for_choice, Selection
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party, get_party_size
 from modules.runtime import get_sprites_path
 
 
@@ -46,7 +46,7 @@ def _import_flags_and_vars() -> None:
 def _give_test_party() -> None:
     pokemon_to_give = debug_get_test_party()
 
-    if len(get_party()) > (6 - len(pokemon_to_give)):
+    if get_party_size() > (6 - len(pokemon_to_give)):
         sure = ask_for_confirmation(
             f"This will overwrite the last {len(pokemon_to_give)} slots of your party. Are you sure?"
         )

--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -54,7 +54,8 @@ from modules.memory import (
 from modules.menuing import is_fade_active
 from modules.player import get_player, get_player_avatar, AvatarFlags, TileTransitionState
 from modules.pokedex import get_pokedex
-from modules.pokemon import get_party, get_species_by_index, get_party_repel_level
+from modules.pokemon import get_species_by_index
+from modules.pokemon_party import get_party
 from modules.pokemon_storage import get_pokemon_storage
 from modules.roamer import get_roamer, get_roamer_location_history
 from modules.tasks import (

--- a/modules/map.py
+++ b/modules/map.py
@@ -22,11 +22,10 @@ from modules.pokemon import (
     Species,
     get_item_by_index,
     get_species_by_index,
-    get_party_repel_level,
     Ability,
-    get_party,
     get_type_by_name,
 )
+from modules.pokemon_party import get_current_repel_level, get_party
 from modules.state_cache import state_cache
 
 if TYPE_CHECKING:
@@ -1984,7 +1983,7 @@ def get_effective_encounter_rates_for_current_map() -> EffectiveWildEncounterLis
     map_group, map_number = player.map_group_and_number
 
     lead_pokemon = get_party()[0]
-    repel_level = get_party_repel_level()
+    repel_level = get_current_repel_level()
     wild_encounters = get_wild_encounters_for_map(map_group, map_number)
 
     def calculate_effective_encounters(

--- a/modules/map_path.py
+++ b/modules/map_path.py
@@ -7,7 +7,7 @@ from modules.context import context
 from modules.map import MapLocation, get_map_all_tiles, get_map_data, get_map_objects
 from modules.map_data import MapFRLG, MapRSE
 from modules.memory import get_event_flag, get_event_flag_by_number, get_event_var_by_number
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party
 
 LocationType: TypeAlias = MapLocation | tuple[tuple[int, int] | MapFRLG | MapRSE, tuple[int, int]]
 
@@ -487,34 +487,23 @@ def calculate_path(
     def can_surf():
         nonlocal _can_surf
         if _can_surf is None:
-            _can_surf = False
-            if not no_surfing and get_event_flag("BADGE05_GET"):
-                for pokemon in get_party():
-                    if pokemon.knows_move("Surf"):
-                        _can_surf = True
-                        break
+            _can_surf = not no_surfing and get_event_flag("BADGE05_GET") and get_party().has_pokemon_with_move("Surf")
         return _can_surf
 
     def can_dive():
         nonlocal _can_dive
         if _can_dive is None:
-            _can_dive = False
-            if context.rom.is_rse and get_event_flag("BADGE07_GET"):
-                for pokemon in get_party():
-                    if pokemon.knows_move("Dive"):
-                        _can_dive = True
-                        break
+            _can_dive = (
+                context.rom.is_rse and get_event_flag("BADGE07_GET") and get_party().has_pokemon_with_move("Dive")
+            )
         return _can_dive
 
     def can_waterfall():
         nonlocal _can_waterfall
         if _can_waterfall is None:
-            _can_waterfall = False
-            if context.rom.is_rse and get_event_flag("BADGE08_GET"):
-                for pokemon in get_party():
-                    if pokemon.knows_move("Waterfall"):
-                        _can_waterfall = True
-                        break
+            _can_waterfall = (
+                context.rom.is_rse and get_event_flag("BADGE08_GET") and get_party().has_pokemon_with_move("Waterfall")
+            )
         return _can_waterfall
 
     # Get all currently loaded objects so we can use their _actual_ location for obstacle calculations, rather

--- a/modules/menu_parsers.py
+++ b/modules/menu_parsers.py
@@ -4,7 +4,8 @@ from enum import IntEnum
 from modules.context import context
 from modules.game import decode_string
 from modules.memory import get_symbol_name, read_symbol, unpack_uint32
-from modules.pokemon import Move, Pokemon, get_move_by_index, get_party, parse_pokemon
+from modules.pokemon import Move, Pokemon, get_move_by_index, parse_pokemon
+from modules.pokemon_party import get_party
 from modules.tasks import get_task, task_is_active
 
 

--- a/modules/modes/_asserts.py
+++ b/modules/modes/_asserts.py
@@ -4,13 +4,12 @@ from modules.context import context
 from modules.items import get_item_bag, get_item_by_name
 from modules.map import ObjectEvent, calculate_targeted_coords
 from modules.map_data import MapRSE, MapFRLG, is_safari_map
-from modules.safari_strategy import get_safari_balls_left
-from modules.battle_state import BattleOutcome
 from modules.player import get_player
-from modules.pokemon import Pokemon, get_party
+from modules.pokemon import Pokemon
+from modules.pokemon_party import get_party, get_party_size
+from modules.safari_strategy import get_safari_balls_left
 from modules.save_data import get_save_data
 from ._interface import BotModeError
-
 
 _error_message_addendum_if_assert_only_failed_in_saved_game = (
     " (This is only the case in the saved game. Perhaps you just need to save again?)"
@@ -108,11 +107,9 @@ def assert_has_pokemon_with_any_move(moves: list[str], error_message: str, check
                                 currently active one.
     """
     party = get_party() if not check_in_saved_game else get_save_data().get_party()
-    for pokemon in party:
-        if not pokemon.is_egg and not pokemon.is_empty:
-            for learned_move in pokemon.moves:
-                if learned_move is not None and learned_move.move.name in moves:
-                    return
+    for move in moves:
+        if party.has_pokemon_with_move(move):
+            return
 
     if check_in_saved_game:
         # If the check has failed for the saved game, run it again for the active game -- if that fails
@@ -160,7 +157,7 @@ def assert_empty_slot_in_party(error_message: str, check_in_saved_game: bool = F
     """
     party = get_party() if not check_in_saved_game else get_save_data().get_party()
     if len(party) >= 6:
-        if check_in_saved_game and len(get_party()) < 6:
+        if check_in_saved_game and get_party_size() < 6:
             error_message += _error_message_addendum_if_assert_only_failed_in_saved_game
         raise BotModeError(error_message)
 
@@ -178,7 +175,7 @@ def assert_player_has_poke_balls() -> None:
             raise BotModeError("Out of Pokéballs! Better grab more before the next shiny slips away...")
 
 
-def is_pokemon_able_to_fight(pokemon: Pokemon) -> bool:
+def pokemon_has_usable_damaging_move(pokemon: Pokemon) -> bool:
     """
     Checks if the given Pokémon has at least one usable attacking move.
     Returns True if a usable move is found; otherwise, False.
@@ -195,8 +192,7 @@ def assert_party_can_fight(error_message: str, check_in_saved_game: bool = False
     Raises a BotModeError if no Pokémon has any attack-capable moves.
     """
     party = get_party() if not check_in_saved_game else get_save_data().get_party()
-
-    if any(not pokemon.is_egg and not pokemon.is_empty and is_pokemon_able_to_fight(pokemon) for pokemon in party):
+    if any(pokemon_has_usable_damaging_move(pokemon) for pokemon in party.non_fainted_pokemon):
         return
 
     raise BotModeError(error_message)

--- a/modules/modes/_listeners.py
+++ b/modules/modes/_listeners.py
@@ -9,7 +9,8 @@ from modules.map_data import MapFRLG, MapRSE
 from modules.memory import GameState, get_game_state, get_game_state_symbol, read_symbol, unpack_uint32, unpack_uint16
 from modules.menuing import CheckForPickup, MenuWrapper, should_check_for_pickup, RotatePokemon
 from modules.player import TileTransitionState, get_player_avatar, player_avatar_is_standing_still
-from modules.pokemon import StatusCondition, clear_opponent, get_opponent, get_party
+from modules.pokemon import StatusCondition, clear_opponent, get_opponent
+from modules.pokemon_party import get_party
 from modules.tasks import get_global_script_context, task_is_active, get_task
 from ._interface import BattleAction, BotListener, BotMode, FrameInfo
 from .util import isolate_inputs, save_the_game
@@ -191,12 +192,7 @@ class BattleListener(BotListener):
     @isolate_inputs
     @debug.track
     def fight(self, strategy: BattleStrategy):
-        first_non_fainted_lead_before_battle = 0
-        for index, pokemon in enumerate(get_party()):
-            if not pokemon.is_egg and pokemon.current_hp > 0:
-                first_non_fainted_lead_before_battle = index
-                break
-
+        first_non_fainted_lead_before_battle = get_party().first_non_fainted.index
         yield from plugin_battle_started(self._active_wild_encounter)
         yield from handle_battle(strategy)
         yield from self._wait_until_battle_is_over()

--- a/modules/modes/feebas.py
+++ b/modules/modes/feebas.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
 from typing import Generator
 
+from modules.battle_state import BattleOutcome
 from modules.context import context
 from modules.items import get_item_by_name, get_item_bag
 from modules.map import get_map_data
 from modules.map_data import MapRSE
 from modules.player import get_player, get_player_avatar, AvatarFlags
-from modules.pokemon import get_party
-from modules.battle_state import BattleOutcome
+from modules.pokemon_party import get_party
 from . import BattleAction
 from ._asserts import assert_player_has_poke_balls
 from ._interface import BotMode, BotModeError
@@ -174,13 +174,7 @@ class FeebasMode(BotMode):
         ):
             raise BotModeError("Error: You cannot use this mode without having a fishing rod.")
 
-        if get_event_flag("BADGE08_GET"):
-            for pokemon in get_party():
-                for learned_move in pokemon.moves:
-                    if learned_move is not None and learned_move.move.name == "Waterfall":
-                        self._can_use_waterfall = True
-                        break
-
+        self._can_use_waterfall = get_event_flag("BADGE08_GET") and get_party().has_pokemon_with_move("Waterfall")
         if not self._can_use_waterfall:
             if not get_event_flag("BADGE08_GET"):
                 context.message = "Warning: You do not have the Rain Badge, so you cannot use Waterfall. There will be some water tiles that we cannot reach."

--- a/modules/modes/game_corner.py
+++ b/modules/modes/game_corner.py
@@ -6,7 +6,7 @@ from modules.gui.multi_select_window import Selection, ask_for_choice
 from modules.map_data import MapFRLG
 from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
 from modules.player import get_player_avatar
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party, get_party_size
 from modules.runtime import get_sprites_path
 from modules.save_data import get_save_data
 from modules.tasks import task_is_active
@@ -126,7 +126,7 @@ class GameCornerMode(BotMode):
 
             # log the encounter
             yield from StartMenuNavigator("POKEMON").step()
-            yield from PokemonPartyMenuNavigator(len(get_party()) - 1, "summary").step()
+            yield from PokemonPartyMenuNavigator(get_party_size() - 1, "summary").step()
 
             handle_encounter(
                 EncounterInfo.create(get_party()[-1], EncounterType.Gift),

--- a/modules/modes/kecleon.py
+++ b/modules/modes/kecleon.py
@@ -5,7 +5,7 @@ from modules.encounter import handle_encounter, EncounterInfo
 from modules.map_data import MapRSE
 from modules.memory import get_event_flag
 from modules.player import get_player_avatar
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party_size
 from modules.save_data import get_last_heal_location
 from . import BattleAction
 from ._asserts import assert_has_pokemon_with_any_move, assert_player_has_poke_balls
@@ -51,7 +51,7 @@ class KecleonMode(BotMode):
             raise BotModeError("This Kecleon has already been encountered.")
         if get_last_heal_location() != MapRSE.FORTREE_CITY:
             raise BotModeError("This mode requires the last heal location to be Fortree City.")
-        if len(get_party()) > 1:
+        if get_party_size() > 1:
             raise BotModeError("This mode requires only one Pokémon in the party.")
 
         while context.bot_mode != "Manual":

--- a/modules/modes/level_grind.py
+++ b/modules/modes/level_grind.py
@@ -6,7 +6,8 @@ from modules.map_data import MapFRLG, MapRSE, PokemonCenter, get_map_enum
 from modules.map_path import calculate_path, PathFindingError
 from modules.modes import BattleAction
 from modules.player import get_player_avatar
-from modules.pokemon import get_party, StatusCondition
+from modules.pokemon import StatusCondition
+from modules.pokemon_party import get_party
 from ._asserts import assert_party_can_fight
 from ._interface import BotMode, BotModeError
 from .util import navigate_to, heal_in_pokemon_center, change_lead_party_pokemon, spin

--- a/modules/modes/nugget_bridge.py
+++ b/modules/modes/nugget_bridge.py
@@ -5,7 +5,7 @@ from modules.items import get_item_bag, get_item_by_name
 from modules.map_data import MapFRLG
 from modules.memory import get_event_flag
 from modules.player import get_player_avatar
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party, get_party_size
 from . import BattleAction
 from ._interface import BotMode, BotModeError
 from .util import navigate_to, wait_for_player_avatar_to_be_standing_still
@@ -44,7 +44,7 @@ class NuggetBridgeMode(BotMode):
     def run(self) -> Generator:
         if get_event_flag("HIDE_NUGGET_BRIDGE_ROCKET"):
             raise BotModeError("Unfortunately, you've already received the nugget. You cannot use this mode.")
-        if len(get_party()) > 1:
+        if get_party_size() > 1:
             raise BotModeError("Deposit all but one Pokémon to use this mode.")
         if get_party()[0].level > 6 and get_party()[0].species.name != "Magikarp":
             raise BotModeError(

--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -8,7 +8,7 @@ from modules.map_data import MapFRLG, MapRSE
 from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
 from modules.modes.util.walking import navigate_to
 from modules.player import get_player_avatar
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party_size, get_party
 from modules.runtime import get_sprites_path
 from modules.save_data import get_save_data
 from ._asserts import SavedMapLocation, assert_save_game_exists, assert_saved_on_map
@@ -22,7 +22,7 @@ from .util import (
     wait_until_task_is_active,
     wait_until_task_is_not_active,
 )
-from ..battle_state import battle_is_active, get_main_battle_callback, EncounterType
+from ..battle_state import get_main_battle_callback, EncounterType
 
 
 def run_frlg() -> Generator:
@@ -54,7 +54,7 @@ def run_frlg() -> Generator:
         yield from wait_for_unique_rng_value()
 
         # Wait for and confirm the first question (the 'Do you choose ...')
-        while len(get_party()) == 0:
+        while get_party_size() == 0:
             context.emulator.press_button("A")
             yield
 
@@ -172,7 +172,7 @@ def run_rse_johto():
             case "Totodile":
                 yield from navigate_to(map=MapRSE.LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB, coordinates=(9, 5))
 
-        if len(get_party()) >= 6:
+        if get_party_size() >= 6:
             raise BotModeError("This mode requires at least one empty party slot, but your party is full.")
 
         yield from ensure_facing_direction("Up")
@@ -193,7 +193,7 @@ def run_rse_johto():
 
         # Navigate to the summary screen to check for shininess
         yield from StartMenuNavigator("POKEMON").step()
-        yield from PokemonPartyMenuNavigator(len(get_party()) - 1, "summary").step()
+        yield from PokemonPartyMenuNavigator(get_party_size() - 1, "summary").step()
 
         handle_encounter(
             EncounterInfo.create(get_party()[-1], EncounterType.Gift),

--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -8,7 +8,7 @@ from modules.map_data import MapFRLG, MapRSE
 from modules.map_path import calculate_path
 from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
 from modules.player import get_player_avatar
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party, get_party_size
 from modules.save_data import get_save_data
 from ._asserts import (
     assert_save_game_exists,
@@ -86,7 +86,7 @@ class StaticGiftResetsMode(BotMode):
         # so in order to make sure that it was Togepi/Wynaut that hatched, we verify that the
         # egg is in the last slot of the party -- since the egg was picked up at the start of
         # the mode, it's guaranteed to be in that slot.
-        if party_index == len(get_party()) - 1:
+        if party_index == get_party_size() - 1:
             self._egg_has_hatched = True
 
     def run(self) -> Generator:
@@ -184,11 +184,7 @@ class StaticGiftResetsMode(BotMode):
                 yield from wait_for_no_script_to_run("B")
 
             def egg_in_party() -> int:
-                total_eggs = 0
-                for pokemon in get_party():
-                    if pokemon.is_egg:
-                        total_eggs += 1
-                return total_eggs
+                return len(get_party().eggs)
 
             def hatch_egg() -> Generator:
                 if encounter[2] == "Wynaut":
@@ -225,6 +221,6 @@ class StaticGiftResetsMode(BotMode):
             else:
                 # Navigate to the summary screen to check for shininess
                 yield from StartMenuNavigator("POKEMON").step()
-                yield from PokemonPartyMenuNavigator(len(get_party()) - 1, "summary").step()
+                yield from PokemonPartyMenuNavigator(get_party_size() - 1, "summary").step()
 
                 handle_encounter(EncounterInfo.create(get_party()[-1], EncounterType.Gift), disable_auto_catch=True)

--- a/modules/modes/sweet_scent.py
+++ b/modules/modes/sweet_scent.py
@@ -1,12 +1,11 @@
-from asyncio import log
 from typing import Generator
 
+from modules.battle_state import BattleOutcome
 from modules.context import context
 from modules.menu_parsers import CursorOptionEmerald, CursorOptionFRLG, CursorOptionRS
 from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
 from modules.player import get_player_avatar
-from modules.battle_state import BattleOutcome
-from modules.pokemon import get_move_by_name, get_party
+from modules.pokemon_party import get_party
 from ._asserts import assert_player_has_poke_balls, assert_has_pokemon_with_any_move
 from ._interface import BotMode
 
@@ -33,13 +32,7 @@ class SweetScentMode(BotMode):
 
         yield from StartMenuNavigator("POKEMON").step()
 
-        move_pokemon = None
-        move_wanted = get_move_by_name("Sweet Scent")
-        for index in range(len(get_party())):
-            for learned_move in get_party()[index].moves:
-                if learned_move is not None and learned_move.move == move_wanted:
-                    move_pokemon = index
-                    break
+        move_pokemon = get_party().first_pokemon_with_move("Sweet Scent")
 
         cursor = None
         if context.rom.is_emerald:
@@ -49,4 +42,4 @@ class SweetScentMode(BotMode):
         elif context.rom.is_frlg:
             cursor = CursorOptionFRLG
 
-        yield from PokemonPartyMenuNavigator(move_pokemon, "", cursor.SWEET_SCENT).step()
+        yield from PokemonPartyMenuNavigator(move_pokemon.index, "", cursor.SWEET_SCENT).step()

--- a/modules/modes/util/higher_level_actions.py
+++ b/modules/modes/util/higher_level_actions.py
@@ -9,7 +9,7 @@ from modules.menu_parsers import CursorOptionEmerald, CursorOptionFRLG, CursorOp
 from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
 from modules.modes.util.sleep import wait_for_n_frames
 from modules.player import get_player_avatar, get_player, TileTransitionState, RunningState
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party
 from modules.region_map import FlyDestinationFRLG, FlyDestinationRSE, get_map_cursor, get_map_region
 from modules.tasks import get_task, task_is_active
 from ._util_helper import isolate_inputs
@@ -49,21 +49,13 @@ def fly_to(destination: Union[FlyDestinationRSE, FlyDestinationFRLG]) -> Generat
     if not get_event_flag(destination.get_flag_name()):
         raise BotModeError(f"Player cannot fly to {destination.name} because that location is not yet available.")
 
-    flying_pokemon_index = -1
-    for index in range(len(get_party())):
-        pokemon = get_party()[index]
-        for learned_move in pokemon.moves:
-            if learned_move is not None and learned_move.move.name == "Fly":
-                flying_pokemon_index = index
-                break
-        if flying_pokemon_index > -1:
-            break
-    if flying_pokemon_index == -1:
+    flying_pokemon = get_party().first_pokemon_with_move("Fly")
+    if flying_pokemon is None:
         raise BotModeError("Player does not have any Pokémon that knows Fly in their party.")
 
     # Select field move FLY
     yield from StartMenuNavigator("POKEMON").step()
-    yield from PokemonPartyMenuNavigator(flying_pokemon_index, "", menu_index).step()
+    yield from PokemonPartyMenuNavigator(flying_pokemon.index, "", menu_index).step()
 
     # Wait for region map to load.
     while (

--- a/modules/modes/util/items.py
+++ b/modules/modes/util/items.py
@@ -6,7 +6,8 @@ from modules.items import Item, ItemPocket, get_item_bag, get_item_by_name, get_
 from modules.memory import GameState, get_event_flag, get_game_state, read_symbol, unpack_uint16
 from modules.menuing import StartMenuNavigator, scroll_to_item_in_bag as real_scroll_to_item
 from modules.player import get_player
-from modules.pokemon import get_party, LearnedMove
+from modules.pokemon import LearnedMove
+from modules.pokemon_party import get_party, get_party_size
 from modules.tasks import task_is_active
 from ._util_helper import isolate_inputs
 from .sleep import wait_for_n_frames
@@ -161,7 +162,7 @@ def teach_hm_or_tm(hm_or_tm: Item, party_index: int, move_index_to_replace: int 
             f"Cannot teach {hm_or_tm.name} to party Pokémon #{party_index} because there aren't that many Pokémon in the party."
         )
 
-    target = party[party_index]
+    target = get_party()[party_index]
     if not target.species.can_learn_tm_hm(hm_or_tm):
         raise BotModeError(f"{target.name} is not able to learn {hm_or_tm.tm_hm_move().name}.")
 
@@ -216,7 +217,7 @@ def teach_hm_or_tm(hm_or_tm: Item, party_index: int, move_index_to_replace: int 
     # Select the target Pokémon in Party Menu
     while True:
         if context.rom.is_rs:
-            current_slot_index = context.emulator.read_bytes(0x0202002F + len(get_party()) * 136 + 3, length=1)[0]
+            current_slot_index = context.emulator.read_bytes(0x0202002F + get_party_size() * 136 + 3, length=1)[0]
         else:
             current_slot_index = read_symbol("gPartyMenu", offset=9, size=1)[0]
         if current_slot_index < party_index:

--- a/modules/pokemon_party.py
+++ b/modules/pokemon_party.py
@@ -1,0 +1,166 @@
+from typing import Generator
+
+from modules.context import context
+from modules.memory import read_symbol, get_event_var
+from modules.pokemon import Pokemon, Move, Species
+from modules.state_cache import state_cache
+
+
+class PartyPokemon(Pokemon):
+    def __init__(self, data: bytes, index: int):
+        super().__init__(data)
+        self.index = index
+
+
+class Party:
+    def __init__(self, pokemon: list[PartyPokemon]):
+        self._pokemon = pokemon
+
+    def __eq__(self, other):
+        if isinstance(other, Party):
+            return len(other._pokemon) == len(self._pokemon) and all(
+                [other[n] == self[n] for n in range(len(self._pokemon))]
+            )
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, Party):
+            return len(other._pokemon) != len(self._pokemon) or any(
+                [other[n] != self[n] for n in range(len(self._pokemon))]
+            )
+        else:
+            return NotImplemented
+
+    def __contains__(self, item):
+        if isinstance(item, Pokemon):
+            return item in self._pokemon
+        elif isinstance(item, Species):
+            return any([pokemon.species is item for pokemon in self._pokemon])
+        else:
+            return NotImplemented
+
+    def __iter__(self) -> Generator[PartyPokemon, None, None]:
+        yield from self._pokemon
+
+    def __len__(self) -> int:
+        return len(self._pokemon)
+
+    def __getitem__(self, item: int) -> PartyPokemon | None:
+        if item not in (0, 1, 2, 3, 4, 5):
+            raise KeyError(f"Cannot access a party index of `{item}`.")
+
+        if len(self._pokemon) > item:
+            return self._pokemon[item]
+        else:
+            return None
+
+    @property
+    def contains_eggs(self) -> bool:
+        return any([pokemon.is_egg for pokemon in self._pokemon])
+
+    @property
+    def eggs(self) -> list[Pokemon]:
+        return [pokemon for pokemon in self._pokemon if pokemon.is_egg]
+
+    @property
+    def non_fainted_pokemon(self) -> list[PartyPokemon]:
+        return list(filter(lambda pokemon: not pokemon.is_egg and pokemon.current_hp > 0, self._pokemon))
+
+    @property
+    def first_non_fainted(self) -> PartyPokemon:
+        return self.non_fainted_pokemon[0]
+
+    def has_pokemon_with_move(self, move: Move | str) -> bool:
+        return any(pokemon.knows_move(move) for pokemon in self._pokemon)
+
+    def first_pokemon_with_move(self, move: Move | str) -> PartyPokemon | None:
+        for pokemon in self._pokemon:
+            if pokemon.knows_move(move):
+                return pokemon
+        return None
+
+    def to_list(self) -> list[PartyPokemon]:
+        return self._pokemon
+
+
+def get_party_size() -> int:
+    return read_symbol("gPlayerPartyCount", size=1)[0]
+
+
+def get_party() -> Party:
+    """
+    :return: The player's party of Pokémon.
+    """
+
+    if state_cache.party.age_in_frames == 0:
+        return state_cache.party.value
+
+    def read_party_pokemon(party_index: int) -> PartyPokemon | None:
+        party_pokemon = PartyPokemon(read_symbol("gPlayerParty", offset=party_index * 100, size=100), party_index)
+        return party_pokemon if not party_pokemon.is_empty and party_pokemon.is_valid else None
+
+    list_of_pokemon = []
+    for index in range(get_party_size()):
+        pokemon = read_party_pokemon(index)
+
+        # It's possible for party data to be written while we are trying to read it, in which case
+        # the checksum would be wrong and `parse_pokemon()` returns `None`.
+        #
+        # In order to still get a valid result, we will 'peek' into next frame's memory by
+        # (1) advancing the emulation by one frame, (2) reading the memory, (3) restoring the previous
+        # frame's state, so we don't mess with frame accuracy.
+        if pokemon is None:
+            retries = 5
+            with context.emulator.peek_frame():
+                while retries > 0 and pokemon is None:
+                    retries -= 1
+                    pokemon = read_party_pokemon(index)
+                    if pokemon is None:
+                        context.emulator._core.run_frame()
+        if pokemon is None:
+            if read_symbol("gPlayerParty", offset=index * 100, size=100).count(b"\x00") >= 99:
+                continue
+            else:
+                raise RuntimeError(f"Party Pokémon #{index + 1} was invalid for two frames in a row.")
+
+        list_of_pokemon.append(pokemon)
+
+    party = Party(list_of_pokemon)
+    state_cache.party = party
+
+    return party
+
+
+def get_opponent_party() -> Party | None:
+    """
+    Gets the opponent's party (obviously only makes sense to check when in a battle.)
+    :return: The full party of the opponent, or `None` if there is no valid opponent at the moment.
+    """
+    if state_cache.opponent.age_in_frames == 0:
+        return state_cache.opponent.value
+
+    list_of_pokemon = []
+    data = read_symbol("gEnemyParty")
+    for index in range(6):
+        offset = index * 100
+        pokemon = PartyPokemon(data[offset : offset + 100], index)
+        if pokemon is None:
+            if index == 0:
+                return None
+            else:
+                continue
+        list_of_pokemon.append(pokemon)
+
+    party = Party(list_of_pokemon)
+    state_cache.opponent = party
+
+    return party
+
+
+def get_current_repel_level() -> int:
+    """
+    :return: The minimum level that wild encounters can have, given the current Repel
+             state and the level of the first non-fainted Pokémon.
+    """
+    return get_party().first_non_fainted.level if get_event_var("REPEL_STEP_COUNT") > 0 else 0

--- a/modules/save_data.py
+++ b/modules/save_data.py
@@ -7,7 +7,7 @@ from modules.items import ItemBag
 from modules.map import ObjectEvent
 from modules.memory import get_save_block, unpack_uint16, unpack_uint32
 from modules.player import Player
-from modules.pokemon import Pokemon, parse_pokemon
+from modules.pokemon_party import Party, PartyPokemon
 
 
 def get_last_heal_location() -> tuple[int, int]:
@@ -84,7 +84,7 @@ class SaveData:
 
         return unpack_uint16(self.get_save_block(1, offset=var_offset, size=2))
 
-    def get_party(self) -> list[Pokemon]:
+    def get_party(self) -> Party:
         party = []
         if context.rom.is_frlg:
             party_count = self.sections[1][0x034]
@@ -94,8 +94,8 @@ class SaveData:
             party_offset = 0x238
         for index in range(party_count):
             offset = party_offset + index * 100
-            party.append(parse_pokemon(self.sections[1][offset : offset + 100]))
-        return party
+            party.append(PartyPokemon(self.sections[1][offset : offset + 100], index))
+        return Party(party)
 
     def get_item_bag(self) -> ItemBag:
         if context.rom.is_frlg:

--- a/modules/state_cache.py
+++ b/modules/state_cache.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from modules.map import EffectiveWildEncounterList
     from modules.memory import GameState
     from modules.player import Player, PlayerAvatar
-    from modules.pokemon import Pokemon
+    from modules.pokemon_party import Party
     from modules.pokemon_storage import PokemonStorage
     from modules.pokedex import Pokedex
     from modules.tasks import TaskList, ScriptContext
@@ -50,8 +50,8 @@ class StateCacheItem(Generic[T]):
 
 class StateCache:
     def __init__(self):
-        self._party: StateCacheItem[list["Pokemon"]] = StateCacheItem([])
-        self._opponent: StateCacheItem["list[Pokemon] | None"] = StateCacheItem(None)
+        self._party: StateCacheItem["Party | None"] = StateCacheItem(None)
+        self._opponent: StateCacheItem["Party | None"] = StateCacheItem(None)
         self._fishing_attempt: StateCacheItem["FishingAttempt | None"] = StateCacheItem(None)
         self._player: StateCacheItem["Player | None"] = StateCacheItem(None)
         self._player_avatar: StateCacheItem["PlayerAvatar | None"] = StateCacheItem(None)
@@ -69,28 +69,22 @@ class StateCache:
         self._battle_state: StateCacheItem["BattleState | None"] = StateCacheItem(None)
 
     @property
-    def party(self) -> StateCacheItem[list["Pokemon"]]:
+    def party(self) -> StateCacheItem["Party | None"]:
         return self._party
 
     @party.setter
-    def party(self, party: list["Pokemon"]):
-        if len(self._party.value) != len(party):
+    def party(self, party: "Party"):
+        if self._party.value != party:
             self._party.value = party
-            return
-
-        for i in range(len(self._party.value)):
-            if self._party.value[i] != party[i]:
-                self._party.value = party
-                return
-
-        self._party.checked()
+        else:
+            self._party.checked()
 
     @property
-    def opponent(self) -> StateCacheItem["list[Pokemon] | None"]:
+    def opponent(self) -> StateCacheItem["Party | None"]:
         return self._opponent
 
     @opponent.setter
-    def opponent(self, opponent: "list[Pokemon] | None"):
+    def opponent(self, opponent: "Party | None"):
         if (
             (self._opponent.value is None and opponent is not None)
             or (self._opponent.value is not None and opponent is None)

--- a/modules/web/http.py
+++ b/modules/web/http.py
@@ -34,7 +34,7 @@ from modules.memory import GameState, get_event_flag, get_game_state
 from modules.modes import get_bot_mode_names
 from modules.player import get_player, get_player_avatar
 from modules.pokedex import get_pokedex
-from modules.pokemon import get_party
+from modules.pokemon_party import get_party
 from modules.pokemon_storage import get_pokemon_storage
 from modules.runtime import get_base_path
 from modules.state_cache import state_cache, StateCacheItem
@@ -189,7 +189,7 @@ def http_server(host: str, port: int) -> web.AppRunner:
         cached_party = state_cache.party
         _update_via_work_queue(cached_party, get_party)
 
-        return web.json_response([p.to_dict() for p in cached_party.value])
+        return web.json_response(cached_party.value.to_list())
 
     @route.get("/pokedex")
     async def http_get_pokedex(request: web.Request):

--- a/modules/web/http_stream.py
+++ b/modules/web/http_stream.py
@@ -14,7 +14,8 @@ from modules.map import get_effective_encounter_rates_for_current_map
 from modules.memory import GameState, get_game_state
 from modules.player import get_player, get_player_avatar
 from modules.pokedex import get_pokedex
-from modules.pokemon import get_opponent, get_party
+from modules.pokemon import get_opponent
+from modules.pokemon_party import get_party
 from modules.state_cache import state_cache
 
 update_interval_in_ms = 1000 / 60
@@ -230,8 +231,7 @@ def run_watcher():
                 work_queue.put_nowait(get_party)
             if state_cache.party.frame > previous_game_state["party"]:
                 previous_game_state["party"] = state_cache.party.frame
-                data = list(map(lambda x: x.to_dict() if x is not None else None, state_cache.party.value))
-                send_message(DataSubscription.Party, data=data, event_type="Party")
+                send_message(DataSubscription.Party, data=state_cache.party.value.to_list(), event_type="Party")
 
         if subscriptions["Pokedex"] > 0:
             if state_cache.pokedex.age_in_seconds > 0:


### PR DESCRIPTION
### Description

This creates a dedicated container class for a party of Pokémon, which is used for the return value of both `get_party()` and `get_opponent_party()`.

It makes it a bit easier to handle by adding some convenience lookup functions to that class, rather than having to do the same 'iterate over party to see if some condition is met' pattern all over the code base.

There's probably room for more improvement, but for now I've added lookup functions for non-fainted Pokémon, eggs, and Pokémon that know a particular move.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
