### PR TITLE
EV Train: Improve battle strategy to never rotate lead, remove dead code, add colours to target table

### DIFF
--- a/wiki/pages/Mode - EV Train.md
+++ b/wiki/pages/Mode - EV Train.md
@@ -2,7 +2,9 @@
 
 # 💊 EV Train Mode
 
-This mode will continuously fight battles in order to EV Train your lead Pokémon. If the lead is unable to battle, the mode will swap to another mon in the party if that is enabled in the profile battle settings (see [⚔ Battling and Pickup config](Configuration%20-%20Battling%20and%20Pickup.md)). This is useful for training weak mons, but keep in mind it will alter the EVs of the mon switched to. The mode only tracks the lead's EVs and does not switch the lead outside of battle.
+This mode will continuously fight battles in order to EV Train your lead Pokémon. It
+will not rotate the lead Pokémon regardless of configuration, so that none of your
+other party members' EVs are messed up.
 
 When the active Pokémon is defeated or gets low on HP, it will heal at the nearest
 Pokémon Center automatically. Likewise, if your entire party gets defeated it will


### PR DESCRIPTION
1. This updates the EV Train mode's battle strategy so it always tries to run away if the lead Pokémon cannot battle. That should avoid adding unwanted EVs to other party members if the user forgot to update their `battle.yml`.
2. The EV train mode shows a table with the lead Pokémon's EVs and their targets after each battle, but this was a bit hard to read since these messages fly by so quickly. I've added some colour-coding (green for targets that have been reached, yellow for in-progress targets, regular font colour for EVs that are not being trained.)