### PR TITLE
Verify that there is space in party/boxes before running modes that catch Pokémon

### DIFF
--- a/modules/modes/bunny_hop.py
+++ b/modules/modes/bunny_hop.py
@@ -4,7 +4,7 @@ from modules.context import context
 from modules.items import get_item_by_name
 from modules.player import AcroBikeState, TileTransitionState, get_player_avatar
 from modules.battle_state import BattleOutcome
-from ._asserts import assert_item_exists_in_bag, assert_player_has_poke_balls
+from ._asserts import assert_item_exists_in_bag, assert_player_has_poke_balls, assert_boxes_or_party_can_fit_pokemon
 from ._interface import BotMode
 from .util import apply_white_flute_if_available, register_key_item
 
@@ -22,11 +22,13 @@ class BunnyHopMode(BotMode):
             return False
 
     def on_battle_ended(self, outcome: "BattleOutcome") -> None:
-        if not outcome == BattleOutcome.Lost:
+        if outcome is not BattleOutcome.Lost:
             assert_player_has_poke_balls()
+            assert_boxes_or_party_can_fit_pokemon()
 
     def run(self) -> Generator:
         assert_player_has_poke_balls()
+        assert_boxes_or_party_can_fit_pokemon()
         assert_item_exists_in_bag(("Acro Bike",), "You need to have the Acro Bike in order to use this mode.")
         yield from register_key_item(get_item_by_name("Acro Bike"))
 

--- a/modules/modes/feebas.py
+++ b/modules/modes/feebas.py
@@ -9,15 +9,13 @@ from modules.map_data import MapRSE
 from modules.player import get_player, get_player_avatar, AvatarFlags
 from modules.pokemon_party import get_party
 from . import BattleAction
-from ._asserts import assert_player_has_poke_balls
+from ._asserts import assert_player_has_poke_balls, assert_boxes_or_party_can_fit_pokemon
 from ._interface import BotMode, BotModeError
 from .util import (
     ensure_facing_direction,
     fish,
     navigate_to,
     register_key_item,
-    wait_for_task_to_start_and_finish,
-    walk_one_tile,
 )
 from ..clock import ClockTime, get_clock_time
 from ..encounter import EncounterInfo
@@ -149,11 +147,13 @@ class FeebasMode(BotMode):
         return None
 
     def on_battle_ended(self, outcome: "BattleOutcome") -> None:
-        if not outcome == BattleOutcome.Lost:
+        if outcome is not BattleOutcome.Lost:
             assert_player_has_poke_balls()
+            assert_boxes_or_party_can_fit_pokemon()
 
     def run(self) -> Generator:
         assert_player_has_poke_balls()
+        assert_boxes_or_party_can_fit_pokemon()
 
         if not get_player_avatar().flags.Surfing:
             raise BotModeError("Player is not surfing, only start this mode while surfing in any water at Route 119.")

--- a/modules/modes/fishing.py
+++ b/modules/modes/fishing.py
@@ -1,12 +1,11 @@
 from typing import Generator
 
-from modules.context import context
+from modules.battle_state import BattleOutcome
 from modules.gui.multi_select_window import Selection, ask_for_choice
 from modules.items import get_item_bag, get_item_by_name
 from modules.player import get_player, get_player_avatar
 from modules.runtime import get_sprites_path
-from modules.battle_state import BattleOutcome
-from ._asserts import assert_item_exists_in_bag, assert_player_has_poke_balls
+from ._asserts import assert_item_exists_in_bag, assert_player_has_poke_balls, assert_boxes_or_party_can_fit_pokemon
 from ._interface import BotMode
 from .util import fish, register_key_item
 
@@ -23,11 +22,13 @@ class FishingMode(BotMode):
         return targeted_tile is not None and targeted_tile.is_surfable
 
     def on_battle_ended(self, outcome: "BattleOutcome") -> None:
-        if not outcome == BattleOutcome.Lost:
+        if outcome is not BattleOutcome.Lost:
             assert_player_has_poke_balls()
+            assert_boxes_or_party_can_fit_pokemon()
 
     def run(self) -> Generator:
         assert_player_has_poke_balls()
+        assert_boxes_or_party_can_fit_pokemon()
 
         # Ask player to register a rod if they have one
         rod_names = ["Old Rod", "Good Rod", "Super Rod"]

