### PR TITLE
Fix Hoenn Starters for EM JP

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.yml
+++ b/modules/data/symbols/patches/language/pokeemerald.yml
@@ -768,6 +768,13 @@ sNamingScreen:
   J: 0x2039c34
 gSprites:
   J: 0x20205AC
+
+
+#---------------------#
+#    Starters Hoenn   #
+#---------------------#
+TryDoEventsBeforeFirstTurn:
+  J: 0x803b26c
 #---------------------#
 
 #---------------------#


### PR DESCRIPTION
### Description

Fix an issue where reset wouldn't trigger on Emerald Japanese for Hoenn starters

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
