### PR TITLE
Fix some level grind issues

### DIFF
--- a/modules/battle_strategies/level_up.py
+++ b/modules/battle_strategies/level_up.py
@@ -67,9 +67,23 @@ class LevelUpLeadBattleStrategy(DefaultBattleStrategy):
         return False
 
     def pokemon_can_battle(self, pokemon: Pokemon) -> bool:
-        return any(
-            move is not None and move.move.base_power > 0 and move.move.name not in context.config.battle.banned_moves
-            for move in pokemon.moves
+        return self._can_battle(pokemon)
+
+    def party_can_battle(self) -> bool:
+        return any(self._can_battle(pokemon) for pokemon in get_party().non_fainted_pokemon)
+
+    def _can_battle(self, pokemon: Pokemon) -> bool:
+        return (
+            pokemon is not None
+            and super()._pokemon_has_enough_hp(pokemon)
+            and pokemon.status_condition is StatusCondition.Healthy
+            and any(
+                move is not None
+                and move.move.base_power > 0
+                and move.pp > 0
+                and move.move.name not in context.config.battle.banned_moves
+                for move in pokemon.moves
+            )
         )
 
     def _escape(self, battle_state: BattleState):

--- a/modules/modes/level_grind.py
+++ b/modules/modes/level_grind.py
@@ -60,7 +60,7 @@ class LevelGrindMode(BotMode):
         if level_mode_choice.startswith("Level-balance"):
             self._controller.battle_strategy = LevelBalancingBattleStrategy
             party_lead_index = LevelBalancingBattleStrategy().choose_new_lead_after_battle()
-            if party_lead_index != 0:
+            if party_lead_index != None:
                 yield from change_lead_party_pokemon(party_lead_index)
         else:
             self._controller.battle_strategy = LevelUpLeadBattleStrategy

--- a/modules/modes/level_grind.py
+++ b/modules/modes/level_grind.py
@@ -64,6 +64,7 @@ class LevelGrindMode(BotMode):
                 yield from change_lead_party_pokemon(party_lead_index)
         else:
             self._controller.battle_strategy = LevelUpLeadBattleStrategy
+            self._controller._focus_on_lead_pokemon = True
             assert_party_has_damaging_move("No Pokémon in the party has a usable attacking move!")
 
             if not LevelUpLeadBattleStrategy().pokemon_can_battle(party_lead_pokemon):


### PR DESCRIPTION
### Description

This PR fixes two issues :

- The bot now goes healing when leader cannot battle in `LevelUpLeadBattleStrategy` instead of leveling all other party Pokemon
- Fixed an issue where the bot was trying to switch the party lead with himself on `LevelBalancingBattleStrategy`

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
