### PR TITLE
Level Grind: Fix check whether party has damaging move

### DIFF
--- a/modules/modes/_asserts.py
+++ b/modules/modes/_asserts.py
@@ -190,13 +190,13 @@ def pokemon_has_usable_damaging_move(pokemon: Pokemon) -> bool:
     )
 
 
-def assert_party_can_fight(error_message: str, check_in_saved_game: bool = False) -> None:
+def assert_party_has_damaging_move(error_message: str, check_in_saved_game: bool = False) -> None:
     """
     Ensures the party has at least one Pokémon with a usable attacking move.
     Raises a BotModeError if no Pokémon has any attack-capable moves.
     """
     party = get_party() if not check_in_saved_game else get_save_data().get_party()
-    if any(pokemon_has_usable_damaging_move(pokemon) for pokemon in party.non_fainted_pokemon):
+    if any(pokemon_has_usable_damaging_move(pokemon) and not pokemon.is_egg for pokemon in party):
         return
 
     raise BotModeError(error_message)

--- a/modules/modes/level_grind.py
+++ b/modules/modes/level_grind.py
@@ -8,7 +8,7 @@ from modules.modes import BattleAction
 from modules.player import get_player_avatar
 from modules.pokemon import StatusCondition
 from modules.pokemon_party import get_party
-from ._asserts import assert_party_can_fight
+from ._asserts import assert_party_has_damaging_move
 from ._interface import BotMode, BotModeError
 from .util import navigate_to, heal_in_pokemon_center, change_lead_party_pokemon, spin
 from ..battle_state import BattleOutcome
@@ -177,7 +177,7 @@ class LevelGrindMode(BotMode):
         if level_mode_choice.startswith("Level-balance"):
             self._level_balance = True
         else:
-            assert_party_can_fight("No Pokémon in the party has a usable attacking move!")
+            assert_party_has_damaging_move("No Pokémon in the party has a usable attacking move!")
 
             if not LevelUpLeadBattleStrategy().pokemon_can_battle(party_lead_pokemon):
                 user_confirmed = ask_for_confirmation(


### PR DESCRIPTION
### Description

I've accidentally changed the condition for the Level Grind mode to start so it only looks at _non-fainted_ Pokémon to have a damaging move.

Meaning that if you had a Pokémon capable of causing damage but that Pokémon was fainted the mode would refuse to start -- even though we go heal before doing the grind anyway.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
