### PR TITLE
Battle State: Use the right data for determining battler ability

### DIFF
--- a/modules/battle_state.py
+++ b/modules/battle_state.py
@@ -542,11 +542,11 @@ class BattlePokemon:
 
     @property
     def is_egg(self) -> bool:
-        return bool(self._data[0x17] & 1)
+        return bool(self._data[0x17] & 0b0100_0000)
 
     @property
     def ability(self) -> Ability:
-        if len(self.species.abilities) > 1 and self._data[0x17] & 0b10:
+        if len(self.species.abilities) > 1 and self._data[0x17] & 0b1000_0000:
             return self.species.abilities[1]
         else:
             return self.species.abilities[0]


### PR DESCRIPTION
### Description

The battle state used the wrong bit in the `BattlePokemon`'s data structure to determine whether a Pokémon had the first or second possible ability of its species.

This could lead to the battle strategy making wrong decisions based on this incorrect ability.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
