### PR TITLE
Display Feebas tiles in debug tabs

### DIFF
--- a/modules/fishing.py
+++ b/modules/fishing.py
@@ -2,6 +2,11 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Optional
 
+from modules.context import context
+from modules.map import get_map_data
+from modules.map_data import MapRSE
+from modules.memory import get_save_block, unpack_uint16
+
 if TYPE_CHECKING:
     from modules.pokemon import Pokemon
 
@@ -38,3 +43,41 @@ class FishingAttempt:
             "result": self.result.name,
             "encounter": self.encounter.to_dict() if self.encounter is not None else None,
         }
+
+
+_route119_fishing_spots = []
+
+
+def get_feebas_tiles() -> list[tuple[int, int]]:
+    if context.rom.is_emerald:
+        offset = 0x2E68
+    elif context.rom.is_rs:
+        offset = 0x2DD4
+    else:
+        return []
+
+    global _route119_fishing_spots
+    if len(_route119_fishing_spots) == 0:
+        route119 = get_map_data(MapRSE.ROUTE119, (0, 0))
+        route119_tiles = route119.all_tiles()
+        for y in range(139):
+            for x in range(route119.map_size[0]):
+                tile = route119_tiles[x][y]
+                if tile.is_surfable and tile.tile_type != "Waterfall":
+                    _route119_fishing_spots.append((x, y))
+
+    seed = unpack_uint16(get_save_block(1, offset + 2, size=2))
+    feebas_tiles = []
+    n = 0
+    while n < 6:
+        seed = (1103515245 * seed + 12345) & 0xFFFF_FFFF
+        spot_index = (seed >> 16) % len(_route119_fishing_spots)
+
+        if spot_index == 0:
+            spot_index = len(_route119_fishing_spots)
+
+        if spot_index >= 4:
+            feebas_tiles.append(_route119_fishing_spots[spot_index - 1])
+            n += 1
+
+    return feebas_tiles

--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -12,6 +12,7 @@ from modules.clock import get_clock_time, get_play_time
 from modules.context import context
 from modules.daycare import get_daycare_data
 from modules.debug import debug
+from modules.fishing import get_feebas_tiles
 from modules.game import (
     decode_string,
     _symbols,
@@ -904,6 +905,7 @@ class MiscTab(DebugTab):
             "Daycare": daycare_information,
             "Roamer": get_roamer() if game_has_started() else None,
             "Location History": location_history,
+            "Feebas Tiles": get_feebas_tiles() if game_has_started() else None,
             "Region Map Cursor": get_map_cursor(),
             "Text Printer #1": get_text_printer(0),
             "gMain.state": read_symbol("gMain", offset=0x438, size=1)[0],


### PR DESCRIPTION
### Description

This adds the current Feebas tiles to the `Misc` debug tab, for easier testing.

![image](https://github.com/user-attachments/assets/df1f33a7-3a62-40ec-babb-4408789bb7f8)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
