### PR TITLE
Rock Smash: Exit Safari Zone when there aren't enough steps for another loops

### DIFF
--- a/modules/modes/rock_smash.py
+++ b/modules/modes/rock_smash.py
@@ -10,7 +10,7 @@ from modules.gui.multi_select_window import Selection, ask_for_choice
 from modules.items import get_item_bag, get_item_by_name
 from modules.map_data import MapRSE
 from modules.map_path import calculate_path
-from modules.memory import get_event_flag, get_event_var
+from modules.memory import get_event_flag, get_event_var, read_symbol, unpack_uint16
 from modules.player import TileTransitionState, get_player, get_player_avatar, AvatarFlags, get_player_location
 from modules.runtime import get_sprites_path
 from modules.save_data import get_save_data
@@ -22,6 +22,7 @@ from ._asserts import (
     assert_save_game_exists,
     assert_saved_on_map,
     assert_player_has_poke_balls,
+    assert_item_exists_in_bag,
 )
 from ._interface import BotMode, BotModeError
 from .util import (
@@ -39,6 +40,7 @@ from .util import (
     wait_until_task_is_not_active,
     walk_one_tile,
 )
+from ..menuing import StartMenuNavigator
 
 
 class RockSmashMode(BotMode):
@@ -122,6 +124,14 @@ class RockSmashMode(BotMode):
                 SavedMapLocation(MapRSE.ROUTE121_SAFARI_ZONE_ENTRANCE),
                 "In order to rock smash for Shuckle you should save in the entrance building to the Safari Zone.",
             )
+            assert_item_exists_in_bag(
+                "Pokéblock Case", error_message="You need to own the Pokéblock Case in order to enter the Safari Zone."
+            )
+            assert_item_exists_in_bag(
+                "Pokéblock Case",
+                error_message="You need to own the Pokéblock Case in order to enter the Safari Zone.",
+                check_in_saved_game=True,
+            )
 
         assert_player_has_poke_balls()
 
@@ -202,12 +212,21 @@ class RockSmashMode(BotMode):
                             yield
                         yield from wait_for_player_avatar_to_be_standing_still()
 
+                    self._in_safari_zone = True
                     if self._using_mach_bike:
-                        yield from self.mount_bicycle()
-                        yield from navigate_to(MapRSE.SAFARI_ZONE_NORTHEAST, (15, 7))
+                        self._in_safari_zone = True
+                        for _ in navigate_to(MapRSE.SAFARI_ZONE_NORTHEAST, (15, 7)):
+                            if self._in_safari_zone:
+                                yield
+                            else:
+                                break
                         yield from self.unmount_bicycle()
                     else:
-                        yield from navigate_to(MapRSE.SAFARI_ZONE_NORTHEAST, (12, 7))
+                        for _ in navigate_to(MapRSE.SAFARI_ZONE_NORTHEAST, (12, 7)):
+                            if self._in_safari_zone:
+                                yield
+                            else:
+                                break
 
     @staticmethod
     @debug.track
@@ -388,6 +407,19 @@ class RockSmashMode(BotMode):
         yield from follow_path([(8, 12)])
         yield from ensure_facing_direction("Down")
         yield from self.smash("TEMP_13")
+
+        # This mode is only available on Emerald anyway. I'm still leaving the symbol name for R/S
+        # and FR/LG in here though, in case someone wants to copy/paste this at some point.
+        steps_remaining_symbol = "sSafariZoneStepCounter" if context.rom.is_emerald else "gSafariZoneStepCounter"
+        steps_remaining = unpack_uint16(read_symbol(steps_remaining_symbol))
+        if steps_remaining < 161:
+            yield from StartMenuNavigator("RETIRE").step()
+            yield from wait_for_script_to_start_and_finish(
+                "Route121_SafariZoneEntrance_EventScript_ExitSafariZone", "A"
+            )
+            yield from wait_for_player_avatar_to_be_standing_still()
+            self._in_safari_zone = False
+            return
 
         if self._using_mach_bike:
             yield from self.mount_bicycle()


### PR DESCRIPTION
### Description

This updates the Rock Smash mode on Emerald so that instead of just using up all their steps, the player will exit the Safari Zone using the Start Menu when there aren't enough steps left for another loop (that usually happens after the 3rd loop.)

This saves a few frames.

It also fixes a bug where the player wouldn't re-enter the Safari Zone if their steps ran out while still on the way to the Shuckle area.

And, finally, this adds a check that the player owns the Pokéblock Case -- which apparently is required to enter the SZ. Thanks to Neka for finding that out.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
