### PR TITLE
R/S : Fix level grind & party rotate

### DIFF
--- a/modules/data/symbols/pokeruby.sym
+++ b/modules/data/symbols/pokeruby.sym
@@ -4709,7 +4709,6 @@
 0806abf4 g 000000d8 Task_ShowResetRtcPrompt
 0806accc g 00000210 Task_ResetRtcScreen
 0806aedc g 00000058 CB2_PartyMenuMain
-0806aedc l 00000000 .gcc2_compiled.
 0806af34 g 00000016 VBlankCB_PartyMenu
 0806af4c g 00000040 SetPartyMenuSettings
 0806af8c g 00000020 DoOpenPartyMenu

--- a/modules/data/symbols/pokeruby_de.sym
+++ b/modules/data/symbols/pokeruby_de.sym
@@ -4736,7 +4736,6 @@
 0806af34 g 000000d8 Task_ShowResetRtcPrompt
 0806b00c g 00000210 Task_ResetRtcScreen
 0806b21c g 00000058 CB2_PartyMenuMain
-0806b21c l 00000000 .gcc2_compiled.
 0806b274 g 00000016 VBlankCB_PartyMenu
 0806b28c g 00000040 SetPartyMenuSettings
 0806b2cc g 00000020 DoOpenPartyMenu

--- a/modules/data/symbols/pokeruby_rev1.sym
+++ b/modules/data/symbols/pokeruby_rev1.sym
@@ -4709,7 +4709,6 @@
 0806ac14 g 000000d8 Task_ShowResetRtcPrompt
 0806acec g 00000210 Task_ResetRtcScreen
 0806aefc g 00000058 CB2_PartyMenuMain
-0806aefc l 00000000 .gcc2_compiled.
 0806af54 g 00000016 VBlankCB_PartyMenu
 0806af6c g 00000040 SetPartyMenuSettings
 0806afac g 00000020 DoOpenPartyMenu

--- a/modules/data/symbols/pokesapphire.sym
+++ b/modules/data/symbols/pokesapphire.sym
@@ -4709,7 +4709,6 @@
 0806abf8 g 000000d8 Task_ShowResetRtcPrompt
 0806acd0 g 00000210 Task_ResetRtcScreen
 0806aee0 g 00000058 CB2_PartyMenuMain
-0806aee0 l 00000000 .gcc2_compiled.
 0806af38 g 00000016 VBlankCB_PartyMenu
 0806af50 g 00000040 SetPartyMenuSettings
 0806af90 g 00000020 DoOpenPartyMenu

--- a/modules/data/symbols/pokesapphire_de.sym
+++ b/modules/data/symbols/pokesapphire_de.sym
@@ -4736,7 +4736,6 @@
 0806af38 g 000000d8 Task_ShowResetRtcPrompt
 0806b010 g 00000210 Task_ResetRtcScreen
 0806b220 g 00000058 CB2_PartyMenuMain
-0806b220 l 00000000 .gcc2_compiled.
 0806b278 g 00000016 VBlankCB_PartyMenu
 0806b290 g 00000040 SetPartyMenuSettings
 0806b2d0 g 00000020 DoOpenPartyMenu

--- a/modules/data/symbols/pokesapphire_rev1.sym
+++ b/modules/data/symbols/pokesapphire_rev1.sym
@@ -4709,7 +4709,6 @@
 0806ac18 g 000000d8 Task_ShowResetRtcPrompt
 0806acf0 g 00000210 Task_ResetRtcScreen
 0806af00 g 00000058 CB2_PartyMenuMain
-0806af00 l 00000000 .gcc2_compiled.
 0806af58 g 00000016 VBlankCB_PartyMenu
 0806af70 g 00000040 SetPartyMenuSettings
 0806afb0 g 00000020 DoOpenPartyMenu

--- a/modules/modes/util/map.py
+++ b/modules/modes/util/map.py
@@ -100,7 +100,7 @@ def find_closest_pokemon_center(
             try:
                 path_to = calculate_path(location, pokemon_center_candidate.value)
                 path_from = calculate_path(pokemon_center_candidate.value, location)
-                path_length = path_to + path_from
+                path_length = len(path_to) + len(path_from)
                 if path_length_to_pokemon_center is None or path_length < path_length_to_pokemon_center:
                     pokemon_center = pokemon_center_candidate
                     path_length_to_pokemon_center = path_length


### PR DESCRIPTION
### Description

- Fix an issue found by a user on [discord](https://discord.com/channels/1057088810950860850/1139190426834833528/1327364824673423390) where party menu memory location would share the same address with a random symbol causing the bot to stop 

- Fix Pokecenter loop crashing because `path_length < path_length_to_pokemon_center` was comparing Waypoint objects instead of integers

### Changes

<!-- In depth changes per file, if feasible -->

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
