### PR TITLE
Simplify Feebas mode pathfinding

### DIFF
--- a/modules/modes/feebas.py
+++ b/modules/modes/feebas.py
@@ -217,32 +217,6 @@ class FeebasMode(BotMode):
                     continue
 
                 if target_spot.coordinates != player_location:
-                    # Move from the lower lake to the upper lake.
-                    if target_spot.coordinates[1] < 98 <= player_location[1]:
-                        yield from navigate_to(MapRSE.ROUTE119, (25, 107))
-                        yield from walk_one_tile("Right")
-                        yield from navigate_to(MapRSE.ROUTE119, (24, 42))
-                        yield from ensure_facing_direction("Left")
-                        yield from wait_for_task_to_start_and_finish("Task_SurfFieldEffect", "A")
-                        yield
-
-                    # Move from upper lake to the lower lake.
-                    if target_spot.coordinates[1] >= 98 > player_location[1]:
-                        yield from navigate_to(MapRSE.ROUTE119, (25, 43))
-                        yield from walk_one_tile("Up")
-                        yield from navigate_to(MapRSE.ROUTE119, (26, 107))
-                        yield from ensure_facing_direction("Left")
-                        yield from wait_for_task_to_start_and_finish("Task_SurfFieldEffect", "A")
-                        yield
-
-                    # Swim up the waterfall is necessary.
-                    if target_spot.coordinates[1] < 28 < player_location[1]:
-                        yield from navigate_to(MapRSE.ROUTE119, (18, 29))
-                        yield from ensure_facing_direction("Up")
-                        context.emulator.press_button("A")
-                        yield from wait_for_task_to_start_and_finish("Task_UseWaterfall", "A")
-                        yield
-
                     # Surf to the closest tile next to the target.
                     target_tile, direction = _get_nearest_accessible_neighbour(target_spot.coordinates, player_location)
                     yield from navigate_to(MapRSE.ROUTE119, target_tile)


### PR DESCRIPTION
### Description

This removes some special handling of land/surf transitions as well as going up the waterfall on Route 119, because that is now natively supported by our pathfinding.

It still really likes to go on land, only to start surfing again one or two tiles later.

That's because the pathfinding _really_ tries to avoid tiles with encounters on them. This could be easily fixed, but for some reason doing so introduces a loop.

More debugging is required to figure out why that is, so for now... good enough!

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
