### PR TITLE
Rock Smash: Do not soft reset after catching a Pokémon

### DIFF
--- a/modules/modes/rock_smash.py
+++ b/modules/modes/rock_smash.py
@@ -99,6 +99,12 @@ class RockSmashMode(BotMode):
         return handle_encounter(encounter)
 
     def on_battle_ended(self, outcome: "BattleOutcome") -> None:
+        if outcome is BattleOutcome.Caught and not context.config.battle.save_after_catching:
+            context.message = (
+                "A Pokémon has been caught. Switching to manual mode so we don't lose it when soft-resetting."
+            )
+            context.set_manual_mode()
+
         if not outcome == BattleOutcome.Lost:
             assert_player_has_poke_balls()
 


### PR DESCRIPTION
### Description

As Neka pointed out, the Rock Smash mode would just keep going after catching a Shiny/CCF Pokémon in Rock Smash mode -- which is an issue because these modes soft-reset after a while.

This is not an issue if `save_after_catching` is enabled because then soft-resetting would just load the game state _after_ catching the Pokémon.

So if that setting is NOT enabled (it's off by default), we switch to manual mode after catching something.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
