### PR TITLE
Debug Menu: Allow adding a Pokémon with an encounter-related ability

### DIFF
--- a/modules/gui/debug_menu.py
+++ b/modules/gui/debug_menu.py
@@ -11,6 +11,7 @@ from modules.debug_utilities import (
     export_flags_and_vars,
     debug_get_test_party,
     debug_write_party,
+    debug_give_fainted_first_slot_pokemon_with_special_ability,
 )
 from modules.gui.debug_edit_item_bag import run_edit_item_bag_screen
 from modules.gui.debug_edit_party import run_edit_party_screen
@@ -106,6 +107,45 @@ class DebugMenu(Menu):
     def __init__(self, window: Tk):
         super().__init__(window, tearoff=0)
 
+        ability_menu = Menu(self, tearoff=0)
+        ability_menu.add_command(
+            label="Illuminate (double encounter rate)",
+            command=lambda: debug_give_fainted_first_slot_pokemon_with_special_ability("Illuminate"),
+        )
+        if context.rom.is_emerald:
+            ability_menu.add_command(
+                label="Sticky Hold (more fishing encounters)",
+                command=lambda: debug_give_fainted_first_slot_pokemon_with_special_ability("Sticky Hold"),
+            )
+            ability_menu.add_command(
+                label="Compound Eyes (higher chance of holding item)",
+                command=lambda: debug_give_fainted_first_slot_pokemon_with_special_ability("Compoundeyes"),
+            )
+            ability_menu.add_command(
+                label="Pressure (higher level encounters)",
+                command=lambda: debug_give_fainted_first_slot_pokemon_with_special_ability("Pressure"),
+            )
+            ability_menu.add_command(
+                label="Intimidate (fewer level<=5 encounters)",
+                command=lambda: debug_give_fainted_first_slot_pokemon_with_special_ability("Intimidate"),
+            )
+            ability_menu.add_command(
+                label="Magnet Pull (more Steel encounters)",
+                command=lambda: debug_give_fainted_first_slot_pokemon_with_special_ability("Magnet Pull"),
+            )
+            ability_menu.add_command(
+                label="Static (more Electric encounters)",
+                command=lambda: debug_give_fainted_first_slot_pokemon_with_special_ability("Static"),
+            )
+            ability_menu.add_command(
+                label="Synchronize (more same nature encounters)",
+                command=lambda: debug_give_fainted_first_slot_pokemon_with_special_ability("Synchronize"),
+            )
+            ability_menu.add_command(
+                label="Cute Charm (more opposite gender encounters)",
+                command=lambda: debug_give_fainted_first_slot_pokemon_with_special_ability("Cute Charm"),
+            )
+
         self.add_command(label="Export events and vars", command=_export_flags_and_vars)
         self.add_command(label="Import events and vars", command=_import_flags_and_vars)
         self.add_separator()
@@ -113,8 +153,9 @@ class DebugMenu(Menu):
         self.add_command(label="Edit Item Bag", command=_edit_item_bag)
         self.add_command(label="Edit Pokédex", command=_edit_pokedex)
         self.add_separator()
-        self.add_command(label="Test Party", command=_give_test_party)
-        self.add_command(label="Test Item Pack", command=_give_test_item_pack)
+        self.add_command(label="Give Test Party", command=_give_test_party)
+        self.add_command(label="Give Test Item Pack", command=_give_test_item_pack)
+        self.add_cascade(label="Give Lead with Ability", menu=ability_menu)
         self.add_separator()
         self.add_command(
             label="Help",

--- a/modules/map.py
+++ b/modules/map.py
@@ -1970,6 +1970,45 @@ class EffectiveWildEncounterList:
         }
 
 
