### PR TITLE
Revert change that prevented EV Train mode from ever rotating

### DIFF
--- a/modules/modes/ev_train.py
+++ b/modules/modes/ev_train.py
@@ -1,4 +1,4 @@
-from typing import Generator, Optional, TYPE_CHECKING
+from typing import Generator
 
 from rich.table import Table
 
@@ -12,14 +12,11 @@ from modules.pokemon_party import get_party
 from ._interface import BotMode, BotModeError
 from .util import navigate_to, heal_in_pokemon_center, spin
 from .util.map import map_has_pokemon_center_nearby, find_closest_pokemon_center
-from ..battle_state import BattleOutcome, BattleState
-from ..battle_strategies import BattleStrategy, DefaultBattleStrategy, BattleStrategyUtil
+from ..battle_state import BattleOutcome
+from ..battle_strategies import BattleStrategy, DefaultBattleStrategy
 from ..console import console
 from ..encounter import handle_encounter, EncounterInfo
 from ..gui.ev_selection_window import ask_for_ev_targets
-
-if TYPE_CHECKING:
-    from modules.battle_strategies import TurnAction
 
 _list_of_stats = ("hp", "attack", "defence", "special_attack", "special_defence", "speed")
 
@@ -83,14 +80,6 @@ def _print_target_table(pokemon: Pokemon, target_evs: StatsValues) -> None:
 class NoRotateLeadDefaultBattleStrategy(DefaultBattleStrategy):
     def choose_new_lead_after_battle(self) -> int | None:
         return None
-
-    def _handle_lead_cannot_battle(
-        self, battle_state: BattleState, util: BattleStrategyUtil, reason: str
-    ) -> tuple["TurnAction", Optional[any]]:
-        # Never try to rotate into another Pokémon as that might mess up their EVs.
-        # Instead, always attempt to escape if the lead Pokémon is no longer able to
-        # battle.
-        return super()._handle_flee(battle_state, util, reason)
 
 
 class EVTrainMode(BotMode):

--- a/wiki/pages/Mode - EV Train.md
+++ b/wiki/pages/Mode - EV Train.md
@@ -2,9 +2,13 @@
 
 # 💊 EV Train Mode
 
-This mode will continuously fight battles in order to EV Train your lead Pokémon. It
-will not rotate the lead Pokémon regardless of configuration, so that none of your
-other party members' EVs are messed up.
+This mode will continuously fight battles in order to EV Train your lead Pokémon.
+If the lead is unable to battle, the mode will swap to another mon in the party if
+that is enabled in the profile battle settings (see
+[⚔ Battling and Pickup config](Configuration%20-%20Battling%20and%20Pickup.md)).
+This is useful for training weak mons, but keep in mind it will alter the EVs of
+the mon switched to. The mode only tracks the lead's EVs and does not switch the
+lead outside of battle.
 
 When the active Pokémon is defeated or gets low on HP, it will heal at the nearest
 Pokémon Center automatically. Likewise, if your entire party gets defeated it will


### PR DESCRIPTION
### Description

As climb026 pointed out on Discord, it makes sense to allow the EV Train mode to rotate the lead (if config allows it) in order to EV train weaker Pokémon.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
