### PR TITLE
Fix timing of egg hatch reporting

### DIFF
--- a/modules/modes/_listeners.py
+++ b/modules/modes/_listeners.py
@@ -362,7 +362,7 @@ class EggHatchListener(BotListener):
             egg_data_pointer = unpack_uint32(read_symbol(self._symbol_name))
             if egg_data_pointer & 0x0200_0000:
                 egg_data = context.emulator.read_bytes(egg_data_pointer, length=16)
-                if egg_data[2] >= 6:
+                if 4 <= egg_data[2] <= 12:
                     self._encounter_info.pokemon = get_party()[self._hatching_party_index]
                     bot_mode.on_egg_hatched(self._encounter_info, self._hatching_party_index)
 


### PR DESCRIPTION
### Description

Due to the egg hatch data structure being filled with some unrelated data, in the very first frame of the egg-hatching animation the EggHatchListener thought that the hatched Pokémon was already visible and would report the hatching immediately.

This fixes it so the hatched Pokémon is reported a couple of frames after the sprite becomes visible (about half a second later.)

I have updated the Static Gift Resets mode (Togepi, Wynaut) so it resets immediately when this happens rather than waiting for the game to get back to the overworld. This saves a few frames, too.

https://github.com/user-attachments/assets/c826e8e9-04dd-4132-90f5-d16550e0c722


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