+def get_encounter_affecting_abilities() -> list[str]:
+    if context.rom.is_emerald:
+        return [
+            # Doubles encounter rate.
+            "Arena Trap",
+            "Illuminate",
+            # Increases the chance of a wild encounter holding an item from 50%/5% to 60%/20%.
+            "Compoundeyes",
+            # 2/3 chance that a wild encounter is of the opposite gender to the lead Pokémon.
+            "Cute Charm",
+            # 50% chance that a wild encounter has the maximum possible level of that encounter slot.
+            "Hustle",
+            "Pressure",
+            "Vital Spirit",
+            # 50% chance that a wild encounter with a level of 5 or lower than the lead Pokémon
+            # is rejected.
+            "Intimidate",
+            "Keen Eye",
+            # 50% chance that a Steel Pokémon is encountered, if such a Pokémon can be encountered
+            # on the current map (only for land encounters.)
+            "Magnet Pull",
+            # Halves encounter rates in areas with a sandstorm
+            "Sand Veil",
+            # 50% chance that an Electric Pokémon is encountered, if such a Pokémon can be
+            # encountered on the current map (only for land and surfing encounters.)
+            "Static",
+            # Halves encounter rates.
+            "Stench",
+            "White Smoke",
+            # Increases bite rates while fishing.
+            "Sticky Hold",
+            "Suction Cups",
+            # 50% chance that an encountered Pokémon has the same nature as the lead Pokémon.
+            "Synchronize",
+        ]
+    else:
+        return ["Stench", "Illuminate"]
+
+
 def get_effective_encounter_rates_for_current_map() -> EffectiveWildEncounterList | None:
     if state_cache.effective_wild_encounters.age_in_frames == 0:
         return state_cache.effective_wild_encounters.value
@@ -2068,42 +2107,7 @@ def get_effective_encounter_rates_for_current_map() -> EffectiveWildEncounterLis
             map_group, map_number, repel_level, None, [], WildEncounterList.empty(), [], [], [], [], [], []
         )
     else:
-        if context.rom.is_emerald:
-            encounter_affecting_abilities = (
-                # Doubles encounter rate.
-                "Arena Trap",
-                "Illuminate",
-                # Increases the chance of a wild encounter holding an item from 50%/5% to 60%/20%.
-                "Compound Eyes",
-                # 2/3 chance that a wild encounter is of the opposite gender to the lead Pokémon.
-                "Cute Charm",
-                # 50% chance that a wild encounter has the maximum possible level of that encounter slot.
-                "Hustle",
-                "Pressure",
-                "Vital Spirit",
-                # 50% chance that a wild encounter with a level of 5 or lower than the lead Pokémon
-                # is rejected.
-                "Intimidate",
-                "Keen Eye",
-                # 50% chance that a Steel Pokémon is encountered, if such a Pokémon can be encountered
-                # on the current map (only for land encounters.)
-                "Magnet Pull",
-                # Halves encounter rates in areas with a sandstorm
-                "Sand Veil",
-                # 50% chance that an Electric Pokémon is encountered, if such a Pokémon can be
-                # encountered on the current map (only for land and surfing encounters.)
-                "Static",
-                # Halves encounter rates.
-                "Stench",
-                "White Smoke",
-                # Increases bite rates while fishing.
-                "Sticky Hold",
-                "Suction Cups",
-                # 50% chance that an encountered Pokémon has the same nature as the lead Pokémon.
-                "Synchronize",
-            )
-        else:
-            encounter_affecting_abilities = ("Stench", "Illuminate")
+        encounter_affecting_abilities = get_encounter_affecting_abilities()
 
         encounter_affecting_items = []
         if (context.rom.is_frlg and get_event_flag("SYS_WHITE_FLUTE_ACTIVE")) or (


### PR DESCRIPTION
### Description

This adds some options to the debug menu that will add a Pokémon with certain encounter-related abilities (such as Illuminate, Sticky Hold, etc.) to the first party slot.

This Pokémon will be fainted, as weak as possible, and only knows moves that will make it faint.

Useful for testing encounter-boosting.

![image](https://github.com/user-attachments/assets/92309976-8eaf-4c62-995f-27073c99dacb)

### Notes

- On FR/LG and R/S only Illuminate is available, because all the other effects only got added in Emerald.
- Some abilities are missing to keep the list somewhat short. I've only added one ability per category (for example, Arena Trap has the same effect as Illuminate so it's not an option) and some 'negative' abilities (like Stench and White Smoke, which _lower_ encounter rates) are omitted.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
