### PR TITLE
Level Balancing Strategy: Go heal if weakest Pokémon is defeated

### DIFF
--- a/modules/battle_strategies/level_balancing.py
+++ b/modules/battle_strategies/level_balancing.py
@@ -15,6 +15,10 @@ def _get_lowest_level_party_member_index(only_non_fainted: bool = False) -> int:
 
 
 class LevelBalancingBattleStrategy(DefaultBattleStrategy):
+    def party_can_battle(self) -> bool:
+        lowest_level_index = _get_lowest_level_party_member_index()
+        return super().party_can_battle() and get_party()[lowest_level_index].current_hp > 0
+
     def choose_new_lead_after_faint(self, battle_state: BattleState) -> int:
         return _get_lowest_level_party_member_index(only_non_fainted=True)
 


### PR DESCRIPTION
### Description

The Level Balancing battle strategy (used by the Level Grind mode) would not go healing until the entire party was unable to battle.

This meant that once the weakest Pokémon fainted, it would just no longer receive any EXP.

So it was quite possible that after a while, all the weak Pokémon in the party were defeated and only the strongest Pokémon got trained until it ran out of PP.

This changes it so that if the weakest Pokémon is defeated, the mode will go heal.

Fixes #653 

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
