### PR TITLE
Add remaining field moves to `use_field_move()` function

### DIFF
--- a/modules/menu_parsers.py
+++ b/modules/menu_parsers.py
@@ -38,7 +38,7 @@ class CursorOptionFRLG(IntEnum):
     TELEPORT = 25
     DIG = 26
     MILK_DRINK = 27
-    SOFT_BOILED = 28
+    SOFTBOILED = 28
     SWEET_SCENT = 29
 
 

--- a/modules/menuing.py
+++ b/modules/menuing.py
@@ -838,8 +838,8 @@ def should_check_for_pickup():
         return get_game_stat(GameStat.TOTAL_BATTLES) % context.config.battle.pickup_check_frequency == 0
 
 
-def use_party_hm_move(move_name: str):
-    assert_has_pokemon_with_any_move([move_name], "No Pokémon with move {move_name} in party.")
+def use_field_move(move_name: str):
+    assert_has_pokemon_with_any_move([move_name], f"No Pokémon with move {move_name} in party.")
     move_name_upper = move_name.upper()
     # badge checks
     if context.rom.is_rse:
@@ -892,16 +892,12 @@ def use_party_hm_move(move_name: str):
             case "WATERFALL":
                 if not get_event_flag("BADGE07_GET"):
                     raise BotModeError("You do not have the Volcano Badge to use Waterfall outside of battle.")
-            case _:
-                raise BotModeError("Invalid HM move name.")
 
     yield from StartMenuNavigator("POKEMON").step()
 
     # find Pokémon with desired HM move
     move_wanted = get_move_by_name(move_name)
     move_pokemon = get_party().first_pokemon_with_move(move_wanted)
-    if move_pokemon is None:
-        raise RuntimeError(f"Could not find a Pokémon that knows {move_wanted.name}.")
 
     cursor = None
     if context.rom.is_emerald:
@@ -927,9 +923,25 @@ def use_party_hm_move(move_name: str):
         case "WATERFALL":
             yield from PokemonPartyMenuNavigator(move_pokemon.index, "", cursor.WATERFALL).step()
         case "DIVE":
-            yield from PokemonPartyMenuNavigator(move_pokemon.index, "", cursor.DIVE).step()
+            if context.rom.is_frlg:
+                raise BotModeError("Diving is not possible on FR/LG.")
+            else:
+                yield from PokemonPartyMenuNavigator(move_pokemon.index, "", cursor.DIVE).step()
+        case "TELEPORT":
+            yield from PokemonPartyMenuNavigator(move_pokemon.index, "", cursor.TELEPORT).step()
         case "DIG":
             yield from PokemonPartyMenuNavigator(move_pokemon.index, "", cursor.DIG).step()
+        case "SECRET POWER":
+            if context.rom.is_frlg:
+                raise BotModeError("There is no Secret Power on FR/LG.")
+            else:
+                yield from PokemonPartyMenuNavigator(move_pokemon.index, "", cursor.SECRET_POWER).step()
+        case "MILK DRINK":
+            yield from PokemonPartyMenuNavigator(move_pokemon.index, "", cursor.MILK_DRINK).step()
+        case "SOFTBOILED":
+            yield from PokemonPartyMenuNavigator(move_pokemon.index, "", cursor.SOFTBOILED).step()
+        case "SWEET SCENT":
+            yield from PokemonPartyMenuNavigator(move_pokemon.index, "", cursor.SWEET_SCENT).step()
         case _:
             raise BotModeError("Invalid HM move name.")
     return

--- a/modules/modes/puzzle_solver.py
+++ b/modules/modes/puzzle_solver.py
@@ -5,7 +5,7 @@ from modules.debug import debug
 from modules.map import get_map_objects
 from modules.map_data import MapFRLG, MapRSE
 from modules.memory import get_event_flag, get_event_var
-from modules.menuing import use_party_hm_move
+from modules.menuing import use_field_move
 from modules.modes.util.higher_level_actions import dive, surface_from_dive
 from modules.player import get_player_avatar
 from modules.pokemon_party import get_party_size
@@ -100,14 +100,14 @@ class PuzzleSolverMode(BotMode):
                     # floor 3
                     yield from navigate_to(MapRSE.MIRAGE_TOWER_3F, (3, 8))
                     yield from ensure_facing_direction("Up")
-                    yield from use_party_hm_move("Rock Smash")
+                    yield from use_field_move("Rock Smash")
                     yield from wait_for_script_to_start_and_finish("EventScript_SmashRock")
                     yield
                     yield from navigate_to(MapRSE.MIRAGE_TOWER_3F, (2, 4))
                     # floor 4
                     yield from navigate_to(MapRSE.MIRAGE_TOWER_4F, (5, 7))
                     yield from ensure_facing_direction("Right")
-                    yield from use_party_hm_move("Rock Smash")
+                    yield from use_field_move("Rock Smash")
                     yield from wait_for_script_to_start_and_finish("EventScript_SmashRock")
                     yield
                     yield from unmount_bike()
@@ -177,7 +177,7 @@ class PuzzleSolverMode(BotMode):
                     yield from surface_from_dive()
                     context.message = "Solving Sealed Chamber Puzzle...\nStarting solution..."
                     yield from navigate_to(MapRSE.SEALED_CHAMBER_OUTER_ROOM, (10, 3))
