### PR TITLE
Ruby: Support Feebas mode for EU languages

### DIFF
--- a/modules/data/symbols/patches/language/pokeruby_rev1.yml
+++ b/modules/data/symbols/patches/language/pokeruby_rev1.yml
@@ -363,7 +363,22 @@ namingScreenDataPtr:
   S: 0x83d1d1c
 #---------------------#
 
-
+#-----------#
+#   Feebas  #
+#-----------#
+# Waterfall
+sub_8086F64:
+  F: 0x80874a0
+  I: 0x8087358
+  J: ~
+  S: 0x8087440
+# Surf
+sub_8088954:
+  F: 0x8088e90
+  I: 0x8088d48
+  J: ~
+  S: 0x8088e30
+#-----------#
 # Ununsed symbols that were conflicting with currently used symbols
 # We set them to 0x0 to 'get them out of our way' and correctly target the desired symbol
 EventScript_SetupRivalOnBikeGfxIdFemale:

--- a/modules/modes/feebas.py
+++ b/modules/modes/feebas.py
@@ -223,7 +223,10 @@ class FeebasMode(BotMode):
                         yield from walk_one_tile("Right")
                         yield from navigate_to(MapRSE.ROUTE119, (24, 42))
                         yield from ensure_facing_direction("Left")
-                        yield from wait_for_task_to_start_and_finish("Task_SurfFieldEffect", "A")
+                        if context.rom.is_rs:
+                            yield from wait_for_task_to_start_and_finish("sub_8088954", "A")
+                        else:
+                            yield from wait_for_task_to_start_and_finish("Task_SurfFieldEffect", "A")
                         yield
 
                     # Move from upper lake to the lower lake.
@@ -232,7 +235,10 @@ class FeebasMode(BotMode):
                         yield from walk_one_tile("Up")
                         yield from navigate_to(MapRSE.ROUTE119, (26, 107))
                         yield from ensure_facing_direction("Left")
-                        yield from wait_for_task_to_start_and_finish("Task_SurfFieldEffect", "A")
+                        if context.rom.is_rs:
+                            yield from wait_for_task_to_start_and_finish("sub_8088954", "A")
+                        else:
+                            yield from wait_for_task_to_start_and_finish("Task_SurfFieldEffect", "A")
                         yield
 
                     # Swim up the waterfall is necessary.
@@ -240,7 +246,11 @@ class FeebasMode(BotMode):
                         yield from navigate_to(MapRSE.ROUTE119, (18, 29))
                         yield from ensure_facing_direction("Up")
                         context.emulator.press_button("A")
-                        yield from wait_for_task_to_start_and_finish("Task_UseWaterfall", "A")
+
+                        if context.rom.is_rs:
+                            yield from wait_for_task_to_start_and_finish("sub_8086F64", "A")
+                        else:
+                            yield from wait_for_task_to_start_and_finish("Task_UseWaterfall", "A")
                         yield
 
                     # Surf to the closest tile next to the target.

--- a/wiki/pages/Mode - Feebas.md
+++ b/wiki/pages/Mode - Feebas.md
@@ -57,10 +57,10 @@ The lakes marked in red are highly likely to contain a Feebas tile.
 |:---------|:-------:|:-----------:|:----------:|
 | English  |    ✅    |      ✅      |     ✅      |
 | Japanese |    ❌    |      ❌      |     ✅      |
-| German   |    ❌    |      ❌      |     ✅      |
-| Spanish  |    ❌    |      ❌      |     ✅      |
-| French   |    ❌    |      ❌      |     ✅      |
-| Italian  |    ❌    |      ❌      |     ✅      |
+| German   |    ✅    |      ❌      |     ✅      |
+| Spanish  |    ✅    |      ❌      |     ✅      |
+| French   |    ✅    |      ❌      |     ✅      |
+| Italian  |    ✅    |      ❌      |     ✅      |
 
 ✅ Tested, working
 


### PR DESCRIPTION
### Description

Added support for Feebas mode in Ruby

Supported languages : 
|          | 🟥 Ruby
| :------- | :-----: |
| English|   Already supported✅    |
| German   |   Supported now ✅    |
| Spanish  |   Supported now ✅    |
| French   |   Supported now ✅    |
| Italian  |   Supported now ✅    |
| Japanese|   Unsupported ❌    |

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
