### PR TITLE
Limit total number of save states in Load State Window

### DIFF
--- a/modules/gui/load_state_window.py
+++ b/modules/gui/load_state_window.py
@@ -60,8 +60,10 @@ class LoadStateWindow:
 
         def filter_state_files(files: list[Path]):
             maximum_number_of_autosave_files = 3
+            maximum_number_of_entries = 128
 
             autosaves_already_included = 0
+            number_of_entries_so_far = 0
             autosave_pattern = re.compile("^\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.ss1$")
             files.sort(reverse=True, key=lambda file: file.stat().st_mtime)
             for file in files:
@@ -69,6 +71,9 @@ class LoadStateWindow:
                     if autosaves_already_included >= maximum_number_of_autosave_files:
                         continue
                     autosaves_already_included += 1
+                number_of_entries_so_far += 1
+                if number_of_entries_so_far > maximum_number_of_entries:
+                    break
                 yield file
 
         photo_buffer = []


### PR DESCRIPTION
### Description

The Load State window crashes once a certain number of loadable states is reached. I haven't tested what that exact 'certain number' is.

We are already limiting the number of autosaves we display to 3.

But 'manual' save states (this includes those created with `Ctrl+S`, but also save states when encountering a shiny/CCF) are not filtered and/or limited.

This PR adds a limit of 128 total save states. That number has been chosen arbitrarily, but it doesn't crash my test profile anymore so I guess that's alright.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