-                    yield from use_party_hm_move("Dig")
+                    yield from use_field_move("Dig")
                     yield from wait_for_task_to_start_and_finish("Task_DuckBGMForPokemonCry", "A")
                     yield from navigate_to(MapRSE.SEALED_CHAMBER_OUTER_ROOM, (10, 2))
                     yield from navigate_to(MapRSE.SEALED_CHAMBER_INNER_ROOM, (10, 5))
@@ -204,7 +204,7 @@ class PuzzleSolverMode(BotMode):
                         context.message = "Two Left, Two Down, Rock Smash..."
                         yield from follow_path([(6, 21), (6, 23)])
                         # use rock smash
-                        yield from use_party_hm_move("Rock Smash")
+                        yield from use_field_move("Rock Smash")
                         yield from wait_for_task_to_start_and_finish("Task_DoFieldMove_RunFunc")
                         if get_event_flag("SYS_REGIROCK_PUZZLE_COMPLETED"):
                             context.message = "Regirock puzzle complete!"
@@ -219,7 +219,7 @@ class PuzzleSolverMode(BotMode):
                         )
                         context.message = "Two Right, Two Down, Strength..."
                         yield from follow_path([(10, 21), (10, 23)])
-                        yield from use_party_hm_move("Strength")
+                        yield from use_field_move("Strength")
                         yield from wait_for_task_to_start_and_finish("Task_DuckBGMForPokemonCry")
                         yield from navigate_to(MapRSE.DESERT_RUINS, (8, 21))
                         yield from walk_one_tile("Up")
@@ -295,7 +295,7 @@ class PuzzleSolverMode(BotMode):
                         )
                         context.message = "Using Flash..."
                         yield from navigate_to(MapRSE.ANCIENT_TOMB, (8, 25))
-                        yield from use_party_hm_move("Flash")
+                        yield from use_field_move("Flash")
                         yield from wait_for_task_to_start_and_finish("Task_DoFieldMove_RunFunc")
                         if get_event_flag("SYS_REGISTEEL_PUZZLE_COMPLETED"):
                             context.message = "Registeel puzzle complete!"
@@ -310,7 +310,7 @@ class PuzzleSolverMode(BotMode):
                             ["Fly"], "Registeel Puzzle (Ruby/Sapphire) requires Pokémon with Fly."
                         )
                         yield from navigate_to(MapRSE.ANCIENT_TOMB, (8, 25))
-                        yield from use_party_hm_move("Fly")
+                        yield from use_field_move("Fly")
                         yield from wait_for_task_to_start_and_finish("Task_DuckBGMForPokemonCry")
                         yield from navigate_to(MapRSE.ANCIENT_TOMB, (8, 21))
                         yield from walk_one_tile("Up")
@@ -403,7 +403,7 @@ class PuzzleSolverMode(BotMode):
 
                 def path():
                     yield from navigate_to(MapFRLG.SEVEN_ISLAND_SEVAULT_CANYON_TANOBY_KEY, (7, 7))
-                    yield from use_party_hm_move("Strength")
+                    yield from use_field_move("Strength")
                     yield from wait_for_script_to_start_and_finish("EventScript_UseStrength", "B")
                     yield
                     yield from walk_one_tile("Up")

--- a/modules/modes/sweet_scent.py
+++ b/modules/modes/sweet_scent.py
@@ -1,12 +1,9 @@
 from typing import Generator
 
 from modules.battle_state import BattleOutcome
-from modules.context import context
-from modules.menu_parsers import CursorOptionEmerald, CursorOptionFRLG, CursorOptionRS
-from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
+from modules.menuing import use_field_move
 from modules.player import get_player_avatar
-from modules.pokemon_party import get_party
-from ._asserts import assert_player_has_poke_balls, assert_has_pokemon_with_any_move
+from ._asserts import assert_player_has_poke_balls
 from ._interface import BotMode
 
 
@@ -25,21 +22,4 @@ class SweetScentMode(BotMode):
 
     def run(self) -> Generator:
         assert_player_has_poke_balls()
-
-        assert_has_pokemon_with_any_move(
-            ["Sweet Scent"], "None of your party Pokémon know the move Sweet Scent. Please teach it to someone."
-        )
-
-        yield from StartMenuNavigator("POKEMON").step()
-
-        move_pokemon = get_party().first_pokemon_with_move("Sweet Scent")
-
-        cursor = None
-        if context.rom.is_emerald:
-            cursor = CursorOptionEmerald
-        elif context.rom.is_rs:
-            cursor = CursorOptionRS
-        elif context.rom.is_frlg:
-            cursor = CursorOptionFRLG
-
-        yield from PokemonPartyMenuNavigator(move_pokemon.index, "", cursor.SWEET_SCENT).step()
+        yield from use_field_move("Sweet Scent")

--- a/modules/modes/util/higher_level_actions.py
+++ b/modules/modes/util/higher_level_actions.py
@@ -6,7 +6,7 @@ from modules.debug import debug
 from modules.map_data import PokemonCenter
 from modules.memory import get_event_flag, get_game_state_symbol, unpack_uint32, read_symbol, get_game_state, GameState
 from modules.menu_parsers import CursorOptionEmerald, CursorOptionFRLG, CursorOptionRS
-from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator, use_party_hm_move
+from modules.menuing import PokemonPartyMenuNavigator, StartMenuNavigator
 from modules.modes.util.sleep import wait_for_n_frames
 from modules.player import (
     get_player_avatar,


### PR DESCRIPTION
### Description

This adds the remaining moves that can be used in the overworld to `use_party_hm_move()` and renames that function to `use_field_move()`.

Sweet Scent mode now also uses that function, which makes it _very_ simple.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
