### PR TITLE
Leaf Green : Fix Fanfare symbol for French LG

### DIFF
--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -320,7 +320,7 @@ gSpecialVar_0x8004:
 
 Task_Fanfare:
   D: 0x8071c20
-  F: 0x8079d44
+  F: 0x8071ce0
   I: 0x8071c0c
   J: 0x8071460
   S: 0x8071cf4


### PR DESCRIPTION
### Description

Fix the Fanfare Task not being mapped correctly, this would cause some modes not to work on LG FR language only.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