--- a/modules/modes/kecleon.py
+++ b/modules/modes/kecleon.py
@@ -8,7 +8,11 @@ from modules.player import get_player_avatar
 from modules.pokemon_party import get_party_size
 from modules.save_data import get_last_heal_location
 from . import BattleAction
-from ._asserts import assert_has_pokemon_with_any_move, assert_player_has_poke_balls
+from ._asserts import (
+    assert_has_pokemon_with_any_move,
+    assert_player_has_poke_balls,
+    assert_boxes_or_party_can_fit_pokemon,
+)
 from ._interface import BotMode, BotModeError
 from .util import ensure_facing_direction, navigate_to
 from ..battle_strategies import BattleStrategy
@@ -42,6 +46,7 @@ class KecleonMode(BotMode):
 
     def run(self) -> Generator:
         assert_player_has_poke_balls()
+        assert_boxes_or_party_can_fit_pokemon()
         assert_has_pokemon_with_any_move(
             ["Selfdestruct", "Explosion"],
             error_message="This mode requires a Pokémon with the move Selfdestruct.",

--- a/modules/modes/roamer_reset.py
+++ b/modules/modes/roamer_reset.py
@@ -14,7 +14,13 @@ from modules.region_map import FlyDestinationFRLG, FlyDestinationRSE
 from modules.runtime import get_sprites_path
 from modules.save_data import get_save_data
 from modules.tasks import get_global_script_context
-from ._asserts import SavedMapLocation, assert_save_game_exists, assert_saved_on_map, assert_player_has_poke_balls
+from ._asserts import (
+    SavedMapLocation,
+    assert_save_game_exists,
+    assert_saved_on_map,
+    assert_player_has_poke_balls,
+    assert_boxes_or_party_can_fit_pokemon,
+)
 from ._interface import BattleAction, BotMode, BotModeError
 from .util import (
     RanOutOfRepels,
@@ -112,7 +118,8 @@ class RoamerResetMode(BotMode):
                 f"{highest_encounter_level + 1} in order for Repel to work."
             )
 
-        assert_player_has_poke_balls()
+        assert_player_has_poke_balls(check_in_saved_game=True)
+        assert_boxes_or_party_can_fit_pokemon(check_in_saved_game=True)
 
         if save_data.get_item_bag().number_of_repels == 0:
             raise BotModeError("You do not have any repels in your item bag. Go and get some first!")

--- a/modules/modes/rock_smash.py
+++ b/modules/modes/rock_smash.py
@@ -23,6 +23,7 @@ from ._asserts import (
     assert_save_game_exists,
     assert_saved_on_map,
     assert_player_has_poke_balls,
+    assert_boxes_or_party_can_fit_pokemon,
     assert_item_exists_in_bag,
 )
 from ._interface import BotMode, BotModeError
@@ -105,8 +106,9 @@ class RockSmashMode(BotMode):
             )
             context.set_manual_mode()
 
-        if not outcome == BattleOutcome.Lost:
+        if outcome is not BattleOutcome.Lost:
             assert_player_has_poke_balls()
+            assert_boxes_or_party_can_fit_pokemon()
 
     def on_repel_effect_ended(self) -> None:
         if self._using_repel:
@@ -124,6 +126,7 @@ class RockSmashMode(BotMode):
                 "You do not have the Dynamo Badge, which is necessary to use Rock Smash outside of battle."
             )
 
+        assert_boxes_or_party_can_fit_pokemon()
         assert_has_pokemon_with_any_move(
             ["Rock Smash"], "None of your party Pokémon know the move Rock Smash. Please teach it to someone."
         )
@@ -135,6 +138,7 @@ class RockSmashMode(BotMode):
             MapRSE.SAFARI_ZONE_SOUTHEAST,
         ):
             assert_save_game_exists("There is no saved game. Cannot soft reset.")
