### PR TITLE
Support nicknaming hatched Pokémon (through plugins)

### DIFF
--- a/modules/map.py
+++ b/modules/map.py
@@ -1467,6 +1467,21 @@ class ObjectEvent:
                 return "Left"
             case 4:
                 return "Right"
+        return "???"
+
+    @property
+    def facing_coordinates(self) -> tuple[int, int]:
+        x, y = self.current_coords
+        match self.facing_direction:
+            case "Down":
+                return x, y + 1
+            case "Up":
+                return x, y - 1
+            case "Left":
+                return x - 1, y
+            case "Right":
+                return x + 1, y
+        return x, y + 1
 
     @property
     def movement_direction(self) -> str:
@@ -1480,6 +1495,7 @@ class ObjectEvent:
                 return "Left"
             case 4:
                 return "Right"
+        return "???"
 
     @property
     def range_x(self) -> int:

--- a/modules/plugin_interface.py
+++ b/modules/plugin_interface.py
@@ -172,12 +172,12 @@ class BotPlugin:
         """
         return False
 
-    def on_should_nickname_pokemon(self, pokemon: "Pokemon") -> str | None:
+    def on_should_nickname_pokemon(self, encounter: "EncounterInfo") -> str | None:
         """
         This is called when the player is asked whether to give a nickname to a newly
         acquired Pokémon.
 
-        :param pokemon: The newly received Pokémon.
+        :param encounter: The newly received Pokémon.
         :return: The nickname (max. 10 characters) to give to the Pokémon, or `None` to
                  not give a nickname.
         """

--- a/modules/plugins.py
+++ b/modules/plugins.py
@@ -143,9 +143,9 @@ def plugin_judge_encounter(pokemon: Pokemon) -> str | bool:
     return False
 
 
-def plugin_should_nickname_pokemon(pokemon: Pokemon) -> str | None:
+def plugin_should_nickname_pokemon(encounter: "EncounterInfo") -> str | None:
     for plugin in plugins:
-        nickname = plugin.on_should_nickname_pokemon(pokemon)
+        nickname = plugin.on_should_nickname_pokemon(encounter)
         if nickname:
             return nickname
 


### PR DESCRIPTION
### Description

We already supported nicknaming Pokémon that have been caught from wild or static encounters.

This change adds that feature to egg hatching as well.

A plugin is needed to actually use this feature, same as before.

### Notes

This introduces a **backwards-incompatible change** by changing the plugin interface's `on_should_nickname_pokemon` function to accept an `EncounterInfo` instance rather than just a `Pokemon`.

The `EncounterInfo` class has the Pokémon as a property, so it's still available and would need minimal code changes (`pokemon = encounter.pokemon`)

If anyone has even bothered to write a plugin for that, I'm sure they'll have the expertise to adapt it accordingly.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
