### PR TITLE
Battle Handler: Fix error in double battles if one Pokémon has no damaging moves

### DIFF
--- a/modules/battle_strategies/default.py
+++ b/modules/battle_strategies/default.py
@@ -171,20 +171,35 @@ class DefaultBattleStrategy(BattleStrategy):
 
         if not util.pokemon_has_enough_hp(pokemon):
             if partner_pokemon is None or not util.pokemon_has_enough_hp(partner_pokemon):
-                return self.handle_lead_cannot_battle(battle_state, util)
+                return self._handle_lead_cannot_battle(battle_state, util)
 
         left_opponent = battle_state.opponent.left_battler
         right_opponent = battle_state.opponent.right_battler
+
+        def first_available_move():
+            for index, learned_move in enumerate(battler.moves):
+                if (
+                    learned_move is not None
+                    and learned_move.pp > 0
+                    and battler.disabled_move is None
+                    or battler.disabled_move is not learned_move.move
+                ):
+                    return index
+            return 0
 
         if left_opponent is not None:
             strongest_move = util.get_strongest_move_against(battler, left_opponent)
             if strongest_move is not None:
                 return TurnAction.use_move_against_left_side_opponent(strongest_move)
+            else:
+                return TurnAction.use_move_against_left_side_opponent(first_available_move())
 
         if right_opponent is not None:
             strongest_move = util.get_strongest_move_against(battler, right_opponent)
             if strongest_move is not None:
                 return TurnAction.use_move_against_right_side_opponent(strongest_move)
+            else:
+                return TurnAction.use_move_against_right_side_opponent(first_available_move())
 
         return self._handle_lead_cannot_battle(battle_state, util, reason="No damaging moves available")
 

--- a/modules/modes/util/walking.py
+++ b/modules/modes/util/walking.py
@@ -155,7 +155,6 @@ def follow_waypoints(path: Iterable[Waypoint], run: bool = True) -> Generator:
     current_position = get_map_data_for_current_position()
     last_waypoint = None
     for waypoint in path:
-        print(waypoint)
         # For the first waypoint it is possible that the player avatar is not facing the same way as it needs to
         # walk. This leads to the first navigation step to actually become two: Turning around, then doing the step.
         # When in tall grass, that could lead to an encounter starting mid-step which messes up the battle handling.


### PR DESCRIPTION
### Description

The bot would previously throw an error if _any_ Pokémon in a double battle didn't have a valid damaging move.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
