### PR TITLE
Stats: Only count catches if it's a shiny or CCF match

### DIFF
--- a/modules/modes/_listeners.py
+++ b/modules/modes/_listeners.py
@@ -131,7 +131,8 @@ class BattleListener(BotListener):
                 clear_opponent()
                 bot_mode.on_battle_ended(outcome)
                 _ensure_plugin_hook_will_run(plugin_battle_ended(outcome))
-                context.stats.log_end_of_battle(outcome)
+                if self._active_wild_encounter is not None:
+                    context.stats.log_end_of_battle(outcome, self._active_wild_encounter)
 
             if (
                 get_game_state_symbol() != "CB2_RETURNTOFIELD"

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -695,11 +695,11 @@ class StatsDatabase:
 
         self._connection.commit()
 
-    def log_end_of_battle(self, battle_outcome: "BattleOutcome"):
+    def log_end_of_battle(self, battle_outcome: "BattleOutcome", encounter_info: "EncounterInfo"):
         if self.last_encounter is not None:
             self.last_encounter.outcome = battle_outcome
             self._update_encounter_outcome(self.last_encounter)
-            if self.last_encounter.species_id in self._encounter_summaries:
+            if self.last_encounter.species_id in self._encounter_summaries and encounter_info.is_of_interest:
                 self._encounter_summaries[self.last_encounter.species_id].update_outcome(battle_outcome)
                 self._insert_or_update_encounter_summary(self._encounter_summaries[self.last_encounter.species_id])
 


### PR DESCRIPTION
### Description

The stats system currently counts _every_ caught Pokémon of a given species, even if it's just the player manually catching something.

While not totally wrong as the field is just called `catches`, in practice we're using it to track how many shiny encounters have been successfully caught (in the stream overlay, for example.)

So it makes more sense to only count catches if it's an 'of-interest' Pokémon.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
