### PR TITLE
Fix PartyPokemon to_list causing endpoint calls crash

### DIFF
--- a/modules/modes/static_gift_resets.py
+++ b/modules/modes/static_gift_resets.py
@@ -49,6 +49,7 @@ def _get_targeted_encounter() -> tuple[MapFRLG | MapRSE, tuple[int, int], str] |
         encounters = [
             (MapRSE.ROUTE119_WEATHER_INSTITUTE_2F, (2, 2), "Castform"),
             (MapRSE.ROUTE119_WEATHER_INSTITUTE_2F, (18, 6), "Castform"),
+            (MapRSE.ROUTE119_WEATHER_INSTITUTE_2F, (4, 6), "Castform"),
             (MapRSE.RUSTBORO_CITY_DEVON_CORP_2F, (14, 8), "Hoenn Fossils"),
             (MapRSE.MOSSDEEP_CITY_STEVENS_HOUSE, (4, 3), "Beldum"),
             (MapRSE.LAVARIDGE_TOWN, (4, 7), "Wynaut"),

--- a/modules/pokemon_party.py
+++ b/modules/pokemon_party.py
@@ -86,7 +86,7 @@ class Party:
         return None
 
     def to_list(self) -> list[PartyPokemon]:
-        return self._pokemon
+        return [pokemon.to_dict() for pokemon in self._pokemon]
 
 
 def get_party_size() -> int:


### PR DESCRIPTION
### Description

- Fixed an issue where Party HTTP calls would crash because PokemonParty list wasn't returning the correct value
- Add a new SGR tile to catch Castform in Sapphire

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
