### PR TITLE
RSE : Fix Roamer Reset mode

### DIFF
--- a/modules/modes/roamer_reset.py
+++ b/modules/modes/roamer_reset.py
@@ -216,7 +216,9 @@ class RoamerResetMode(BotMode):
                 # Run to Battle Tent, enter, leave, go back to Route 110
                 # This is necessary because the game saves the last 3 locations the player
                 # has been in and avoids them, so we need additional map transitions.
-                yield from navigate_to(MapRSE.SLATEPORT_CITY, (10, 12))
+                yield from navigate_to(MapRSE.SLATEPORT_CITY, (10, 13))
+                yield from walk_one_tile("Up")
+                yield from wait_for_player_avatar_to_be_standing_still()
                 yield from walk_one_tile("Down")
 
             while not self._should_reset and not self._ran_out_of_repels:
@@ -344,7 +346,9 @@ class RoamerResetMode(BotMode):
                 # This is necessary because the game saves the last 3 locations the player
                 # has been in and avoids them, so we need additional map transitions.
                 # The NPC that can block the way to Contest Hall is avoided.
-                yield from navigate_to(MapRSE.SLATEPORT_CITY, (19, 19))
+                yield from navigate_to(MapRSE.SLATEPORT_CITY, (19, 20))
+                yield from walk_one_tile("Up")
+                yield from wait_for_player_avatar_to_be_standing_still()
                 yield from walk_one_tile("Down")
 
             while not self._should_reset and not self._ran_out_of_repels:


### PR DESCRIPTION
### Description

This fixes issue https://github.com/40Cakes/pokebot-gen3/issues/635

For some reason pathing works on FR/LG when targetting a door but not on RSE anymore since a few changes we made on `navigate_to` function. 

This PR fixes the problem until we can investigate it a little more

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
