### PR TITLE
Fix using negative indices to acccess last party Pokémon

### DIFF
--- a/modules/pokemon_party.py
+++ b/modules/pokemon_party.py
@@ -47,16 +47,7 @@ class Party:
         return len(self._pokemon)
 
     def __getitem__(self, item: int | slice):
-        if isinstance(item, slice):
-            return self._pokemon[item]
-
-        if item not in (0, 1, 2, 3, 4, 5):
-            raise KeyError(f"Cannot access a party index of `{item}`.")
-
-        if len(self._pokemon) > item:
-            return self._pokemon[item]
-        else:
-            return None
+        return self._pokemon[item]
 
     @property
     def contains_eggs(self) -> bool:


### PR DESCRIPTION
### Description

Some places use something like `get_party()[-1]` to access the last Pokémon in the player's party.

Due to my attempt at cleverly catching errors in the new Party class's `__getitem__` function, an index of `-1` was not considered valid.

I've removed the error checking entirely now and just pass the index through verbatim. So you might get a `KeyError`, but at least all of these things should work again.

Fixes Static Gift Resets, Starters, and Game Corner modes at the very least.

![image](https://github.com/user-attachments/assets/cb2801e1-5edc-4e24-b54f-1b521a9c510d)


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
