### PR TITLE
Fix 'Infinite Safari Zone' helper on R/S

### DIFF
--- a/modules/gui/debug_menu.py
+++ b/modules/gui/debug_menu.py
@@ -160,7 +160,8 @@ class InfiniteSafariZoneListener(BotListener):
     def handle_frame(self, bot_mode: BotMode, frame: FrameInfo):
         if not battle_is_active():
             write_symbol("gNumSafariBalls", pack_uint8(30))
-            write_symbol("sSafariZoneStepCounter", pack_uint16(500))
+            step_counter_symbol = "sSafariZoneStepCounter" if context.rom.is_emerald else "gSafariZoneStepCounter"
+            write_symbol(step_counter_symbol, pack_uint16(500))
 
 
 class ForceShinyEncounterListener(BotListener):


### PR DESCRIPTION
### Description

The variable for the 'remaining steps in Safari Zone' counter has a different symbol name on R/S, so the 'Infinite Safari Zone' debug utility didn't work.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
