### PR TITLE
Stats: Fix invalid function call

### DIFF
--- a/modules/stats.py
+++ b/modules/stats.py
@@ -658,7 +658,7 @@ class StatsDatabase:
             self._encounter_summaries[species_index].update(encounter)
 
         self._insert_or_update_encounter_summary(self._encounter_summaries[species_index])
-        self.commit()
+        self._commit()
         self._next_encounter_id += 1
 
         return encounter
@@ -691,7 +691,7 @@ class StatsDatabase:
             encounter_summary.phase_highest_sv = None
             encounter_summary.phase_lowest_sv = None
 
-        self.commit()
+        self._commit()
 
     def log_end_of_battle(self, battle_outcome: "BattleOutcome", encounter_info: "EncounterInfo"):
         if self.last_encounter is not None:


### PR DESCRIPTION
### Description

Due to a silly typo the stats system tries to call `self.commit()` instead of `self._commit()` which is fixed by this PR.

Background: `commit()` needs to be called for database changes to actually be written. This was missing in some places, which meant that these changes were only written to disk once some other function actually called `commit()`.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
