### PR TITLE
Emerald : Support Berry Blender for non English ROMs

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.yml
+++ b/modules/data/symbols/patches/language/pokeemerald.yml
@@ -769,3 +769,22 @@ sNamingScreen:
 gSprites:
   J: 0x20205AC
 #---------------------#
+
+#---------------------#
+#    Berry blending   #
+#---------------------#
+CB2_PlayBlender:
+  D: 0x808189c
+  F: 0x8081890
+  I: 0x8081894
+  J: 0x80812b4
+  S: 0x8081894
+sArrowHitRangeStart:
+  D: 0x834e383
+  F: 0x834153f
+  I: 0x8339397
+  J: 0x830f8d7
+  S: 0x833fcaf
+sBerryBlender:
+  J: 0x2031f44
+#---------------------#

--- a/wiki/pages/Mode - Berry Blender.md
+++ b/wiki/pages/Mode - Berry Blender.md
@@ -15,11 +15,11 @@ one with 1-3 NPCs around it as the empty ones are for multiplayer only.)
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald |
 |:---------|:-------:|:-----------:|:----------:|
 | English  |    ✅    |      ✅      |     ✅      |
-| Japanese |   🟨    |     🟨      |     🟨     |
-| German   |   🟨    |     🟨      |     🟨     |
-| Spanish  |   🟨    |     🟨      |     🟨     |
-| French   |   🟨    |     🟨      |     🟨     |
-| Italian  |   🟨    |     🟨      |     🟨     |
+| Japanese |    ❌    |      ❌      |     ✅      |
+| German   |   🟨    |     🟨      |     ✅      |
+| Spanish  |    ❌    |      ❌      |     ✅      |
+| French   |    ❌    |      ❌      |     ✅      |
+| Italian  |    ❌    |      ❌      |     ✅      |
 
 ✅ Tested, working
 


### PR DESCRIPTION
### Description

Add support these modes on Emerald :
- Berry Blender

Supported languages : 
|          | 🟢 Emerald
| :------- | :-----: |
| English|   Already supported✅    |
| German   |   Supported now ✅    |
| Spanish  |   Supported now ✅    |
| French   |   Supported now ✅    |
| Italian  |   Supported now ✅    |
| Japanese|   Supported now ✅    |

### Notes

I pushed testing save states on the save state repo

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
