### PR TITLE
RS : Fix encounter logging for FR/IT/ES/JP

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.yml
+++ b/modules/data/symbols/patches/language/pokeemerald.yml
@@ -695,9 +695,6 @@ Task_DoFieldMove_RunFunc:
   I: 0x813522c
   J: 0x8135670
   S: 0x8135234
-#---------------------#
-#    Puzzle Solver    #
-#---------------------#
 EventScript_UseDiveUnderwater:
   D: ~
   F: ~
@@ -710,7 +707,6 @@ Task_UseDive:
   I: ~
   J: ~
   S: ~
-#---------------------#
 #---------------------#
 
 #----------------#

--- a/modules/data/symbols/patches/language/pokeruby.yml
+++ b/modules/data/symbols/patches/language/pokeruby.yml
@@ -110,6 +110,8 @@ gBattlescriptCurrInstr:
   J: 0x2024970
 GTASKS:
   J: 0x3004a50
+gWindowTemplate_Contest_MoveDescription:
+  J: 0x3004160
 gEnemyParty:
   J: 0x30044f0
 gBattleTypeFlags:

--- a/modules/data/symbols/patches/language/pokeruby_rev1.yml
+++ b/modules/data/symbols/patches/language/pokeruby_rev1.yml
@@ -157,6 +157,10 @@ GTASKS:
   F: 0x3004b30
   I: 0x3004b30
   S: 0x3004b30
+gWindowTemplate_Contest_MoveDescription:
+  F: 0x3004220
+  I: 0x3004220
+  S: 0x3004220
 gEnemyParty:
   F: 0x030045d0
   I: 0x030045d0

--- a/modules/data/symbols/patches/language/pokesapphire.yml
+++ b/modules/data/symbols/patches/language/pokesapphire.yml
@@ -110,6 +110,8 @@ gBattlescriptCurrInstr:
   J: 0x2024970
 GTASKS:
   J: 0x3004a50
+gWindowTemplate_Contest_MoveDescription:
+  J: 0x3004160
 gEnemyParty:
   J: 0x30044f0
 gBattleTypeFlags:

--- a/modules/data/symbols/patches/language/pokesapphire_rev1.yml
+++ b/modules/data/symbols/patches/language/pokesapphire_rev1.yml
@@ -157,6 +157,10 @@ GTASKS:
   F: 0x3004b30
   I: 0x3004b30
   S: 0x3004b30
+gWindowTemplate_Contest_MoveDescription:
+  F: 0x3004220
+  I: 0x3004220
+  S: 0x3004220
 gEnemyParty:
   F: 0x030045d0
   I: 0x030045d0


### PR DESCRIPTION
### Description

Fixed an [issue](https://discord.com/channels/1057088810950860850/1139190426834833528/1333980942989266954) where wild encounters weren't logged in `Ruby/Sapphire` for these languages : 
- French
- Italian
- Spanish
- Japanese

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
