### PR TITLE
Overlay: Fix encounter reporting for non-battle encounters

### DIFF
--- a/modules/web/static/pokemon.d.ts
+++ b/modules/web/static/pokemon.d.ts
@@ -248,6 +248,8 @@ export type Pokemon = {
 
     species: Species;
 
+    species_name_for_stats: string;
+
     held_item: Item | null;
 
     // Total number of Experience that this Pokémon has collected.
@@ -562,7 +564,7 @@ export type Player = {
     registered_item: string;
 };
 
-export type PlayerAvatar = {
+export type PlayerAvatarType = {
     map_group_and_number: [number, number];
 
     // Local coordinates (in tiles) on the current map.

--- a/modules/web/static/stream-overlay/config.dist.js
+++ b/modules/web/static/stream-overlay/config.dist.js
@@ -285,6 +285,12 @@ const config = {
                 similarSpecies: [],
                 hidden: false,
             },
+
+            "Vileplume": {
+                goal: 3,
+                similarSpecies: ["Oddish", "Gloom"],
+                hidden: false,
+            },
         },
 
         6: {
@@ -330,9 +336,9 @@ const config = {
                 hidden: false,
             },
 
-            "Vileplume": {
+            "Shiftry": {
                 goal: 3,
-                similarSpecies: ["Oddish", "Gloom"],
+                similarSpecies: ["Seedot", "Nuzleaf"],
                 hidden: false,
             },
 

--- a/modules/web/static/stream-overlay/connection.js
+++ b/modules/web/static/stream-overlay/connection.js
@@ -1,436 +1,96 @@
-import {updateMapName, updateRouteEncountersList} from "./content/route-encounters.js";
-import {updateSectionChecklist} from "./content/section-checklist.js";
-import {updateShinyLog} from "./content/shiny-log.js";
-import {updateEncounterLog} from "./content/encounter-log.js";
-import {updatePartyList} from "./content/party-list.js";
-import {updateBadgeList} from "./content/badge-list.js";
-import {updatePhaseStats} from "./content/phase-stats.js";
-import {updatePCStorage, updateTotalStats} from "./content/total-stats.js";
-import config from "./config.js";
-import {updateInputs} from "./content/inputs.js";
-import {updateClock} from "./content/clock.js";
-import {
-    hideFishingInfoBubble,
-    updateEncounterInfoBubble,
-    updateFishingInfoBubble,
-    updateInfoBubbles,
-    updatePokeNavInfoBubble
-} from "./content/info-bubbles.js";
-import {hideCurrentEncounterStats, showCurrentEncounterStats} from "./content/current-encounter-stats.js";
-import {numberOfEncounterLogEntries} from "./helper.js";
+export const fetchers = {
+    /** @return {Promise<PokeBotApi.GetStatsResponse>} */
+    stats: () => fetch("/stats").then(response => response.json()),
 
-let interval;
-let hideEncounterStatsTimeout;
+    /** @return {Promise<PokeBotApi.GetMapResponse>} */
+    map: () => fetch("/map").then(response => response.json()),
 
-export default function initOverlay() {
-    if (interval) {
-        window.clearInterval(interval);
-    }
-    interval = window.setInterval(() => updateClock(config.startDate, config.timeZone, config.overrideDisplayTimezone), 1000);
-    updateClock(config.startDate, config.timeZone, config.overrideDisplayTimezone);
+    /** @return {Promise<PokeBotApi.GetMapEncountersResponse>} */
+    mapEncounters: () => fetch("/map_encounters").then(response => response.json()),
 
-    const initialFetch = [
-        fetch("/stats").then(response => response.json()),
-        fetch("/map").then(response => response.json()),
-        fetch("/map_encounters").then(response => response.json()),
-        fetch("/shiny_log").then(response => response.json()),
-        fetch("/encounter_log").then(response => response.json()),
-        fetch("/player_avatar").then(response => response.json()),
-        fetch("/party").then(response => response.json()),
-        fetch("/emulator").then(response => response.json()),
-        fetch("/event_flags").then(response => response.json()),
-        fetch("/encounter_rate").then(response => response.json()),
-        fetch("/game_state").then(response => response.json()),
-        fetch("/pokemon_storage").then(response => response.json()),
-    ];
+    /** @return {Promise<PokeBotApi.GetShinyLogResponse>} */
+    shinyLog: () => fetch("/shiny_log").then(response => response.json()),
 
-    Promise.all(initialFetch).then(
-        /**
-         * @param {[
-         *     PokeBotApi.GetStatsResponse,
-         *     PokeBotApi.GetMapResponse,
-         *     PokeBotApi.GetMapEncountersResponse,
-         *     PokeBotApi.GetShinyLogResponse,
-         *     PokeBotApi.GetEncounterLogResponse,
-         *     PokeBotApi.GetPlayerAvatarResponse,
-         *     PokeBotApi.GetPartyResponse,
-         *     PokeBotApi.GetEmulatorResponse,
-         *     PokeBotApi.GetEventFlagsResponse,
-         *     PokeBotApi.GetEncounterRateResponse,
-         *     PokeBotApi.GetGameStateResponse,
-         *     PokeBotApi.GetPokemonStorageResponse,
-         * ]} data
-         */
-        ([stats, map, mapEncounters, shinyLog, encounterLog, playerAvatar, party, emulator, eventFlags, encounterRate, gameState, pokemonStorage]) => {
-            const wildEncounterTypes = ["land", "surfing", "fishing_old_rod", "fishing_good_rod", "fishing_super_rod", "rock_smash"];
-            /** @type {EncounterType} lastEncounterType */
-            let lastEncounterType = "land";
-            /** @type {Encounter} */
-            let lastEncounter = encounterLog.length > 0 ? encounterLog[0] : null;
-            let additionalRouteSpecies = [];
-            if (encounterLog.length > 0 && wildEncounterTypes.includes(encounterLog[0].type)) {
-                lastEncounterType = encounterLog[0].type;
-            } else if (encounterLog.length > 0 && ["hatched", "gift", "static"].includes(encounterLog[0].type)) {
-                additionalRouteSpecies.push(encounterLog[0].pokemon.species.name);
-            }
-            if (lastEncounterType === "land" && playerAvatar.flags.Surfing) {
-                lastEncounterType = "surfing";
-            } else if (lastEncounterType === "surfing" && !playerAvatar.flags.Surfing) {
-                lastEncounterType = "land";
-            }
+    /** @return {Promise<PokeBotApi.GetEncounterLogResponse>} */
+    encounterLog: () => fetch("/encounter_log").then(response => response.json()),
 
-            updateMapName(map);
-            updateRouteEncountersList(mapEncounters, stats, lastEncounterType, config.sectionChecklist, additionalRouteSpecies);
-            updateSectionChecklist(config.sectionChecklist, stats);
-            updateShinyLog(shinyLog);
-            updateEncounterLog(encounterLog);
-            updatePartyList(party);
-            updateBadgeList(emulator.game.title, eventFlags);
-            updatePhaseStats(stats);
-            updatePCStorage(pokemonStorage, party);
-            updateTotalStats(stats, encounterRate.encounter_rate);
-            updateInfoBubbles(mapEncounters, stats, config.targetTimers, lastEncounterType, party);
+    /** @return {Promise<PokeBotApi.GetPlayerAvatarResponse>} */
+    playerAvatar: () => fetch("/player_avatar").then(response => response.json()),
 
-            const battleStates = ["BATTLE_STARTING", "BATTLE", "BATTLE_ENDING"];
-            let isInBattle = battleStates.includes(gameState);
-            let isInEggHatch = gameState === "EGG_HATCH";
-            let wasShinyEncounter = false;
+    /** @return {Promise<PokeBotApi.GetPartyResponse>} */
+    party: () => fetch("/party").then(response => response.json()),
 
-            /** @param {StreamEvents.PerformanceData} data */
-            const handlePerformanceData = data => {
-                encounterRate = data;
-                updateTotalStats(stats, encounterRate.encounter_rate);
-            };
+    /** @return {Promise<PokeBotApi.GetEmulatorResponse>} */
+    emulator: () => fetch("/emulator").then(response => response.json()),
 
-            /** @param {StreamEvents.GameState} gameState */
-            const handleGameState = gameState => {
-                if (isInEggHatch && gameState !== "EGG_HATCH") {
-                    updatePartyList(party);
-                    isInEggHatch = false;
-                } else if (!isInEggHatch && gameState === "EGG_HATCH") {
-                    isInEggHatch = true;
-                }
-                if (isInBattle && gameState === "OVERWORLD") {
-                    hideCurrentEncounterStats();
-                    if (wasShinyEncounter) {
-                        wasShinyEncounter = false;
-                        Promise.all([
-                            fetch("/stats").then(response => response.json()),
-                            fetch("/shiny_log").then(response => response.json()),
-                        ]).then(
-                            /**
-                             * @param {PokeBotApi.GetStatsResponse} newStats
-                             * @param {PokeBotApi.GetShinyLogResponse} newShinyLog
-                             */
-                            ([newStats, newShinyLog]) => {
-                                stats = newStats;
-                                shinyLog = newShinyLog;
+    /** @return {Promise<PokeBotApi.GetEventFlagsResponse>} */
+    eventFlags: () => fetch("/event_flags").then(response => response.json()),
 
-                                updateShinyLog(shinyLog);
-                                updateSectionChecklist(config.sectionChecklist, stats);
-                                updateRouteEncountersList(mapEncounters, stats, lastEncounterType, config.sectionChecklist, additionalRouteSpecies);
-                                updatePhaseStats(stats);
-                                updateTotalStats(stats);
-                            });
-                    }
-                    isInBattle = false;
-                }
+    /** @return {Promise<PokeBotApi.GetEncounterRateResponse>} */
+    encounterRate: () => fetch("/encounter_rate").then(response => response.json()),
 
-                if (!isInBattle && battleStates.includes(gameState)) {
-                    isInBattle = true;
-                }
-            };
+    /** @return {Promise<PokeBotApi.GetGameStateResponse>} */
+    gameState: () => fetch("/game_state").then(response => response.json()),
 
-            /** @param {StreamEvents.Party} data */
-            const handleParty = data => {
-                party = data;
-                if (!isInEggHatch) {
-                    updatePartyList(data);
-                }
-            };
-
-            /** @param {StreamEvents.PlayerAvatar} data */
-            const handlePlayerAvatar = data => {
-                playerAvatar = data;
-                if (lastEncounterType === "land" && playerAvatar.flags.Surfing) {
-                    lastEncounterType = "surfing";
-                    updateRouteEncountersList(mapEncounters, stats, lastEncounterType, config.sectionChecklist, additionalRouteSpecies);
-                } else if (lastEncounterType === "surfing" && !playerAvatar.flags.Surfing) {
-                    lastEncounterType = "land";
-                    updateRouteEncountersList(mapEncounters, stats, lastEncounterType, config.sectionChecklist, additionalRouteSpecies);
-                }
-            };
-
-            /** @param {StreamEvents.MapChange} data */
-            const handleMap = data => {
-                updateMapName(data);
-                hideFishingInfoBubble();
-                additionalRouteSpecies = [];
-                if (lastEncounter && ["hatched", "gift", "static"].includes(lastEncounter.type) && !additionalRouteSpecies.includes(lastEncounter.pokemon.species.name)) {
-                    additionalRouteSpecies.push(lastEncounter.pokemon.species.name);
-                }
-            };
-
-            /** @param {StreamEvents.MapEncounters} data */
-            const handleMapEncounters = data => {
-                mapEncounters = data;
-                updateRouteEncountersList(mapEncounters, stats, lastEncounterType, config.sectionChecklist, additionalRouteSpecies);
-            };
-
-            const handlePokenavCall = () => {
-                if (stats.current_phase) {
-                    stats.current_phase.pokenav_calls++;
-                    updatePokeNavInfoBubble(stats);
-                }
-            };
-
-            /** @param {StreamEvents.FishingAttempt} attempt */
-            const handleFishingAttempt = attempt => {
-                if (stats.current_phase) {
-                    stats.current_phase.fishing_attempts++;
-                    if (attempt.result === "Encounter") {
-                        stats.current_phase.successful_fishing_attempts++;
-                        stats.current_phase.current_unsuccessful_fishing_streak = 0;
-                    } else {
-                        stats.current_phase.current_unsuccessful_fishing_streak++;
-                        if (stats.current_phase.longest_unsuccessful_fishing_streak < stats.current_phase.current_unsuccessful_fishing_streak) {
-                            stats.current_phase.longest_unsuccessful_fishing_streak = stats.current_phase.current_unsuccessful_fishing_streak
-                        }
-                    }
-                    let rod = "Old";
-                    if (attempt.rod === "GoodRod") {
-                        rod = "Good";
-                    } else if (attempt.rod === "SuperRod") {
-                        rod = "Super";
-                    }
-                    updateFishingInfoBubble(stats, rod);
-                }
-            };
-
-            /** @param {StreamEvents.Inputs} inputs */
-            const handleInput = inputs => {
-                updateInputs(inputs);
-            };
-
-            /** @param {StreamEvents.WildEncounter} encounter */
-            const handleWildEncounter = encounter => {
-                if (hideEncounterStatsTimeout) {
-                    window.clearTimeout(hideEncounterStatsTimeout);
-                }
-
-                lastEncounter = encounter;
-                if (wildEncounterTypes.includes(encounter.type)) {
-                    lastEncounterType = encounter.type;
-                } else {
-                    hideEncounterStatsTimeout = window.setTimeout(() => hideCurrentEncounterStats(), 1000 * config.nonBattleEncounterStatsTimeoutInSeconds);
-                }
-
-                if (["hatched", "gift", "static"].includes(encounter.type) && !additionalRouteSpecies.includes(encounter.pokemon.species.name)) {
-                    additionalRouteSpecies.push(encounter.pokemon.species.name);
-                }
-
-                encounterLog.unshift(encounter);
-                while (encounterLog.length > numberOfEncounterLogEntries) {
-                    encounterLog.pop();
-                }
-
-                stats.totals.total_encounters++;
-
-                const sv = encounter.pokemon.shiny_value;
-                const ivSum =
-                    encounter.pokemon.ivs.hp +
-                    encounter.pokemon.ivs.attack +
-                    encounter.pokemon.ivs.defence +
-                    encounter.pokemon.ivs.special_attack +
-                    encounter.pokemon.ivs.special_defence +
-                    encounter.pokemon.ivs.speed;
-
-                if (!stats.totals.total_highest_iv_sum?.species_name || stats.totals.total_highest_iv_sum.value < ivSum) {
-                    stats.totals.total_highest_iv_sum = {
-                        species_name: encounter.pokemon.species.name,
-                        value: ivSum,
-                    };
-                }
-
-                if (!stats.totals.total_lowest_iv_sum?.species_name || stats.totals.total_lowest_iv_sum.value > ivSum) {
-                    stats.totals.total_lowest_iv_sum = {
-                        species_name: encounter.pokemon.species.name,
-                        value: ivSum,
-                    };
-                }
-
-                if (!stats.totals.total_highest_sv?.species_name || stats.totals.total_highest_sv.value < sv) {
-                    stats.totals.total_highest_sv = {
-                        species_name: encounter.pokemon.species.name,
-                        value: sv,
-                    };
-                }
-
-                if (!stats.totals.total_lowest_sv?.species_name || stats.totals.total_lowest_sv.value > sv) {
-                    stats.totals.total_lowest_sv = {
-                        species_name: encounter.pokemon.species.name,
-                        value: sv,
-                    };
-                }
-
-                stats.totals.phase_encounters++;
-
-                if (!stats.totals?.phase_highest_iv_sum?.species_name || stats.totals.phase_highest_iv_sum.value < ivSum) {
-                    stats.totals.phase_highest_iv_sum = {
-                        species_name: encounter.pokemon.species.name,
-                        value: ivSum,
-                    };
-                }
-
-                if (!stats.totals.phase_lowest_iv_sum?.species_name || stats.totals.phase_lowest_iv_sum.value > ivSum) {
-                    stats.totals.phase_lowest_iv_sum = {
-                        species_name: encounter.pokemon.species.name,
-                        value: ivSum,
-                    };
-                }
-
-                if (!stats.totals.phase_highest_sv?.species_name || stats.totals.phase_highest_sv.value < sv) {
-                    stats.totals.phase_highest_sv = {
-                        species_name: encounter.pokemon.species.name,
-                        value: sv,
-                    };
-                }
-
-                if (!stats.totals.phase_lowest_sv?.species_name || stats.totals.phase_lowest_sv.value > sv) {
-                    stats.totals.phase_lowest_sv = {
-                        species_name: encounter.pokemon.species.name,
-                        value: sv,
-                    };
-                }
-
-                if (!stats.pokemon.hasOwnProperty(encounter.pokemon.species.name)) {
-                    stats.pokemon[encounter.pokemon.species.name] = {
-                        species_id: encounter.pokemon.species.index,
-                        species_name: encounter.pokemon.species.name,
-                        total_encounters: 1,
-                        shiny_encounters: encounter.pokemon.is_shiny ? 1 : 0,
-                        catches: 0,
-                        total_highest_iv_sum: ivSum,
-                        total_lowest_iv_sum: ivSum,
-                        total_highest_sv: sv,
-                        total_lowest_sv: sv,
-                        phase_encounters: 1,
-                        phase_highest_iv_sum: ivSum,
-                        phase_lowest_iv_sum: ivSum,
-                        phase_highest_sv: sv,
-                        phase_lowest_sv: sv,
-                        last_encounter_time: new Date().toISOString(),
-                    };
-                } else {
-                    stats.pokemon[encounter.pokemon.species.name].total_encounters++;
-                    stats.pokemon[encounter.pokemon.species.name].phase_encounters++;
-                    stats.pokemon[encounter.pokemon.species.name].last_encounter_time = new Date().toISOString();
-                    if (stats.pokemon[encounter.pokemon.species.name].total_highest_iv_sum < ivSum) {
-                        stats.pokemon[encounter.pokemon.species.name].total_highest_iv_sum = ivSum;
-                    }
-                    if (stats.pokemon[encounter.pokemon.species.name].total_lowest_iv_sum > ivSum) {
-                        stats.pokemon[encounter.pokemon.species.name].total_lowest_iv_sum = ivSum;
-                    }
-                    if (stats.pokemon[encounter.pokemon.species.name].total_highest_sv < sv) {
-                        stats.pokemon[encounter.pokemon.species.name].total_highest_sv = sv;
-                    }
-                    if (stats.pokemon[encounter.pokemon.species.name].total_lowest_sv > sv) {
-                        stats.pokemon[encounter.pokemon.species.name].total_lowest_sv = sv;
-                    }
-                    if (stats.pokemon[encounter.pokemon.species.name].phase_highest_iv_sum < ivSum) {
-                        stats.pokemon[encounter.pokemon.species.name].phase_highest_iv_sum = ivSum;
-                    }
-                    if (stats.pokemon[encounter.pokemon.species.name].phase_lowest_iv_sum > ivSum) {
-                        stats.pokemon[encounter.pokemon.species.name].phase_lowest_iv_sum = ivSum;
-                    }
-                    if (stats.pokemon[encounter.pokemon.species.name].phase_highest_sv < sv) {
-                        stats.pokemon[encounter.pokemon.species.name].phase_highest_sv = sv;
-                    }
-                    if (stats.pokemon[encounter.pokemon.species.name].phase_lowest_sv > sv) {
-                        stats.pokemon[encounter.pokemon.species.name].phase_lowest_sv = sv;
-                    }
-                }
-
-                stats.current_phase.encounters++;
-                if (!stats.current_phase.highest_iv_sum?.species_name || stats.current_phase.highest_iv_sum.value < ivSum) {
-                    stats.current_phase.highest_iv_sum = {
-                        species_name: encounter.pokemon.species.name,
-                        value: ivSum,
-                    };
-                }
-                if (!stats.current_phase.lowest_iv_sum?.species_name || stats.current_phase.lowest_iv_sum.value > ivSum) {
-                    stats.current_phase.lowest_iv_sum = {
-                        species_name: encounter.pokemon.species.name,
-                        value: ivSum,
-                    };
-                }
-                if (!stats.current_phase.highest_sv?.species_name || stats.current_phase.highest_sv.value < sv) {
-                    stats.current_phase.highest_sv = {
-                        species_name: encounter.pokemon.species.name,
-                        value: sv,
-                    };
-                }
-                if (!stats.current_phase.lowest_sv?.species_name || stats.current_phase.lowest_sv.value > sv) {
-                    stats.current_phase.lowest_sv = {
-                        species_name: encounter.pokemon.species.name,
-                        value: sv,
-                    };
-                }
-                if (stats.current_phase?.current_streak?.species_name === encounter.pokemon.species.name) {
-                    stats.current_phase.current_streak.value++;
-                } else {
-                    stats.current_phase.current_streak = {
-                        species_name: encounter.pokemon.species.name,
-                        value: 1,
-                    };
-                }
-                if (!stats.current_phase?.longest_streak?.species_name || stats.current_phase.longest_streak.value < stats.current_phase.current_streak.value) {
-                    stats.current_phase.longest_streak = {
-                        species_name: stats.current_phase.current_streak.species_name,
-                        value: stats.current_phase.current_streak.value,
-                    };
-                }
-
-                if (encounter.pokemon.is_shiny) {
-                    wasShinyEncounter = true;
-                    stats.totals.shiny_encounters++;
-                    stats.pokemon[encounter.pokemon.species.name].shiny_encounters++;
-                    updatePokeNavInfoBubble(null);
-                }
-
-                updateRouteEncountersList(mapEncounters, stats, lastEncounterType, config.sectionChecklist, additionalRouteSpecies, encounter.pokemon.species.name);
-                updatePhaseStats(stats);
-                updateTotalStats(stats, encounterRate.encounter_rate);
-                updateEncounterInfoBubble(encounter.pokemon.species.name, stats);
-                updateInfoBubbles(mapEncounters, stats, config.targetTimers, encounter.type, party);
-                updateEncounterLog(encounterLog);
-                showCurrentEncounterStats(encounter);
-            };
-
-            const url = new URL(window.location.origin + "/stream_events");
-            url.searchParams.append("topic", "PerformanceData");
-            url.searchParams.append("topic", "BotMode");
-            url.searchParams.append("topic", "GameState");
-            url.searchParams.append("topic", "Party");
-            url.searchParams.append("topic", "WildEncounter");
-            url.searchParams.append("topic", "Map");
-            url.searchParams.append("topic", "MapEncounters");
-            url.searchParams.append("topic", "Player");
-            url.searchParams.append("topic", "PlayerAvatar");
-            url.searchParams.append("topic", "Inputs");
-            url.searchParams.append("topic", "PokenavCall");
-            url.searchParams.append("topic", "FishingAttempt");
-
-            const eventSource = new EventSource(url);
-            eventSource.addEventListener("PerformanceData", event => handlePerformanceData(JSON.parse(event.data)));
-            eventSource.addEventListener("GameState", event => handleGameState(JSON.parse(event.data)));
-            eventSource.addEventListener("Party", event => handleParty(JSON.parse(event.data)));
-            eventSource.addEventListener("WildEncounter", event => handleWildEncounter(JSON.parse(event.data)));
-            eventSource.addEventListener("MapChange", event => handleMap(JSON.parse(event.data)));
-            eventSource.addEventListener("MapEncounters", event => handleMapEncounters(JSON.parse(event.data)));
-            eventSource.addEventListener("PlayerAvatar", event => handlePlayerAvatar(JSON.parse(event.data)));
-            eventSource.addEventListener("PokenavCall", event => handlePokenavCall());
-            eventSource.addEventListener("FishingAttempt", event => handleFishingAttempt(JSON.parse(event.data)));
-            eventSource.addEventListener("Inputs", event => handleInput(JSON.parse(event.data)));
-        });
+    /** @return {Promise<PokeBotApi.GetPokemonStorageResponse>} */
+    pokemonStorage: () => fetch("/pokemon_storage").then(response => response.json()),
 };
+
+/**
+ * @param {OverlayState} state
+ * @return {Promise<OverlayState>}
+ */
+export function loadAllData(state) {
+    return new Promise((resolve, reject) => {
+            Promise.all([
+                fetchers.stats(),
+                fetchers.map(),
+                fetchers.mapEncounters(),
+                fetchers.shinyLog(),
+                fetchers.encounterLog(),
+                fetchers.playerAvatar(),
+                fetchers.party(),
+                fetchers.emulator(),
+                fetchers.eventFlags(),
+                fetchers.encounterRate(),
+                fetchers.gameState(),
+                fetchers.pokemonStorage(),
+            ]).then(
+                data => {
+                    state.stats = data[0];
+                    state.map = data[1];
+                    state.mapEncounters = data[2];
+                    state.shinyLog = data[3];
+                    state.encounterLog = data[4];
+                    state.playerAvatar = data[5];
+                    state.party = data[6];
+                    state.emulator = data[7];
+                    state.eventFlags = data[8];
+                    state.encounterRate = data[9].encounter_rate;
+                    state.gameState = data[10];
+                    state.pokemonStorage = data[11];
+                    state.reset();
+                    resolve();
+                },
+                reject);
+        }
+    );
+}
+
+/** @return {EventSource} */
+export function getEventSource() {
+    const url = new URL(window.location.origin + "/stream_events");
+    url.searchParams.append("topic", "PerformanceData");
+    url.searchParams.append("topic", "BotMode");
+    url.searchParams.append("topic", "GameState");
+    url.searchParams.append("topic", "Party");
+    url.searchParams.append("topic", "WildEncounter");
+    url.searchParams.append("topic", "Map");
+    url.searchParams.append("topic", "MapEncounters");
+    url.searchParams.append("topic", "Player");
+    url.searchParams.append("topic", "PlayerAvatar");
+    url.searchParams.append("topic", "Inputs");
+    url.searchParams.append("topic", "PokenavCall");
+    url.searchParams.append("topic", "FishingAttempt");
+    return new EventSource(url);
+}

--- a/modules/web/static/stream-overlay/content/encounter-log.js
+++ b/modules/web/static/stream-overlay/content/encounter-log.js
@@ -33,7 +33,7 @@ function updateEncounterLog(encounterLog) {
 
         tbody.append(renderTableRow({
             sprite: [
-                speciesSprite(entry.pokemon.species.name, entry.pokemon.is_shiny ? "shiny" : "normal"),
+                speciesSprite(entry.pokemon.species_name_for_stats, entry.pokemon.is_shiny ? "shiny" : "normal"),
                 genderSprite(entry.pokemon.gender),
                 itemSprite(entry.pokemon.held_item),
             ],

--- a/modules/web/static/stream-overlay/content/info-bubbles.js
+++ b/modules/web/static/stream-overlay/content/info-bubbles.js
@@ -49,14 +49,14 @@ function updateInfoBubbles(mapEncounters, stats, targetTimers, lastEncounterType
             if (["Magma Armor", "Flame Body"].includes(activeAbility)) {
                 for (const member of party) {
                     if (member.ability.name === activeAbility) {
-                        sprite = speciesSprite(member.species.name, member.is_shiny ? "shiny-cropped" : "normal-cropped", false);
+                        sprite = speciesSprite(member.species_name_for_stats, member.is_shiny ? "shiny-cropped" : "normal-cropped", false);
                         sprite.classList.add("icon-species-static");
                         break;
                     }
                 }
             } else {
                 if (party[0].ability.name === activeAbility) {
-                    sprite = speciesSprite(party[0].species.name, party[0].is_shiny ? "shiny-cropped" : "normal-cropped", false);
+                    sprite = speciesSprite(party[0].species_name_for_stats, party[0].is_shiny ? "shiny-cropped" : "normal-cropped", false);
                     sprite.classList.add("icon-species-static");
                 }
             }
@@ -123,6 +123,7 @@ function updateEncounterInfoBubble(speciesName, stats) {
     }
 
     if (!stats.pokemon.hasOwnProperty(speciesName)) {
+        targetTimerBubbles[speciesName][1].style.display = "none";
         targetTimerBubbles[speciesName][1].innerText = "?";
         return;
     }
@@ -144,6 +145,7 @@ function updateEncounterInfoBubble(speciesName, stats) {
         } else {
             targetTimerBubbles[speciesName][1].innerHTML = `${hours} <small>hr</small> ${minutes} <small>min</small>`;
         }
+        targetTimerBubbles[speciesName][1].style.display = "inline-block";
     }
 
     const msUntilNextMinute = ((diffInMinutes + 1) * 60000) - diffInMS;

--- a/modules/web/static/stream-overlay/content/party-list.js
+++ b/modules/web/static/stream-overlay/content/party-list.js
@@ -20,10 +20,10 @@ function updatePartyList(party) {
             hpPercentage = 0;
             expPercentage = Math.round(100 * (member.species.egg_cycles - member.friendship) / member.species.egg_cycles);
         } else if (member.current_hp === 0) {
-            sprite = speciesSprite(member.species.name, member.is_shiny ? "shiny" : "normal", false);
+            sprite = speciesSprite(member.species_name_for_stats, member.is_shiny ? "shiny" : "normal", false);
             sprite.classList.add("fainted");
         } else {
-            sprite = speciesSprite(member.species.name, member.is_shiny ? "shiny" : "normal", true);
+            sprite = speciesSprite(member.species_name_for_stats, member.is_shiny ? "shiny" : "normal", true);
         }
 
         let statusCondition = "";

--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -26,7 +26,7 @@ const updateMapName = map => {
  * @param {PokeBotApi.GetStatsResponse} stats
  * @param {EncounterType} encounterType
  * @param {StreamOverlay.SectionChecklist} checklistConfig
- * @param {string[] | null} [additionalRouteSpecies]
+ * @param {Set<string>} [additionalRouteSpecies]
  * @param {string} [animateSpecies]
  */
 const updateRouteEncountersList = (encounters, stats, encounterType, checklistConfig, additionalRouteSpecies = null, animateSpecies = null) => {
@@ -75,18 +75,16 @@ const updateRouteEncountersList = (encounters, stats, encounterType, checklistCo
 
     // Add species to this list that have been encountered here but are not part of the
     // regular encounter table (i.e. egg hatches, gift Pokémon, ...)
-    if (Array.isArray(additionalRouteSpecies)) {
-        for (const speciesName of additionalRouteSpecies) {
-            let alreadyInList = false;
-            for (const encounterSpecies of encounterList) {
-                if (encounterSpecies.species_name === speciesName) {
-                    alreadyInList = true;
-                }
+    for (const speciesName of additionalRouteSpecies) {
+        let alreadyInList = false;
+        for (const encounterSpecies of encounterList) {
+            if (encounterSpecies.species_name === speciesName) {
+                alreadyInList = true;
             }
+        }
 
-            if (!alreadyInList) {
-                encounterList.push({species_name: speciesName, encounter_rate: 0});
-            }
+        if (!alreadyInList) {
+            encounterList.push({species_name: speciesName, encounter_rate: 0});
         }
     }
 

--- a/modules/web/static/stream-overlay/content/shiny-log.js
+++ b/modules/web/static/stream-overlay/content/shiny-log.js
@@ -28,7 +28,7 @@ function updateShinyLog(shinyLog) {
             entry.shiny_encounter.outcome === "InProgress" ||
             entry.shiny_encounter.outcome === null;
 
-        const sprite = speciesSprite(entry.shiny_encounter.pokemon.species.name, "shiny");
+        const sprite = speciesSprite(entry.shiny_encounter.pokemon.species_name_for_stats, "shiny");
         if (!successful) {
             sprite.classList.add("unsuccessful");
         }

--- a/modules/web/static/stream-overlay/index.html
+++ b/modules/web/static/stream-overlay/index.html
@@ -322,9 +322,9 @@
 </section>
 
 <script type="module">
-    import initOverlay from "./connection.js";
+    import runOverlay from "./overlay.js";
 
-    initOverlay();
+    runOverlay().then(() => {});
 </script>
 </body>
 </html>

--- a/modules/web/static/stream-overlay/layout/current-encounter-stats.css
+++ b/modules/web/static/stream-overlay/layout/current-encounter-stats.css
@@ -37,6 +37,11 @@ table#encounter-stats {
 
     td {
         padding: .5vh 0;
+
+        &:nth-child(2) img {
+            height: 1rem;
+            transform: scale(1.5);
+        }
     }
 
     .arrow-sprite {

--- a/modules/web/static/stream-overlay/layout/global.css
+++ b/modules/web/static/stream-overlay/layout/global.css
@@ -10,6 +10,7 @@ html, body {
     font-size: 1.75vh;
     margin: 0;
     padding: 0;
+    overflow: hidden;
 }
 
 img {

--- a/modules/web/static/stream-overlay/overlay.js
+++ b/modules/web/static/stream-overlay/overlay.js
@@ -1,0 +1,265 @@
+import {fetchers, getEventSource, loadAllData} from "./connection.js";
+import OverlayState, {WILD_ENCOUNTER_TYPES} from "./state.js";
+import {updateMapName, updateRouteEncountersList} from "./content/route-encounters.js";
+import config from "./config.js";
+import {updateSectionChecklist} from "./content/section-checklist.js";
+import {updateShinyLog} from "./content/shiny-log.js";
+import {updateEncounterLog} from "./content/encounter-log.js";
+import {updatePartyList} from "./content/party-list.js";
+import {updateBadgeList} from "./content/badge-list.js";
+import {updatePhaseStats} from "./content/phase-stats.js";
+import {updatePCStorage, updateTotalStats} from "./content/total-stats.js";
+import {
+    hideFishingInfoBubble,
+    updateEncounterInfoBubble,
+    updateFishingInfoBubble,
+    updateInfoBubbles,
+    updatePokeNavInfoBubble
+} from "./content/info-bubbles.js";
+import {hideCurrentEncounterStats, showCurrentEncounterStats} from "./content/current-encounter-stats.js";
+import {updateInputs} from "./content/inputs.js";
+import {updateClock} from "./content/clock.js";
+
+const BATTLE_STATES = ["BATTLE_STARTING", "BATTLE", "BATTLE_ENDING"];
+
+let clockUpdateInterval;
+let fetchStatsAfterSummaryScreenTimeout;
+let hideEncounterStatsTimeout;
+
+let isInBattle = false;
+let isInEggHatch = false;
+let isInSummaryScreen = false;
+let isInMainMenu = false;
+let wasShinyEncounter = false;
+
+/** @param {OverlayState} state */
+async function doFullUpdate(state) {
+    await loadAllData(state);
+
+    isInBattle = BATTLE_STATES.includes(state.gameState);
+    isInEggHatch = state.gameState === "EGG_HATCH";
+    isInSummaryScreen = state.gameState === "POKEMON_SUMMARY_SCREEN";
+    isInMainMenu = state.gameState === "MAIN_MENU" || state.gameState === "TITLE_SCREEN";
+
+    updateMapName(state.map);
+    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies);
+    updateSectionChecklist(config.sectionChecklist, state.stats);
+    updateShinyLog(state.shinyLog);
+    updateEncounterLog(state.encounterLog);
+    updatePartyList(state.party);
+    updateBadgeList(state.emulator.game.title, state.eventFlags);
+    updatePhaseStats(state.stats);
+    updatePCStorage(state.pokemonStorage, state.party);
+    updateTotalStats(state.stats, state.encounterRate);
+    updateInfoBubbles(state.mapEncounters, state.stats, config.targetTimers, state.lastEncounterType, state.party);
+}
+
+/**
+ * @param {OverlayState} state
+ * @returns {Promise<void>}
+ */
+async function doUpdateAfterEncounter(state) {
+    if (wasShinyEncounter) {
+        wasShinyEncounter = false;
+        const [stats, shinyLog] = await Promise.all([fetchers.stats(), fetchers.shinyLog()]);
+        state.stats = stats;
+        state.shinyLog = shinyLog;
+
+        updateShinyLog(state.shinyLog);
+        updateSectionChecklist(config.sectionChecklist, state.stats);
+        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies);
+        updatePhaseStats(state.stats);
+        updateTotalStats(state.stats, state.encounterRate);
+        updatePokeNavInfoBubble(null);
+    }
+}
+
+/**
+ * @param {StreamEvents.PerformanceData} event
+ * @param {OverlayState} state
+ */
+function handlePerformanceData(event, state) {
+    state.encounterRate = event.encounter_rate;
+    updateTotalStats(state.stats, state.encounterRate);
+}
+
+/**
+ * @param {StreamEvents.GameState} event
+ * @param {OverlayState} state
+ */
+function handleGameState(event, state) {
+    state.gameState = event;
+
+    // We do not update the party list while we are in the egg-hatching
+    // animation (to avoid spoilers) so we need to update it once that
+    // game mode ended.
+    if (isInEggHatch && state.gameState !== "EGG_HATCH") {
+        updatePartyList(state.party);
+        isInEggHatch = false;
+    } else if (!isInEggHatch && state.gameState === "EGG_HATCH") {
+        isInEggHatch = true;
+    }
+
+    // If we detect that the game was in the main menu, that means the
+    // game has been reset and all data might have changed (due to the
+    // save game being reloaded.) So once the game is back in the
+    // overworld, we will update _all_ data.
+    if (isInMainMenu && state.gameState === "OVERWORLD") {
+        doFullUpdate(state);
+        isInMainMenu = false;
+    } else if (!isInMainMenu && ["TITLE_SCREEN", "MAIN_MENU"].includes(state.gameState)) {
+        isInMainMenu = true;
+        if (fetchStatsAfterSummaryScreenTimeout) {
+            window.clearTimeout(fetchStatsAfterSummaryScreenTimeout);
+        }
+    }
+
+    // If we enter a Pokémon summary screen, that probably means that we received
+    // a new gift Pokémon and should reload the shiny log.
+    if (isInSummaryScreen && state.gameState !== "POKEMON_SUMMARY_SCREEN") {
+        isInSummaryScreen = false;
+    } else if (!isInSummaryScreen && state.gameState === "POKEMON_SUMMARY_SCREEN") {
+        isInSummaryScreen = true;
+        fetchStatsAfterSummaryScreenTimeout = window.setTimeout(
+            () => doUpdateAfterEncounter(state),
+            1000);
+    }
+
+    // After exiting a battle, we might need to update the shiny log, and also
+    // hide the encounter stats again.
+    if (isInBattle && state.gameState === "OVERWORLD") {
+        hideCurrentEncounterStats();
+        doUpdateAfterEncounter(state).then(() => {});
+        isInBattle = false;
+    } else if (!isInBattle && BATTLE_STATES.includes(state.gameState)) {
+        isInBattle = true;
+    }
+}
+
+/**
+ * @param {StreamEvents.Party} event
+ * @param {OverlayState} state
+ */
+function handleParty(event, state) {
+    state.party = event;
+    if (!isInEggHatch) {
+        updatePartyList(event);
+    }
+}
+
+/**
+ * @param {StreamEvents.WildEncounter} event
+ * @param {OverlayState} state
+ */
+function handleWildEncounter(event, state) {
+    if (hideEncounterStatsTimeout) {
+        window.clearTimeout(hideEncounterStatsTimeout);
+    }
+
+    state.logEncounter(event);
+    if (!WILD_ENCOUNTER_TYPES.includes(event.type)) {
+        hideEncounterStatsTimeout = window.setTimeout(() => hideCurrentEncounterStats(), 1000 * config.nonBattleEncounterStatsTimeoutInSeconds);
+    }
+
+    if (event.pokemon.is_shiny) {
+        wasShinyEncounter = true;
+    }
+
+    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies, event.pokemon.species_name_for_stats);
+    updatePhaseStats(state.stats);
+    updateTotalStats(state.stats, state.encounterRate);
+    updateEncounterInfoBubble(event.pokemon.species_name_for_stats, state.stats);
+    updateInfoBubbles(state.mapEncounters, state.stats, config.targetTimers, event.type, state.party);
+    updateEncounterLog(state.encounterLog);
+    showCurrentEncounterStats(event);
+}
+
+/**
+ * @param {StreamEvents.MapChange} event
+ * @param {OverlayState} state
+ */
+function handleMapChange(event, state) {
+    state.logNewMap(event);
+
+    updateMapName(event);
+    hideFishingInfoBubble();
+    state.additionalRouteSpecies.clear();
+    if (state.lastEncounter && ["hatched", "gift", "static"].includes(state.lastEncounter.type)) {
+        state.additionalRouteSpecies.add(state.lastEncounter.pokemon.species_name_for_stats);
+    }
+}
+
+/**
+ * @param {StreamEvents.MapEncounters} event
+ * @param {OverlayState} state
+ */
+function handleMapEncounters(event, state) {
+    state.mapEncounters = event;
+    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies);
+}
+
+/**
+ * @param {StreamEvents.PlayerAvatar} event
+ * @param {OverlayState} state
+ */
+function handlePlayerAvatar(event, state) {
+    if (state.logPlayerAvatarChange(event)) {
+        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies);
+    }
+}
+
+/**
+ * @param {OverlayState} state
+ */
+function handlePokenavCall(state) {
+    state.logPokenavCall()
+    updatePokeNavInfoBubble(state.stats);
+}
+
+/**
+ * @param {StreamEvents.FishingAttempt} event
+ * @param {OverlayState} state
+ */
+function handleFishingAttempt(event, state) {
+    state.logFishingAttempt(event);
+    updateFishingInfoBubble(state.stats, state.lastFishingRod);
+}
+
+/**
+ * @param {StreamEvents.Inputs} event
+ * @param {OverlayState} state
+ */
+function handleInputs(event, state) {
+    updateInputs(event);
+}
+
+
+export default async function runOverlay() {
+    const state = new OverlayState();
+    window.overlayState = state;
+
+    clockUpdateInterval = window.setInterval(() => {
+        updateClock(config.startDate, config.timeZone, config.overrideDisplayTimezone);
+        if (new Date().getSeconds() === 0) {
+            // These things need to be updated once a minute because they might
+            // display timers at a minute resolution.
+            updateShinyLog(state.shinyLog);
+            updatePhaseStats(state.stats);
+        }
+    }, 1000);
+    updateClock(config.startDate, config.timeZone, config.overrideDisplayTimezone);
+
+    await doFullUpdate(state);
+    const eventSource = getEventSource();
+
+    eventSource.addEventListener("PerformanceData", event => handlePerformanceData(JSON.parse(event.data), state));
+    eventSource.addEventListener("GameState", event => handleGameState(JSON.parse(event.data), state));
+    eventSource.addEventListener("Party", event => handleParty(JSON.parse(event.data), state));
+    eventSource.addEventListener("WildEncounter", event => handleWildEncounter(JSON.parse(event.data), state));
+    eventSource.addEventListener("MapChange", event => handleMapChange(JSON.parse(event.data), state));
+    eventSource.addEventListener("MapEncounters", event => handleMapEncounters(JSON.parse(event.data), state));
+    eventSource.addEventListener("PlayerAvatar", event => handlePlayerAvatar(JSON.parse(event.data), state));
+    eventSource.addEventListener("PokenavCall", event => handlePokenavCall(state));
+    eventSource.addEventListener("FishingAttempt", event => handleFishingAttempt(JSON.parse(event.data), state));
+    eventSource.addEventListener("Inputs", event => handleInputs(JSON.parse(event.data), state));
+}

--- a/modules/web/static/stream-overlay/state.js
+++ b/modules/web/static/stream-overlay/state.js
@@ -1,0 +1,341 @@
+export const WILD_ENCOUNTER_TYPES = [
+    "land",
+    "surfing",
+    "fishing_old_rod",
+    "fishing_good_rod",
+    "fishing_super_rod",
+    "rock_smash"
+];
+
+const ENCOUNTER_LOG_LENGTH = 8;
+
+export default class OverlayState {
+    /** @type {GlobalStats} */
+    stats = {
+        pokemon: {},
+        totals: {
+            total_encounters: 0,
+            shiny_encounters: 0,
+            catches: 0,
+            total_highest_iv_sum: null,
+            total_lowest_iv_sum: null,
+            total_highest_sv: null,
+            total_lowest_sv: null,
+            phase_encounters: 0,
+            phase_highest_iv_sum: null,
+            phase_lowest_iv_sum: null,
+            phase_highest_sv: null,
+            phase_lowest_sv: null,
+        },
+        current_phase: {
+            start_time: 0,
+            encounters: 0,
+            highest_iv_sum: null,
+            lowest_iv_sum: null,
+            highest_sv: null,
+            lowest_sv: null,
+            longest_streak: null,
+            current_streak: null,
+            fishing_attempts: 0,
+            successful_fishing_attempts: 0,
+            longest_unsuccessful_fishing_streak: 0,
+            current_unsuccessful_fishing_streak: 0,
+            pokenav_calls: 0,
+        },
+        longest_phase: null,
+        shortest_phase: null,
+        pickup_items: {},
+    };
+
+    /** @type {MapLocation|null} */
+    map = null;
+
+    /** @type {PokeBotApi.GetMapEncountersResponse|null} */
+    mapEncounters = null;
+
+    /** @type {ShinyPhase[]} */
+    shinyLog = [];
+
+    /** @type {Encounter[]} */
+    encounterLog = [];
+
+    /** @type {PlayerAvatarType|null} */
+    playerAvatar = null;
+
+    /** @type {Pokemon[]} */
+    party = [];
+
+    /** @type {PokeBotApi.GetEmulatorResponse} */
+    emulator = {
+        emulation_speed: 1,
+        video_enabled: true,
+        audio_enabled: true,
+        bot_mode: "Manual",
+        current_message: "",
+        frame_count: 0,
+        current_fps: 0,
+        current_time_spent_in_bot_fraction: 0,
+        profile: {name: ""},
+        game: null,
+    };
+
+    /** @type {PokeBotApi.GetEventFlagsResponse} */
+    eventFlags = {};
+
+    /** @type {number} */
+    encounterRate = 0;
+
+    /** @type {string} */
+    gameState = "UNKNOWN";
+
+    /** @type {PokemonStorage} */
+    pokemonStorage = {
+        active_box_index: 0,
+        pokemon_count: 0,
+        boxes: [],
+    };
+
+    /** @type {Set<string>} */
+    additionalRouteSpecies = new Set();
+
+    /** @type {"Old" | "Good" | "Super"} */
+    lastFishingRod = "Old";
+
+    /** @type {string|null} */
+    #cachedLastEncounterType = null;
+
+    /** @type {Encounter|null} */
+    #cachedLastEncounter = null;
+
+    reset() {
+        this.additionalRouteSpecies.clear();
+        this.#cachedLastEncounterType = null;
+        this.#cachedLastEncounter = null;
+
+        if (this.lastEncounter && ["hatched", "gift", "static"].includes(this.lastEncounter.type)) {
+            this.additionalRouteSpecies.add(this.lastEncounter.pokemon.species_name_for_stats);
+        }
+    }
+
+    /** @return {Encounter|null} */
+    get lastEncounter() {
+        if (this.#cachedLastEncounter) {
+            return this.#cachedLastEncounter;
+        } else if (this.encounterLog.length > 0) {
+            this.#cachedLastEncounter = this.encounterLog[0];
+            return this.encounterLog[0];
+        } else {
+            return null;
+        }
+    }
+
+    get lastEncounterType() {
+        if (this.#cachedLastEncounterType === null) {
+            if (this.lastEncounter === null || this.gameState === "MAIN_MENU" || this.gameState === "TITLE_SCREEN") {
+                return "land";
+            }
+
+            this.additionalRouteSpecies.clear();
+
+            if (WILD_ENCOUNTER_TYPES.includes(this.lastEncounter.type)) {
+                this.#cachedLastEncounterType = this.lastEncounter.type;
+            } else if (["hatched", "gift", "static"].includes(this.lastEncounter.type)) {
+                this.additionalRouteSpecies.add(this.lastEncounter.pokemon.species_name_for_stats)
+            }
+
+            if (this.#cachedLastEncounterType === "land" && this.playerAvatar && this.playerAvatar.flags.Surfing) {
+                this.#cachedLastEncounterType = "surfing";
+            } else if (this.#cachedLastEncounterType === "surfing" && this.playerAvatar && !this.playerAvatar.flags.Surfing) {
+                this.#cachedLastEncounterType = "land";
+            }
+        }
+
+        return this.#cachedLastEncounterType;
+    }
+
+    /** @param {StreamEvents.WildEncounter} encounter */
+    logEncounter(encounter) {
+        this.#cachedLastEncounter = encounter;
+        if (WILD_ENCOUNTER_TYPES.includes(encounter.type)) {
+            this.#cachedLastEncounterType = encounter.type;
+        }
+
+        const speciesName = encounter.pokemon.species_name_for_stats;
+
+        if (["hatched", "gift", "static"].includes(encounter.type)) {
+            this.additionalRouteSpecies.add(speciesName);
+        }
+
+        this.encounterLog.unshift(encounter);
+        while (this.encounterLog.length > ENCOUNTER_LOG_LENGTH) {
+            this.encounterLog.pop();
+        }
+
+        const sv = encounter.pokemon.shiny_value;
+        const ivSum =
+            encounter.pokemon.ivs.hp +
+            encounter.pokemon.ivs.attack +
+            encounter.pokemon.ivs.defence +
+            encounter.pokemon.ivs.special_attack +
+            encounter.pokemon.ivs.special_defence +
+            encounter.pokemon.ivs.speed;
+
+        const updateStreak = (type, section, streak_name, species_name, value) => {
+            let isNewRecord = false;
+            if (type === "min" && value < this.stats[section][streak_name]?.value) {
+                isNewRecord = true;
+            } else if (type === "max" && value > this.stats[section][streak_name]?.value) {
+                isNewRecord = true;
+            }
+
+            if (!this.stats[section][streak_name] || !this.stats[section][streak_name]?.species_name || isNewRecord) {
+                this.stats[section][streak_name] = {species_name, value};
+            }
+        }
+
+        this.stats.totals.total_encounters++;
+        updateStreak("max", "totals", "total_highest_iv_sum", encounter.pokemon.species.name, ivSum);
+        updateStreak("min", "totals", "total_lowest_iv_sum", encounter.pokemon.species.name, ivSum);
+        updateStreak("max", "totals", "total_highest_sv", encounter.pokemon.species.name, sv);
+        updateStreak("min", "totals", "total_lowest_isv", encounter.pokemon.species.name, sv);
+
+        this.stats.totals.phase_encounters++;
+        updateStreak("max", "totals", "phase_highest_iv_sum", encounter.pokemon.species.name, ivSum);
+        updateStreak("min", "totals", "phase_lowest_iv_sum", encounter.pokemon.species.name, ivSum);
+        updateStreak("max", "totals", "phase_highest_sv", encounter.pokemon.species.name, sv);
+        updateStreak("min", "totals", "phase_lowest_isv", encounter.pokemon.species.name, sv);
+
+        if (!this.stats.pokemon[speciesName]) {
+            this.stats.pokemon[speciesName] = {
+                species_id: encounter.pokemon.species.index,
+                species_name: encounter.pokemon.species.name,
+                total_encounters: 1,
+                shiny_encounters: encounter.pokemon.is_shiny ? 1 : 0,
+                catches: 0,
+                total_highest_iv_sum: ivSum,
+                total_lowest_iv_sum: ivSum,
+                total_highest_sv: sv,
+                total_lowest_sv: sv,
+                phase_encounters: 1,
+                phase_highest_iv_sum: ivSum,
+                phase_lowest_iv_sum: ivSum,
+                phase_highest_sv: sv,
+                phase_lowest_sv: sv,
+                last_encounter_time: new Date().toISOString(),
+            };
+        } else {
+            this.stats.pokemon[speciesName].total_encounters++;
+            this.stats.pokemon[speciesName].phase_encounters++;
+            this.stats.pokemon[speciesName].last_encounter_time = new Date().toISOString();
+            if (this.stats.pokemon[speciesName].total_highest_iv_sum < ivSum) {
+                this.stats.pokemon[speciesName].total_highest_iv_sum = ivSum;
+            }
+            if (this.stats.pokemon[speciesName].total_lowest_iv_sum > ivSum) {
+                this.stats.pokemon[speciesName].total_lowest_iv_sum = ivSum;
+            }
+            if (this.stats.pokemon[speciesName].total_highest_sv < sv) {
+                this.stats.pokemon[speciesName].total_highest_sv = sv;
+            }
+            if (this.stats.pokemon[speciesName].total_lowest_sv > sv) {
+                this.stats.pokemon[speciesName].total_lowest_sv = sv;
+            }
+            if (this.stats.pokemon[speciesName].phase_highest_iv_sum === null || this.stats.pokemon[speciesName].phase_highest_iv_sum < ivSum) {
+                this.stats.pokemon[speciesName].phase_highest_iv_sum = ivSum;
+            }
+            if (this.stats.pokemon[speciesName].phase_lowest_iv_sum === null || this.stats.pokemon[speciesName].phase_lowest_iv_sum > ivSum) {
+                this.stats.pokemon[speciesName].phase_lowest_iv_sum = ivSum;
+            }
+            if (this.stats.pokemon[speciesName].phase_highest_sv === null || this.stats.pokemon[speciesName].phase_highest_sv < sv) {
+                this.stats.pokemon[speciesName].phase_highest_sv = sv;
+            }
+            if (this.stats.pokemon[speciesName].phase_lowest_sv === null || this.stats.pokemon[speciesName].phase_lowest_sv > sv) {
+                this.stats.pokemon[speciesName].phase_lowest_sv = sv;
+            }
+        }
+
+        this.stats.current_phase.encounters++;
+        updateStreak("max", "current_phase", "highest_iv_sum", encounter.pokemon.species.name, ivSum);
+        updateStreak("min", "current_phase", "lowest_iv_sum", encounter.pokemon.species.name, ivSum);
+        updateStreak("max", "current_phase", "highest_sv", encounter.pokemon.species.name, sv);
+        updateStreak("min", "current_phase", "lowest_sv", encounter.pokemon.species.name, sv);
+
+        if (this.stats.current_phase?.current_streak?.species_name === encounter.pokemon.species.name) {
+            this.stats.current_phase.current_streak.value++;
+        } else {
+            this.stats.current_phase.current_streak = {
+                species_name: encounter.pokemon.species.name,
+                value: 1,
+            };
+        }
+        if (!this.stats.current_phase?.longest_streak?.species_name || this.stats.current_phase.longest_streak.value < this.stats.current_phase.current_streak.value) {
+            this.stats.current_phase.longest_streak = {
+                species_name: this.stats.current_phase.current_streak.species_name,
+                value: this.stats.current_phase.current_streak.value,
+            };
+        }
+
+        if (encounter.pokemon.is_shiny) {
+            this.stats.totals.shiny_encounters++;
+            this.stats.pokemon[speciesName].shiny_encounters++;
+
+            for (const species in this.stats.pokemon) {
+                this.stats.pokemon[species].phase_encounters = 0;
+                this.stats.pokemon[species].phase_highest_iv_sum = null;
+                this.stats.pokemon[species].phase_lowest_iv_sum = null;
+                this.stats.pokemon[species].phase_encounters = null;
+                this.stats.pokemon[species].phase_encounters = null;
+            }
+        }
+    }
+
+    /** @param {StreamEvents.FishingAttempt} attempt */
+    logFishingAttempt(attempt) {
+        this.stats.current_phase.fishing_attempts++;
+        if (attempt.result === "Encounter") {
+            this.stats.current_phase.successful_fishing_attempts++;
+            this.stats.current_phase.current_unsuccessful_fishing_streak = 0;
+        } else {
+            this.stats.current_phase.current_unsuccessful_fishing_streak++;
+            if (this.stats.current_phase.longest_unsuccessful_fishing_streak < this.stats.current_phase.current_unsuccessful_fishing_streak) {
+                this.stats.current_phase.longest_unsuccessful_fishing_streak = this.stats.current_phase.current_unsuccessful_fishing_streak
+            }
+        }
+
+        if (attempt.rod === "GoodRod") {
+            this.lastFishingRod = "Good";
+        } else if (attempt.rod === "SuperRod") {
+            this.lastFishingRod = "Super";
+        } else {
+            this.lastFishingRod = "Old";
+        }
+    }
+
+    logPokenavCall() {
+        this.stats.current_phase.pokenav_calls++;
+    }
+
+    /** @param {StreamEvents.MapChange} map */
+    logNewMap(map) {
+        this.map = map.map;
+        this.additionalRouteSpecies.clear();
+        if (this.lastEncounter && ["hatched", "gift", "static"].includes(this.lastEncounter.type) && !this.additionalRouteSpecies.has(this.lastEncounter.pokemon.species_name_for_stats)) {
+            this.additionalRouteSpecies.add(this.lastEncounter.pokemon.species_name_for_stats);
+        }
+    }
+
+    /**
+     * @param {StreamEvents.PlayerAvatar} data
+     * @return {boolean} If the last encounter type has changed.
+     * */
+    logPlayerAvatarChange(data) {
+        this.playerAvatar = data;
+        if (this.lastEncounterType === "land" && data.flags.Surfing) {
+            this.#cachedLastEncounterType = "surfing";
+            return true;
+        } else if (this.lastEncounterType === "surfing" && !data.flags.Surfing) {
+            this.#cachedLastEncounterType = "land";
+            return true;
+        }
+        return false;
+    }
+}

--- a/modules/web/static/stream_events.d.ts
+++ b/modules/web/static/stream_events.d.ts
@@ -1,4 +1,4 @@
-import {MapLocation, Pokemon, Player as PlayerType, Pokedex as PokedexType} from "./pokemon";
+import {MapLocation, Pokemon, Player as PlayerType, Pokedex as PokedexType, PlayerAvatarType} from "./pokemon";
 import {EffectiveEncounterList, Encounter, RegularEncounterList} from "./stats";
 
 declare namespace StreamEvents {
@@ -23,7 +23,7 @@ declare namespace StreamEvents {
     // Contains some basic data about the player (such as name, IDs, current money, ...)
     export type Player = PlayerType;
 
-    export type PlayerAvatar = PlayerType;
+    export type PlayerAvatar = PlayerAvatarType;
 
     // Lists Pokémon in the current party. May contain between 0 and 6 entries.
     export type Party = Pokemon[];


### PR DESCRIPTION
### Description

The new overlay didn't properly display shiny encounters for the fossil resurrection mode and also didn't work quite right with the new 'check gender via the nicknaming screen' method.

This has been fixed, and the quite unweildy `connection.js` has been refactored into... well, several unwieldy files.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
