### PR TITLE
Fix party checking eggs for moves and abilities

### DIFF
--- a/modules/modes/_asserts.py
+++ b/modules/modes/_asserts.py
@@ -97,7 +97,9 @@ def assert_registered_item(
         raise BotModeError(error_message)
 
 
-def assert_has_pokemon_with_any_move(moves: list[str], error_message: str, check_in_saved_game: bool = False) -> None:
+def assert_has_pokemon_with_any_move(
+    moves: list[str], error_message: str, check_in_saved_game: bool = False, with_pp_remaining: bool = False
+) -> None:
     """
     Raises an exception if the player has no Pokémon that knows any of the given move in their
     party.
@@ -105,10 +107,12 @@ def assert_has_pokemon_with_any_move(moves: list[str], error_message: str, check
     :param error_message: Error message to display if the assertion fails.
     :param check_in_saved_game: Whether to get the party in the saved game, rather than th
                                 currently active one.
+    :param with_pp_remaining: Also make sure that the Pokémon has at least 1 PP remaining, i.e.
+                              can actually use it in battle.
     """
     party = get_party() if not check_in_saved_game else get_save_data().get_party()
     for move in moves:
-        if party.has_pokemon_with_move(move):
+        if party.has_pokemon_with_move(move, with_pp_remaining):
             return
 
     if check_in_saved_game:

--- a/modules/modes/daycare.py
+++ b/modules/modes/daycare.py
@@ -101,7 +101,8 @@ class DaycareMode(BotMode):
             console.print("[bold yellow]Egg generation rates may be affected.")
 
         if context.rom.is_emerald:
-            if not any(pokemon.ability.name in ("Flame Body", "Magma Armor") for pokemon in get_party()):
+            party = get_party()
+            if not party.has_pokemon_with_ability("Flame Body") and not party.has_pokemon_with_ability("Magma Armor"):
                 console.print(
                     "[bold yellow]WARNING: No Pokémon in your party has the Flame Body or Magma Armor ability."
                 )

--- a/modules/modes/kecleon.py
+++ b/modules/modes/kecleon.py
@@ -43,7 +43,9 @@ class KecleonMode(BotMode):
     def run(self) -> Generator:
         assert_player_has_poke_balls()
         assert_has_pokemon_with_any_move(
-            ["Selfdestruct", "Explosion"], "This mode requires a Pokémon with the move Selfdestruct."
+            ["Selfdestruct", "Explosion"],
+            error_message="This mode requires a Pokémon with the move Selfdestruct.",
+            with_pp_remaining=True,
         )
         if not (get_event_flag("RECEIVED_DEVON_SCOPE")):
             raise BotModeError("This mode requires the Devon Scope.")

--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -994,11 +994,15 @@ class Pokemon:
     def moves(self) -> tuple[LearnedMove | None, LearnedMove | None, LearnedMove | None, LearnedMove | None]:
         return self.move(0), self.move(1), self.move(2), self.move(3)
 
-    def knows_move(self, move: str | Move):
+    def knows_move(self, move: str | Move, with_pp_remaining: bool = False):
         if isinstance(move, Move):
             move = move.name
         for learned_move in self.moves:
-            if learned_move is not None and learned_move.move.name == move:
+            if (
+                learned_move is not None
+                and learned_move.move.name == move
+                and (not with_pp_remaining or learned_move.pp > 0)
+            ):
                 return True
         return False
 

--- a/modules/pokemon_party.py
+++ b/modules/pokemon_party.py
@@ -2,7 +2,7 @@ from typing import Generator
 
 from modules.context import context
 from modules.memory import read_symbol, get_event_var
-from modules.pokemon import Pokemon, Move, Species
+from modules.pokemon import Pokemon, Move, Species, Ability
 from modules.state_cache import state_cache
 
 
@@ -74,12 +74,23 @@ class Party:
     def first_non_fainted(self) -> PartyPokemon:
         return self.non_fainted_pokemon[0]
 
-    def has_pokemon_with_move(self, move: Move | str) -> bool:
-        return any(pokemon.knows_move(move) for pokemon in self._pokemon)
+    def has_pokemon_with_move(self, move: Move | str, with_pp_remaining: bool = False) -> bool:
+        return any(pokemon.knows_move(move, with_pp_remaining) and not pokemon.is_egg for pokemon in self._pokemon)
 
-    def first_pokemon_with_move(self, move: Move | str) -> PartyPokemon | None:
+    def first_pokemon_with_move(self, move: Move | str, with_pp_remaining: bool = False) -> PartyPokemon | None:
         for pokemon in self._pokemon:
-            if pokemon.knows_move(move):
+            if not pokemon.is_egg and pokemon.knows_move(move, with_pp_remaining):
+                return pokemon
+        return None
+
+    def has_pokemon_with_ability(self, ability: Ability | str) -> bool:
+        ability_name = ability.name if isinstance(ability, Ability) else str(ability)
+        return any(pokemon.ability.name == ability_name and not pokemon.is_egg for pokemon in self._pokemon)
+
+    def first_pokemon_with_ability(self, ability: Ability | str) -> PartyPokemon | None:
+        ability_name = ability.name if isinstance(ability, Ability) else str(ability)
+        for pokemon in self._pokemon:
+            if not pokemon.is_egg and pokemon.ability.name == ability_name:
                 return pokemon
         return None
 


### PR DESCRIPTION
### Description

The `has_pokemon_with_move()` and `first_pokemon_with_move()` utility functions would also check _eggs_ for moves, which probably isn't what we want in pretty much any case.

I've also added a flag to these functions that allows verifying that the move is actually usable, i.e. has PP left.

And while I was at it, I mirrored these utility functions for abilities as well.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
