### PR TITLE
Ruby : Support Poison and battle listener for EU languages

### DIFF
--- a/modules/data/symbols/patches/language/pokeruby_rev1.yml
+++ b/modules/data/symbols/patches/language/pokeruby_rev1.yml
@@ -414,6 +414,21 @@ gEggHatchData:
   F: 0x300482c
   I: 0x300482c
   S: 0x300482c
+# Poison faint 0x5
+gUnknown_081A14B8:
+  F: 0x81a699c
+  I: 0x81a1ed3
+  S: 0x81a483a
+# 0x8
+EventScript_StartTrainerBattle:
+  F: 0x81a4c10
+  I: 0x81a01b5
+  S: 0x81a2ad5
+# 0x4
+EventScript_DoTrainerBattle:
+  F: 0x81a4cf7
+  I: 0x81a029c
+  S: 0x81a2bbc
 #----------------#
 
 
@@ -423,3 +438,5 @@ EventScript_SetupRivalOnBikeGfxIdFemale:
   I: 0x0
 __fpcmp_parts_f:
   F: 0x0
+Common_EventScript_SetupEvilTeamGfxIds:
+  I: 0x0

--- a/wiki/pages/Mode - Roamer Resets.md
+++ b/wiki/pages/Mode - Roamer Resets.md
@@ -61,7 +61,7 @@ Unlike Emerald version, Ruby and Sapphire are not restricted by the sequence tha
 | German   |    ✅    |      ❌      |     ✅      |     ✅      |      ✅       |
 | Spanish  |    ✅    |      ❌      |     ✅      |     ✅      |      ✅       |
 | French   |    ✅    |      ❌      |     ✅      |     ✅      |      ✅       |
-| Italian  |    ❌    |      ❌      |     ✅      |     ✅      |      ✅       |
+| Italian  |    ✅    |      ❌      |     ✅      |     ✅      |      ✅       |
 
 ✅ Tested, working
 


### PR DESCRIPTION
### Description

There might be some symbols unsupported still for corner case or unused features, but these listeners mapping should end the overall Ruby coverage for EU languages

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
