### PR TITLE
Debug Menu: Setting for infinite Repel/Safari Zone, option for Magma Armor Pokémon

### DIFF
--- a/modules/debug_utilities.py
+++ b/modules/debug_utilities.py
@@ -611,6 +611,8 @@ def debug_give_fainted_first_slot_pokemon_with_special_ability(ability: str) -> 
             species = "Ralts"
         case "Cute Charm":
             species = "Delcatty"
+        case "Magma Armor":
+            species = "Slugma"
         case _:
             raise ValueError(f"Ability not supported: {ability}")
 


### PR DESCRIPTION
### Description

This updates the debug menu with a few new options:

1. A (toggleable) option to enable infinite Repel steps (which will just reset the number of repel steps to 250 each frame.)
2. A (toggleable) option to enable infinite Safari Zone steps and Safari balls (again, it resets steps and balls each frame in the overworld.) This does not work within battles, so there are still only 30 balls available per encounter. But they reset afterwards.
3. In the 'Give Lead with Ability' menu I've added a choice for Magma Armor which is useful when breeding.
4. Added a `Create state with save game` option that will create a save state, but with the save game data already included (instead of having a separate `*.sav` file.) I am using this type of save state for the e2e tests that are meant to soft reset.

![image](https://github.com/user-attachments/assets/b39af655-ea6d-4175-875a-ca72c2d4d5a5)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