+            assert_boxes_or_party_can_fit_pokemon(check_in_saved_game=True)
             assert_saved_on_map(
                 SavedMapLocation(MapRSE.ROUTE121_SAFARI_ZONE_ENTRANCE),
                 "In order to rock smash for Shuckle you should save in the entrance building to the Safari Zone.",
@@ -166,6 +170,8 @@ class RockSmashMode(BotMode):
 
             if mode == "Use Repel":
                 assert_save_game_exists("There is no saved game. Cannot soft reset.")
+                assert_player_has_poke_balls(check_in_saved_game=True)
+                assert_boxes_or_party_can_fit_pokemon(check_in_saved_game=True)
                 assert_saved_on_map(
                     SavedMapLocation(MapRSE.GRANITE_CAVE_B2F),
                     "In order to use Repel, you need to save on this map.",

--- a/modules/modes/safari.py
+++ b/modules/modes/safari.py
@@ -30,6 +30,7 @@ from ._asserts import (
     assert_item_exists_in_bag,
     assert_save_game_exists,
     assert_saved_on_map,
+    assert_boxes_or_party_can_fit_pokemon,
 )
 from .util import (
     spin,
@@ -83,6 +84,7 @@ class SafariMode(BotMode):
             if catched_pokemon == self._target_pokemon:
                 self._target_caught = True
             self._atleast_one_pokemon_catched = True
+            assert_boxes_or_party_can_fit_pokemon()
         if get_safari_balls_left() < 30:
             current_cash = get_player().money
             if (self._starting_cash - current_cash > self._money_spent_limit) or (current_cash < 500):
@@ -94,6 +96,9 @@ class SafariMode(BotMode):
         self._starting_cash = get_player().money
 
         assert_save_game_exists("There is no saved game. Cannot start Safari mode. Please save your game.")
+
+        assert_boxes_or_party_can_fit_pokemon()
+        assert_boxes_or_party_can_fit_pokemon(check_in_saved_game=True)
 
         assert_saved_on_map(
             SavedMapLocation(self._safari_config["map"]),

--- a/modules/modes/spin.py
+++ b/modules/modes/spin.py
@@ -1,10 +1,9 @@
 from typing import Generator
 
-from modules.context import context
 from modules.player import get_player_avatar
 from modules.battle_state import BattleOutcome
 from ._interface import BotMode
-from ._asserts import assert_player_has_poke_balls
+from ._asserts import assert_player_has_poke_balls, assert_boxes_or_party_can_fit_pokemon
 from .util import apply_white_flute_if_available, spin
 
 
@@ -18,10 +17,12 @@ class SpinMode(BotMode):
         return get_player_avatar().map_location.has_encounters
 
     def on_battle_ended(self, outcome: "BattleOutcome") -> None:
-        if not outcome == BattleOutcome.Lost:
+        if outcome is not BattleOutcome.Lost:
             assert_player_has_poke_balls()
+            assert_boxes_or_party_can_fit_pokemon()
 
     def run(self) -> Generator:
         assert_player_has_poke_balls()
+        assert_boxes_or_party_can_fit_pokemon()
         yield from apply_white_flute_if_available()
         yield from spin()

--- a/modules/modes/static_run_away.py
+++ b/modules/modes/static_run_away.py
@@ -6,8 +6,7 @@ from modules.map import get_map_objects
 from modules.map_data import MapFRLG, MapRSE
 from modules.memory import get_event_flag
 from modules.player import get_player_avatar
-from modules.pokemon import get_opponent
-from ._asserts import assert_player_has_poke_balls
+from ._asserts import assert_player_has_poke_balls, assert_boxes_or_party_can_fit_pokemon
 from ._interface import BattleAction, BotMode, BotModeError
 from .util import (
     follow_path,
@@ -185,6 +184,7 @@ class StaticRunAway(BotMode):
             raise BotModeError(f"{pokemon_name} has already been caught.")
 
         assert_player_has_poke_balls()
+        assert_boxes_or_party_can_fit_pokemon()
 
         while True:
             yield from path()

--- a/modules/modes/static_soft_resets.py
+++ b/modules/modes/static_soft_resets.py
@@ -6,7 +6,13 @@ from modules.encounter import handle_encounter, log_encounter, EncounterInfo
 from modules.map_data import MapFRLG, MapRSE
 from modules.player import get_player_avatar
 from modules.save_data import get_save_data
-from ._asserts import SavedMapLocation, assert_save_game_exists, assert_saved_on_map, assert_player_has_poke_balls
+from ._asserts import (
+    SavedMapLocation,
+    assert_save_game_exists,
+    assert_saved_on_map,
+    assert_player_has_poke_balls,
+    assert_boxes_or_party_can_fit_pokemon,
+)
 from ._interface import BattleAction, BotMode, BotModeError
 from .util import (
     soft_reset,
@@ -112,7 +118,8 @@ class StaticSoftResetsMode(BotMode):
         if encounter.condition is not None and not encounter.condition():
             raise BotModeError(f"This {encounter.name} has already been encountered.")
 
-        assert_player_has_poke_balls()
+        assert_player_has_poke_balls(check_in_saved_game=True)
+        assert_boxes_or_party_can_fit_pokemon(check_in_saved_game=True)
 
         while context.bot_mode != "Manual":
             yield from soft_reset(mash_random_keys=True)

--- a/modules/modes/sudowoodo.py
+++ b/modules/modes/sudowoodo.py
@@ -10,6 +10,7 @@ from ._asserts import (
     assert_save_game_exists,
     assert_saved_on_map,
     assert_player_has_poke_balls,
+    assert_boxes_or_party_can_fit_pokemon,
 )
 from ._interface import BattleAction, BotMode
 from .util import soft_reset, wait_for_task_to_start_and_finish, wait_for_unique_rng_value, wait_until_task_is_active
@@ -47,6 +48,7 @@ class SudowoodoMode(BotMode):
         )
 
         assert_player_has_poke_balls()
+        assert_boxes_or_party_can_fit_pokemon(check_in_saved_game=True)
 
         while context.bot_mode != "Manual":
             yield from soft_reset(mash_random_keys=True)

--- a/modules/modes/sweet_scent.py
+++ b/modules/modes/sweet_scent.py
@@ -3,7 +3,7 @@ from typing import Generator
 from modules.battle_state import BattleOutcome
 from modules.menuing import use_field_move
 from modules.player import get_player_avatar
-from ._asserts import assert_player_has_poke_balls
+from ._asserts import assert_player_has_poke_balls, assert_boxes_or_party_can_fit_pokemon
 from ._interface import BotMode
 
 
@@ -17,9 +17,11 @@ class SweetScentMode(BotMode):
         return get_player_avatar().map_location.has_encounters
 
     def on_battle_ended(self, outcome: "BattleOutcome") -> None:
-        if not outcome == BattleOutcome.Lost:
+        if outcome is not BattleOutcome.Lost:
             assert_player_has_poke_balls()
+            assert_boxes_or_party_can_fit_pokemon()
 
     def run(self) -> Generator:
         assert_player_has_poke_balls()
+        assert_boxes_or_party_can_fit_pokemon()
         yield from use_field_move("Sweet Scent")

--- a/modules/save_data.py
+++ b/modules/save_data.py
@@ -8,6 +8,7 @@ from modules.map import ObjectEvent
 from modules.memory import get_save_block, unpack_uint16, unpack_uint32
 from modules.player import Player
 from modules.pokemon_party import Party, PartyPokemon
+from modules.pokemon_storage import PokemonStorage
 
 
 def get_last_heal_location() -> tuple[int, int]:
@@ -57,7 +58,7 @@ class SaveData:
 
     @cached_property
     def _save_block_1(self) -> bytes:
-        return self.sections[1] + self.sections[2] + self.sections[3] + self.sections[4]
+        return b"".join([self.sections[1], self.sections[2], self.sections[3], self.sections[4]])
 
     def get_save_block(self, num: int = 1, offset: int = 0, size: int = 1) -> bytes:
         if num == 2:
@@ -96,6 +97,10 @@ class SaveData:
             offset = party_offset + index * 100
             party.append(PartyPokemon(self.sections[1][offset : offset + 100], index))
         return Party(party)
+
+    def get_pokemon_storage(self) -> PokemonStorage:
+        data = b"".join(self.sections[5:])
+        return PokemonStorage(0, data)
 
     def get_item_bag(self) -> ItemBag:
         if context.rom.is_frlg:


### PR DESCRIPTION
### Description

This adds a new assertion, `assert_boxes_or_party_can_fit_pokemon()`, which will verify that there is at least one empty slot in either the party or one of the boxes. (Because if there isn't, a Pokémon cannot be caught which would be a bit sad.)

This assertion is used in each mode that is meant to find shinies (i.e. it's not checked in modes like Level Grind and EV Train -- even though they _could_ also encounter shinies that's not their primary purpose.)

I've also updated the `assert_player_has_poke_balls()` check in some modes that use soft resets to check the saved game and not the currently running one, as that's the actually important part.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
