### PR TITLE
Fix rotating party lead after battle

### DIFF
--- a/modules/battle_strategies/default.py
+++ b/modules/battle_strategies/default.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from modules.battle_state import BattleState, BattlePokemon
+from modules.battle_state import BattleState, BattlePokemon, get_battle_state
 from modules.context import context
 from modules.modes._interface import BotModeError
 from modules.pokemon import Pokemon, Move, LearnedMove
@@ -140,6 +140,7 @@ class DefaultBattleStrategy(BattleStrategy):
     def choose_new_lead_after_battle(self) -> int | None:
         party = get_party()
         if not self.pokemon_can_battle(party[self._first_non_fainted_party_index_before_battle]):
+            util = BattleStrategyUtil(get_battle_state())
             return util.select_rotation_target()
 
         return None


### PR DESCRIPTION
### Description

The default battle handler's `choose_new_lead_after_battle()` method tried to use an instance of `BattleStrategyUtil` that was never initialised.

This led to an exception whenever the game tried to rotate the lead after a battle.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
