### PR TITLE
Fix handling whiteout during Pokecenter Loop modes

### DIFF
--- a/modules/modes/util/pokecenter_loop.py
+++ b/modules/modes/util/pokecenter_loop.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from typing import Optional
 
 from modules.battle_strategies import BattleStrategy, DefaultBattleStrategy
+from modules.context import context
 from modules.encounter import handle_encounter
 from modules.map import get_map_data_for_current_position, get_effective_encounter_rates_for_current_map
 from modules.map_data import MapFRLG, get_map_enum
@@ -23,7 +24,7 @@ class PokecenterLoopController:
         return self.battle_strategy() if action is BattleAction.Fight else action
 
     def on_battle_ended(self) -> None:
-        if not self.battle_strategy().party_can_battle():
+        if len(get_party().non_fainted_pokemon) == 0 or not self.battle_strategy().party_can_battle():
             self._needs_healing = True
         elif self._focus_on_lead_pokemon and not self.battle_strategy().pokemon_can_battle(get_party().non_eggs[0]):
             self._needs_healing = True
@@ -62,12 +63,13 @@ class PokecenterLoopController:
             if self._leave_pokemon_center:
                 # This will run after a whiteout when the player respawns
                 # inside the Pokémon Center.
-                current_map = get_player_location()[0]
-                if current_map is MapFRLG.PALLET_TOWN_PLAYERS_HOUSE_1F:
-                    door_coordinates = (4, 8)
-                else:
-                    door_coordinates = (7, 8)
-                yield from navigate_to(current_map, door_coordinates)
+                if context.rom.is_frlg:
+                    current_map = get_player_location()[0]
+                    if current_map is MapFRLG.PALLET_TOWN_PLAYERS_HOUSE_1F:
+                        door_coordinates = (4, 8)
+                    else:
+                        door_coordinates = (7, 8)
+                    yield from navigate_to(current_map, door_coordinates)
             elif self._needs_healing:
                 yield from heal_in_pokemon_center(pokemon_center)
 


### PR DESCRIPTION
### Description

When whiting out during a Pokécenter Loop (Level Grind, EV Train), the bot would run into an error while trying to access the first non-fainted Pokémon in the party -- of which there are none if the party has been defeated.

Also, the code assumed that the player would respawn _inside_ of the Pokémon Center, which is only true in FR/LG and R/S/E. So in the latter case, the bot would try to exit the building even though the player wasn't actually in it.

Fixes #651

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
