### PR TITLE
Emerald : Fix box checking when using SRA on JP

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.yml
+++ b/modules/data/symbols/patches/language/pokeemerald.yml
@@ -300,6 +300,10 @@ Task_PokeStorageMain:
   I: 0x80c7f00
   J: 0x80c7b48
   S: 0x80c7f00
+gPokemonStorage:
+  J: 0x20294ac
+gPokemonStoragePtr:
+  J: 0x3005af4
 Task_ExitDoor:
   D: 0x80af454
   F: 0x80af44c


### PR DESCRIPTION
### Description

When doing SRA or other actions in the game, the bot would check if there's space in our party or our boxes. The box symbols weren't mapped on Emerald Japanase.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)
