### PR TITLE
Add a `pretty_name` property to map enums

### DIFF
--- a/modules/built_in_plugins/discord_integration.py
+++ b/modules/built_in_plugins/discord_integration.py
@@ -40,12 +40,15 @@ def iv_table(pokemon: "Pokemon") -> str:
     )
 
 
-def pokemon_label(pokemon: "Pokemon") -> str:
+def pokemon_label(encounter: "EncounterInfo") -> str:
+    pokemon = encounter.pokemon
     if pokemon.gender is not None and not pokemon.species.name.startswith("Nidoran"):
         gender_code = "♂" if pokemon.gender == "male" else "♀"
     else:
         gender_code = ""
-    return f"{pokemon.nature.name} **{pokemon.species_name_for_stats}{gender_code}** (Lv. {pokemon.level:,}) at {pokemon.location_met}!"
+
+    map_name = encounter.map.pretty_name if encounter.map is not None else pokemon.location_met
+    return f"{pokemon.nature.name} **{pokemon.species_name_for_stats}{gender_code}** (Lv. {pokemon.level:,}) at {map_name}!"
 
 
 def pokemon_fields(pokemon: "Pokemon", species_stats: "EncounterSummary", short: bool = False) -> dict[str, str]:
@@ -139,7 +142,7 @@ class DiscordPlugin(BotPlugin):
                 content=f"{encounter.type.verb.title()} a shiny ✨ {opponent.species_name_for_stats} ✨!",
                 embed=DiscordMessageEmbed(
                     title=f"Shiny {encounter.type.verb}!",
-                    description=pokemon_label(opponent),
+                    description=pokemon_label(encounter),
                     fields=pokemon_fields(opponent, species_stats)
                     | phase_summary_fields(opponent, shiny_phase, global_stats),
                     thumbnail=get_shiny_sprite(opponent),
@@ -160,7 +163,7 @@ class DiscordPlugin(BotPlugin):
                 content=f"{encounter.type.verb.title()} a shiny ✨ {opponent.species_name_for_stats} ✨.\n❌ But this species is on the block list, so it will not be caught. ❌",
                 embed=DiscordMessageEmbed(
                     title=f"(Blocked) Shiny {encounter.type.verb}",
-                    description=pokemon_label(opponent),
+                    description=pokemon_label(encounter),
                     fields=pokemon_fields(opponent, species_stats, short=True)
                     | phase_summary_fields(opponent, shiny_phase, global_stats),
                     thumbnail=get_shiny_sprite(opponent),
@@ -261,7 +264,7 @@ class DiscordPlugin(BotPlugin):
                 content=f"{encounter.type.verb.title()} an anti-shiny 💀 {opponent.species_name_for_stats} 💀!",
                 embed=DiscordMessageEmbed(
                     title=f"Anti-Shiny {encounter.type.verb}!",
-                    description=pokemon_label(opponent),
+                    description=pokemon_label(encounter),
                     fields=pokemon_fields(opponent, species_stats)
                     | phase_summary_fields(opponent, shiny_phase, global_stats),
                     thumbnail=get_anti_shiny_sprite(opponent),
@@ -280,7 +283,7 @@ class DiscordPlugin(BotPlugin):
                 webhook_config=context.config.discord.custom_filter_pokemon_encounter,
                 content=f"{encounter.type.verb.title()} a {opponent.species_name_for_stats} matching custom filter: `{encounter.catch_filters_result}`!",
                 embed=DiscordMessageEmbed(
-                    description=pokemon_label(opponent),
+                    description=pokemon_label(encounter),
                     fields=pokemon_fields(opponent, species_stats)
                     | phase_summary_fields(opponent, shiny_phase, global_stats),
                     thumbnail=get_regular_sprite(opponent),

--- a/modules/console.py
+++ b/modules/console.py
@@ -210,11 +210,12 @@ def print_stats(stats: "GlobalStats", encounter: "EncounterInfo") -> None:
     grid.add_column()
     grid.add_row(pokemon_table, Group(iv_table, move_list, ev_yields))
 
+    map_name = encounter.map.pretty_name if encounter.map is not None else pokemon.location_met
     console.print(
         Panel.fit(
             Group(grid, "\n", stats_table),
             border_style=type_colour,
-            title=f"{rich_name} [default]{encounter.type.verb} at [bold]{pokemon.location_met}[/bold][/default]",
+            title=f"{rich_name} [default]{encounter.type.verb} at [bold]{map_name}[/bold][/default]",
         )
     )
 

--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -891,11 +891,11 @@ class MiscTab(DebugTab):
             location_history = {"__value": []}
             for index, location in enumerate(get_roamer_location_history()):
                 if index == 0:
-                    location_history["Current Map"] = location.name
+                    location_history["Current Map"] = location.pretty_name
                 else:
                     # Do not show the current map in the short-form location history to save space.
-                    location_history["__value"].append(location.name)
-                    location_history[f"Current-{index} Map"] = location.name
+                    location_history["__value"].append(location.pretty_name)
+                    location_history[f"Current-{index} Map"] = location.pretty_name
             location_history["__value"] = ", ".join(location_history["__value"])
         else:
             location_history = None
@@ -1490,7 +1490,8 @@ class MapTab(DebugTab):
 
         return {
             "Map": {
-                "__value": map_enum.name,
+                "__value": map_enum.pretty_name,
+                "Enum Name": map_enum.name,
                 "In-game Name": map_data.map_name,
                 "Group": group_enum.name,
                 "Group Number": map_data.map_group,

--- a/modules/map_data.py
+++ b/modules/map_data.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum
 from typing import Generator
 
@@ -629,6 +630,110 @@ class MapFRLG(Enum):
     @property
     def exists_on_rs(self) -> bool:
         return False
+
+    @property
+    def pretty_name(self) -> str:
+        name = self.name.replace("_", " ").title().split()
+
+        substitutions = {
+            "Pokemon": "Pokémon",
+            "Ssanne": "S.S. Anne",
+            "Digletts": "Diglett’s",
+            "Co": "Co.",
+            "Mt": "Mt.",
+            "Loreleis": "Lorelei’s",
+            "Brunos": "Bruno’s",
+            "Agathas": "Agatha’s",
+            "Lances": "Lance’s",
+            "Champions": "Champion’s",
+            "Players": "Player’s",
+            "Rivals": "Rival’s",
+            "Oaks": "Oak’s",
+            "Wardens": "Warden’s",
+            "Copycats": "Copycat’s",
+            "Mr": "Mr.",
+            "Psychics": "Psychic’s",
+            "Captains": "Captain’s",
+        }
+
+        for index in range(len(name)):
+            if name[index] in substitutions:
+                name[index] = substitutions[name[index]]
+
+            if match := re.match("^([A-Z][a-z]+)(\\d+)$", name[index]):
+                name[index] = f"{match.group(1)} {match.group(2)}"
+                if len(name) > index + 1:
+                    name[index] += ","
+
+            if re.match("^B?\\d+[FP]$", name[index]):
+                name[index] = f"({name[index]})"
+
+        name = " ".join(name).replace(", (", " (")
+
+        prefixes = (
+            "S.S. Anne",
+            "Underground Path",
+            "Diglett’s Cave",
+            "Rocket Hideout",
+            "Safari Zone",
+            "Safari Zone, Center",
+            "Safari Zone, East",
+            "Safari Zone, North",
+            "Safari Zone, West",
+            "Pokémon League",
+            "Mt. Ember",
+            "One Island",
+            "One Island, Kindle Road",
+            "Two Island",
+            "Two Island, Cape Brink",
+            "Three Island",
+            "Four Island",
+            "Four Island, Icefall Cave",
+            "Five Island",
+            "Five Island, Lost Cave",
+            "Five Island, Resort Gorgeous",
+            "Six Island",
+            "Six Island, Dotted Hole",
+            "Six Island, Water Path",
+            "Seven Island",
+            "Seven Island, Tanoby Ruins",
+            "Seven Island, Sevault Canyon",
+            "Navel Rock",
+            "Trainer Tower",
+            "Birth Island",
+            "Indigo Plateau",
+            "Saffron City",
+            "Pallet Town",
+            "Viridian City",
+            "Pewter City",
+            "Cerulean City",
+            "Lavender Town",
+            "Vermilion City",
+            "Celadon City",
+            "Celadon City, Game Corner",
+            "Fuchsia City",
+            "Cinnabar Island",
+            "Cinnabar Island, Pokémon Lab",
+        )
+
+        for prefix in prefixes:
+            if name.startswith(prefix):
+                first_part = prefix
+                next_part = name[len(prefix) :].strip()
+                if next_part.startswith("("):
+                    first_part += " " + next_part[: next_part.index(")") + 1]
+                    next_part = next_part[next_part.index(")") + 1 :].strip()
+                if next_part not in ("", "Gym", "School", "Mart", "Museum"):
+                    name = f"{first_part}, {next_part}"
+
+        full_substitutions = {
+            "North South Tunnel": "North/South Tunnel",
+            "East West Tunnel": "East/West Tunnel",
+        }
+        for substitution in full_substitutions:
+            name = name.replace(substitution, full_substitutions[substitution])
+
+        return name
 
 
 class MapGroupRSE(Enum):
@@ -1318,6 +1423,102 @@ class MapRSE(Enum):
     def exists_on_rs(self) -> bool:
         emerald_only_maps = [(0, 54), (0, 55), (0, 56), (5, 7), (6, 8), (9, 13), (15, 13), (15, 14), (16, 14)]
         return self.value not in emerald_only_maps and (self.value[0] != 26 or self.value[1] <= 11)
+
+    @property
+    def pretty_name(self) -> str:
+        name = self.name.replace("_", " ").title().split()
+
+        substitutions = {
+            "Pokemon": "Pokémon",
+            "Brendans": "Brendan’s",
+            "Mays": "May’s",
+            "Birchs": "Birch’s",
+            "Cozmos": "Cozmo’s",
+            "Wandas": "Wanda’s",
+            "Relearners": "Relearner’s",
+            "Raters": "Rater’s",
+            "Wallys": "Wally’s",
+            "Sterns": "Stern’s",
+            "Cutters": "Cutter’s",
+            "Deleters": "Deleter’s",
+            "Stevens": "Steven’s",
+            "Sidneys": "Sidney’s",
+            "Phoebes": "Phoebe’s",
+            "Glacias": "Glacia’s",
+            "Drakes": "Drake’s",
+            "Champions": "Champion’s",
+            "Brineys": "Briney’s",
+            "Familys": "Family’s",
+            "Ladys": "Lady’s",
+            "Tunnelers": "Tunneler’s",
+            "Maniacs": "Maniac’s",
+            "Captains": "Captain’s",
+            "Mt": "Mt.",
+            "Ss": "S.S.",
+            "Corp": "Corp.",
+            "Northwest": "North/West",
+            "Southwest": "South/West",
+            "Northeast": "North/East",
+            "Southeast": "South/East",
+        }
+
+        for index in range(len(name)):
+            if name[index] in substitutions:
+                name[index] = substitutions[name[index]]
+
+            if match := re.match("^([A-Z][a-z]+)(\\d+)$", name[index]):
+                name[index] = f"{match.group(1)} {match.group(2)}"
+                if len(name) > index + 1:
+                    name[index] += ","
+
+            if re.match("^B?\\d+[FP]$", name[index]):
+                name[index] = f"({name[index]})"
+
+        if self.name.startswith("CONTEST_HALL_"):
+            name[2] = f"({name[2]})"
+
+        if "_BATTLE_TENT_" in self.name:
+            name[3] += ","
+
+        if (
+            self.name.startswith("BATTLE_FRONTIER_")
+            or self.name.startswith("SAFARI_ZONE_")
+            or self.name.startswith("BATTLE_PYRAMID_")
+            or self.name.startswith("SS_TIDAL_")
+            or self.name.startswith("NEW_MAUVILLE_")
+            or self.name.startswith("ABANDONED_SHIP_")
+            or self.name.startswith("SEALED_CHAMBER_")
+            or self.name.startswith("SECRET_BASE_")
+            or re.match("^SKY_PILLAR_[A-Z]", self.name)
+            or (len(name) > 2 and (name[1] == "Town" or name[1] == "City"))
+        ):
+            if len(name) > 2 and name[2] != "Gym" and name[2] != "Mart":
+                name[1] += ","
+
+        if self.name.startswith("EVER_GRANDE_CITY_"):
+            if len(name) > 3 and name[3] != "Gym" and name[3] != "Mart":
+                name[2] += ","
+
+        if self.name.startswith("SHOAL_CAVE_"):
+            name[2] = f"({name[2]}"
+            name[3] = f"{name[3]})"
+
+        if (
+            self.name.startswith("BATTLE_FRONTIER_BATTLE_TOWER_")
+            or self.name.startswith("BATTLE_FRONTIER_BATTLE_DOME_")
+            or self.name.startswith("BATTLE_FRONTIER_BATTLE_PALACE_")
+            or self.name.startswith("BATTLE_FRONTIER_BATTLE_PYRAMID_")
+            or self.name.startswith("BATTLE_FRONTIER_BATTLE_ARENA_")
+            or self.name.startswith("BATTLE_FRONTIER_BATTLE_FACTORY_")
+            or self.name.startswith("BATTLE_FRONTIER_BATTLE_PIKE_")
+            or self.name.startswith("ROUTE110_SEASIDE_CYCLING_ROAD_")
+            or self.name.startswith("SHOAL_CAVE_LOW_TIDE")
+            or self.name.startswith("SHOAL_CAVE_HIGH_TIDE")
+        ):
+            name[3] += ","
+
+        name = " ".join(name).replace(", (", " (")
+        return name
 
 
 class PokemonCenter(Enum):


### PR DESCRIPTION
### Description

This adds a `pretty_name` property to `MapFRLG` and `MapRSE` that format the enum value's name in a nice-looking way.

I've originally written these functions for some other project, but they work well here.

These names are now being used in some debug tab locations, as well as in console/Discord notifications about new encounters.

![image](https://github.com/user-attachments/assets/194548b4-6d89-4d76-9edc-2798091f7125)

![image](https://github.com/user-attachments/assets/2c5563ee-f9d1-45f1-8357-2f6d0e4fd0c2)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
