### PR TITLE
Some more debug menu options

### DIFF
--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -870,10 +870,6 @@ class Pokemon:
         return self.data[:32] + decrypted.tobytes() + self.data[80:100]
 
     @property
-    def _foo_data(self) -> str:
-        return self._decrypted_data[32:80].hex(" ", 12)
-
-    @property
     def _character_set(self) -> Literal["international", "japanese"]:
         """
         Figures out which character set needs to be used for decoding nickname and


### PR DESCRIPTION
### Description

This adds a `Force Shiny Encounter` option to the debug menu that will try to make every encounter a shiny. It does this by waiting for `Task_BattleStart` to appear and then just overwrites the opponent data. Therefore, it does not work for gifts (including daycare.)

Also, this changes the `Infinite Repel` feature so it resets the repel steps to 0 once it is disabled. That way, the Repel effect is disabled immediately rather than still having to walk 250 steps to get rid of it.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
