### PR TITLE
Pathfinding: Increase timeout when activating Surf

### DIFF
--- a/modules/modes/util/walking.py
+++ b/modules/modes/util/walking.py
@@ -155,6 +155,7 @@ def follow_waypoints(path: Iterable[Waypoint], run: bool = True) -> Generator:
     current_position = get_map_data_for_current_position()
     last_waypoint = None
     for waypoint in path:
+        print(waypoint)
         # For the first waypoint it is possible that the player avatar is not facing the same way as it needs to
         # walk. This leads to the first navigation step to actually become two: Turning around, then doing the step.
         # When in tall grass, that could lead to an encounter starting mid-step which messes up the battle handling.
@@ -170,7 +171,7 @@ def follow_waypoints(path: Iterable[Waypoint], run: bool = True) -> Generator:
         if waypoint.is_warp:
             frames_remaining_until_timeout += extra_timeout_in_frames_for_warps
         if waypoint.action is WaypointAction.Surf:
-            frames_remaining_until_timeout += 270
+            frames_remaining_until_timeout += 300
         elif waypoint.action is WaypointAction.Waterfall:
             frames_remaining_until_timeout += 195 + (get_player_location()[0][1] - waypoint.coordinates[1]) * 42
 


### PR DESCRIPTION
### Description

I've given the pathfinding algorithm 270 extra frames for waypoints that require activating Surf before triggering a pathing timeout for not having moved tiles for a while.

I don't remember how I chose that particular number, but it caused some issues for me on Emerald where the timeout got triggered before the bot was done starting to surf.

I've increased that limit to 300 frames and now it works. Oh well.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
