### PR TITLE
Add menu option for clearing shiny phase stats

### DIFF
--- a/modules/gui/emulator_controls.py
+++ b/modules/gui/emulator_controls.py
@@ -1,5 +1,6 @@
 import tkinter.font
 import webbrowser
+from textwrap import dedent
 from tkinter import Menu, Tk, ttk
 from typing import Union
 
@@ -8,6 +9,7 @@ from showinfm import show_in_file_manager
 from modules.console import console
 from modules.context import context
 from modules.gui.debug_menu import DebugMenu
+from modules.gui.multi_select_window import ask_for_confirmation
 from modules.libmgba import LibmgbaEmulator
 from modules.memory import GameState, get_game_state
 from modules.modes import get_bot_modes
@@ -62,6 +64,7 @@ class EmulatorControls:
         self.profile_menu.add_command(
             label="Open Profile Folder", command=lambda: show_in_file_manager(str(context.profile.path))
         )
+        self.profile_menu.add_command(label="Reset Shiny Phase Stats", command=self._reset_shiny_phase_stats)
 
         self.help_menu = Menu(self.window, tearoff=0)
         self.help_menu.add_command(
@@ -315,6 +318,29 @@ class EmulatorControls:
         if context.debug:
             stats.append(f"{round(current_load * 100, 1)}%")
         self.stats_label.config(text=" | ".join(stats))
+
+    def _reset_shiny_phase_stats(self):
+        is_the_user_sure = ask_for_confirmation(
+            dedent(
+                """
+                This will reset all stats from your current shiny phase -- such
+                as encounters, IV/SV records, fishing attempts etc. -- to zero.
+                
+                That can be useful if for example you have changed location and
+                would like tostart hunting on this route with a clean slate
+                instead of having some random encounters from the way to get
+                here show up.
+                
+                Total encounter numbers will not be affected.
+                
+                This cannot be undone! Are you sure you want to proceed?
+                """
+            )
+        )
+
+        if is_the_user_sure:
+            context.stats.clear_current_shiny_phase()
+            context.message = "Shiny phase stats have been reset to zero."
 
 
 class DebugTab:

--- a/modules/gui/multi_select_window.py
+++ b/modules/gui/multi_select_window.py
@@ -153,7 +153,7 @@ def ask_for_confirmation(message: str, window_title: str = "Confirmation") -> bo
         # Scale the window to fit the label.
         if not checked_window_height:
             checked_window_height = True
-            window_height = label.winfo_height() + 100
+            window_height = label.winfo_reqheight() + 100
             if window_height > 180:
                 window.geometry(f"400x{window_height}")
 


### PR DESCRIPTION
### Description

This introduces a new menu option for resetting the current shiny phase's stats to 0.

![image](https://github.com/user-attachments/assets/52c7f25b-17b3-4592-8072-da7c4710b0b4)

Can be useful to get rid of some random encounters that you do not really care about (individual encounters on the way to the current route or trainer battles, that would remain at 1 or 2 encounters because they don't exist in the place where the bot is now hunting.)

Or, like happened on stream, if the bot kept hunting even though we found our target already and only got moved after 1,500 more encounters.

### Changes

Fixes `ask_for_confirmation()` that was already supposed to automatically grow to the correct height to fit the entire message, but used the wrong property to calculate it.

### Notes

There is a confirmation prompt before the reset:

![image](https://github.com/user-attachments/assets/2e16d8a5-71ca-44ed-9acf-e1b0a0f8c180)

And a message once the action has been executed:

![image](https://github.com/user-attachments/assets/c520556c-026b-41c5-a30a-39cbb030ad9b)


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
