### PR TITLE
Clarify SGR doc for Lileep/Anorith

### DIFF
--- a/wiki/pages/Mode - Static Gift Resets.md
+++ b/wiki/pages/Mode - Static Gift Resets.md
@@ -15,6 +15,8 @@ Soft reset for a static gift Pokémon that are directly added to your party with
 ![](../../modules/web/static/sprites/pokemon/shiny/Kabuto.png)
 ![](../../modules/web/static/sprites/pokemon/shiny/Aerodactyl.png)
 
+- Hand a fossil to the Scientist
+- Leave the room and come back in
 - Place the player in front of the Scientist in the Eastern most room of [Cinnibar Lab](https://bulbapedia.bulbagarden.net/wiki/Cinnabar_Island#Cinnabar_Lab)
 - The scientist may be trapped on either of the two marked tiles, please stand facing these to activate the mode
 - Save the game (**in-game, not a save state**)


### PR DESCRIPTION
### Description

Some players are having issues with SGR in Emerald because you can start the SGR mode when handing the fossil to the scientist which end up the bot being stuck. The right behavior would be to hand the fossil to the scientist and then start the mode.

I made some clarification in the doc to avoid this confusion

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
