### PR TITLE
Fix using slices on party again

### DIFF
--- a/modules/pokemon_party.py
+++ b/modules/pokemon_party.py
@@ -46,7 +46,10 @@ class Party:
     def __len__(self) -> int:
         return len(self._pokemon)
 
-    def __getitem__(self, item: int) -> PartyPokemon | None:
+    def __getitem__(self, item: int | slice):
+        if isinstance(item, slice):
+            return self._pokemon[item]
+
         if item not in (0, 1, 2, 3, 4, 5):
             raise KeyError(f"Cannot access a party index of `{item}`.")
 


### PR DESCRIPTION
### Description

This re-adds the `get_party()[1:3]`-style syntax again, which got broken by the party refactoring.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
