### PR TITLE
Fix stale battle state being used in R/S Safari Zone when throwing Pokéblocks

### DIFF
--- a/modules/battle_action_selection.py
+++ b/modules/battle_action_selection.py
@@ -129,6 +129,7 @@ def handle_battle_action_selection(strategy: BattleStrategy) -> Generator:
                     raise RuntimeError("The 'Pokéblock' option is not available in FR/LG Safari battles.")
 
                 yield from battle_action_use_pokeblock(index)
+                break
 
             case SafariTurnAction.Bait:
                 if context.rom.is_rse:


### PR DESCRIPTION
When using a Pokéblock in R/S, after our block-throwing function has completed the game is already back in the action selection screen.

This means that the battle handler will never break out of that `while` loop (which is only meant to run for a single turn) and keeps providing the `decide_turn_in_safari_zone()` function with the battle state that has been generated before the Pokéblock has been thrown.

This fix just forces the battle handler to break out of the loop.