### PR TITLE
Fix overriding symbol on load when sharing the same memory address 

### DIFF
--- a/modules/game.py
+++ b/modules/game.py
@@ -31,8 +31,7 @@ def _load_symbols(symbols_file: str, language: ROMLanguage) -> None:
                 label = label.strip()
 
                 _symbols[label.upper()] = (address, length)
-                if address not in _reverse_symbols or (_reverse_symbols[address][2] == 0 and length > 0):
-                    _reverse_symbols[address] = (label.upper(), label, length)
+                _reverse_symbols[address] = (label.upper(), label, length)
 
     language_code = str(language)
     language_patch_file = symbols_file.replace(".sym", ".yml")
@@ -51,15 +50,23 @@ def _load_symbols(symbols_file: str, language: ROMLanguage) -> None:
                         addresses_list = [addresses_list]
 
                     if label.upper() in _symbols:
-                        _reverse_symbols.pop(_symbols[label.upper()][0], None)
+                        existing_address = _symbols[label.upper()][0]
+                        if (
+                            existing_address in _reverse_symbols
+                            and _reverse_symbols[existing_address][0] == label.upper()
+                        ):
+                            _reverse_symbols.pop(existing_address, None)
 
                     for addr in addresses_list:
                         if addr is not None:
-                            _symbols[label.upper()] = (addr, _symbols[label.upper()][1])
+                            _symbols[label.upper()] = (
+                                addr,
+                                _symbols[label.upper()][1] if label.upper() in _symbols else 0,
+                            )
                             _reverse_symbols[addr] = (
                                 label.upper(),
                                 label,
-                                _symbols[label.upper()][1],
+                                _symbols[label.upper()][1] if label.upper() in _symbols else 0,
                             )
 
 


### PR DESCRIPTION

### Description

This PR addresses an issue where symbols were being unintentionally overridden when applying language-specific patches.  

#### Problem  
Symbols with identical addresses (e.g., `Task_MapNamePopup` and `sub_80A3118` in Ruby Rev1) caused `_reverse_symbols` to overwrite existing entries due to the address conflict. This led to incorrect mappings being loaded.

#### Solution  
- Adjusted the logic to ensure `_reverse_symbols` only replaces an entry if it matches the correct label or intended mapping.  
- This change allows new mappings from language patches to overwrite existing values safely, without unintentionally removing unrelated symbols.

### Checklist

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
