### PR TITLE
Allow plugins and bot modes to prevent manual mode after hatched/gifted shiny

### DIFF
--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -192,6 +192,7 @@ def handle_encounter(
     disable_auto_catch: bool = False,
     enable_auto_battle: bool = False,
     do_not_log_battle_action: bool = False,
+    do_not_switch_to_manual: bool = False,
 ) -> BattleAction:
     pokemon = encounter_info.pokemon
     match encounter_info.value:
@@ -258,7 +259,8 @@ def handle_encounter(
         if context.config.battle.auto_catch and not disable_auto_catch and battle_is_active:
             encounter_info.battle_action = BattleAction.Catch
         else:
-            context.set_manual_mode()
+            if not do_not_switch_to_manual:
+                context.set_manual_mode()
             encounter_info.battle_action = BattleAction.CustomAction
     elif encounter_info.pokemon.species.name in context.config.battle.avoided_pokemon:
         encounter_info.battle_action = BattleAction.RunAway

--- a/modules/modes/_interface.py
+++ b/modules/modes/_interface.py
@@ -190,7 +190,7 @@ class BotMode:
         """
         return False
 
-    def on_egg_hatched(self, encounter: "EncounterInfo", party_index: int) -> None:
+    def on_egg_hatched(self, encounter: "EncounterInfo", party_index: int) -> bool | None:
         """
         This is called when an egg is hatching.
 
@@ -199,6 +199,8 @@ class BotMode:
 
         :param encounter: Information about the Pokémon that has hatched.
         :param party_index: Party index (0-5) of the Pokémon that has hatched.
+        :return: If `True`, the bot will not be switched to manual mode once a
+                 shiny or CCF match are found.
         """
         pass
 

--- a/modules/modes/_listeners.py
+++ b/modules/modes/_listeners.py
@@ -377,11 +377,16 @@ class EggHatchListener(BotListener):
                 egg_data = context.emulator.read_bytes(egg_data_pointer, length=16)
                 if 4 <= egg_data[2] <= 12:
                     self._encounter_info.pokemon = get_party()[self._hatching_party_index]
-                    bot_mode.on_egg_hatched(self._encounter_info, self._hatching_party_index)
+                    do_not_switch_to_manual = False
+                    if bot_mode.on_egg_hatched(self._encounter_info, self._hatching_party_index) is True:
+                        do_not_switch_to_manual = True
 
                     def report_hatched():
-                        yield from plugin_egg_hatched(self._encounter_info)
-                        handle_encounter(self._encounter_info)
+                        nonlocal do_not_switch_to_manual
+                        result = yield from plugin_egg_hatched(self._encounter_info)
+                        if result is True:
+                            do_not_switch_to_manual = True
+                        handle_encounter(self._encounter_info, do_not_switch_to_manual=do_not_switch_to_manual)
 
                     _ensure_plugin_hook_will_run(report_hatched())
                     self._reported_hatched_egg = True

--- a/modules/plugin_interface.py
+++ b/modules/plugin_interface.py
@@ -132,7 +132,7 @@ class BotPlugin:
 
         pass
 
-    def on_egg_hatched(self, hatched_pokemon: "EncounterInfo") -> Generator | None:
+    def on_egg_hatched(self, hatched_pokemon: "EncounterInfo") -> Generator[None, None, bool | None] | bool | None:
         """
         This is called during the egg-hatching cutscene once the egg has hatched and the
         Pokémon is visible.
@@ -141,6 +141,10 @@ class BotPlugin:
         :return: This _may_ return a Generator (so you can use `yield` inside here), in
                  which case the current bot mode is suspended and this generator function
                  takes control.
+
+                 And/or it can return a boolean, which if True indicates that the bot
+                 should not switch to manual mode in any case (which is the default for
+                 gift Pokémon and hatched eggs once a shiny/CCF match is found.)
         """
         pass
 

--- a/modules/plugins.py
+++ b/modules/plugins.py
@@ -120,11 +120,17 @@ def plugin_egg_starting_to_hatch(hatching_pokemon: "EncounterInfo") -> Generator
             yield from result
 
 
-def plugin_egg_hatched(hatched_pokemon: "EncounterInfo") -> Generator:
+def plugin_egg_hatched(hatched_pokemon: "EncounterInfo") -> Generator[None, None, bool]:
+    do_not_switch_to_manual = False
     for plugin in plugins:
         result = plugin.on_egg_hatched(hatched_pokemon)
         if isinstance(result, GeneratorType):
-            yield from result
+            return_value = yield from result
+            if return_value is True:
+                do_not_switch_to_manual = True
+        elif result is True:
+            do_not_switch_to_manual = True
+    return do_not_switch_to_manual
 
 
 def plugin_whiteout() -> Generator:


### PR DESCRIPTION
### Description

If the bot hatches or receives a shiny Pokémon (or a CCF match) it will currently always switch to manual mode.

This might not always be what we want: In daycare, we might need more than one shiny (for evolutions) and for gift soft-resets or starters, we might require a female shiny and therefore need to skip male ones.

This will be required for the stream plugin, so this new option is not being used by any default mode so far.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
