### PR TITLE
Prevent `on_battle_ended()` to run at the start of a battle

### DIFF
--- a/modules/modes/_listeners.py
+++ b/modules/modes/_listeners.py
@@ -121,6 +121,7 @@ class BattleListener(BotListener):
 
         elif (
             self._in_battle
+            and self._reported_start_of_battle
             and get_game_state() not in self.battle_states
             and not frame.task_is_active("Task_BattleStart")
             and get_last_battle_outcome() != BattleOutcome.InProgress


### PR DESCRIPTION
There is a brief moment after a battle commenced and before the battle handler callbacks are enabled, where all the conditions for 'we are no longer in a battle' are met.

That led to `on_battle_ended()` to be called at the start of a battle (as well as at the end.)

This fix just adds another check that the battle has actually started properly before considering to report the battle as done.