### PR TITLE
Fix bot sometimes hanging when trying to pathfind to a warp

### DIFF
--- a/modules/map_path.py
+++ b/modules/map_path.py
@@ -757,7 +757,7 @@ def calculate_path(
             if neighbour is None or not is_tile_accessible(neighbour, direction, node.elevation):
                 continue
 
-            if neighbour.warps_to is not None:
+            if neighbour.warps_to is not None and neighbour.global_coordinates != destination_tile.global_coordinates:
                 cost = 1000000
             else:
                 cost = node.current_cost + 1


### PR DESCRIPTION
### Description

In order to teach the bot to not 'accidentally' step on warping tiles, I have added an artifical cost to these tiles.

But that also means that if we specifically _tell_ the bot to pathfind towards a warp, the route would appear very expensive and the bot would keep looking for alternative ways that are cheaper.

Depending on the map and the situation, this might mean that the bot would try to check every conceivable path on the world map before accepting the route.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
