### PR TITLE
Do not crash if a profile with a GBC ROM exists

### DIFF
--- a/modules/profiles.py
+++ b/modules/profiles.py
@@ -41,8 +41,11 @@ def list_available_profiles() -> list[Profile]:
     for entry in PROFILES_DIRECTORY.iterdir():
         if entry.name.startswith("_"):
             continue
-        with contextlib.suppress(RuntimeError):
-            profiles.append(load_profile(entry))
+        try:
+            profile = load_profile(entry)
+            profiles.append(profile)
+        except RuntimeError:
+            pass
     return profiles
 
 
@@ -63,6 +66,8 @@ def load_profile(path: Path) -> Profile:
     rom_file = ROMS_DIRECTORY / metadata.rom.file_name
     if rom_file.is_file():
         rom = load_rom_data(rom_file)
+        if rom.is_gen2:
+            raise RuntimeError("Only Generation 3 games are supported")
         return Profile(rom, path, last_played)
     else:
         for rom in list_available_roms():


### PR DESCRIPTION
### Description

This adds handling for GB(C) ROMs.

Every time I switch between the gen2 branch and any other branch, I have to remove all the Gen2 profiles because otherwise the bot refuses to start due to the `*.gbc` files not being recognised as a valid ROM.

So this change adds support for these ROMs, but hides them. So as long as you don't try to _start_ a Gen2 profile, the mere existence of one won't cause an issue anymore.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
