### PR TITLE
Some more overlay fixes and tweaks

### DIFF
--- a/modules/web/static/stream-overlay/content/info-bubbles.js
+++ b/modules/web/static/stream-overlay/content/info-bubbles.js
@@ -102,7 +102,10 @@ function updateInfoBubbles(mapEncounters, stats, targetTimers, lastEncounterType
         sprite.classList.add("icon-species");
 
         if (FOSSIL_SPECIES.includes(speciesName)) {
-            sprite.classList.add("female");
+            const femaleIcon = document.createElement("img");
+            femaleIcon.src = "/static/sprites/other/Female.png";
+            femaleIcon.classList.add("icon-female");
+            bubble.append(femaleIcon);
         }
 
         let span = document.createElement("span");

--- a/modules/web/static/stream-overlay/content/info-bubbles.js
+++ b/modules/web/static/stream-overlay/content/info-bubbles.js
@@ -15,10 +15,14 @@ const infoBubbleFailedFishingRecord = document.querySelector("#info-bubble-faile
 const infoBubblePokeNav = document.querySelector("#info-bubble-pokenav");
 const infoBubblePokeNavCalls = document.querySelector("#info-bubble-pokenav span");
 
+const FOSSIL_SPECIES = ["Anorith", "Lileep", "Omanyte", "Kabuto", "Aerodactyl"];
+
 let lastSetAbility = null;
 let lastRepelLevel = null;
 /** @type {{[k: string]: [HTMLDivElement, HTMLSpanElement, number, number | undefined]}} */
 const targetTimerBubbles = {};
+/** @type {Date | null} */
+let lastFemale = null;
 
 /**
  * @param {StreamEvents.MapEncounters} mapEncounters
@@ -96,6 +100,11 @@ function updateInfoBubbles(mapEncounters, stats, targetTimers, lastEncounterType
 
         const sprite = speciesSprite(speciesName, "normal", true);
         sprite.classList.add("icon-species");
+
+        if (FOSSIL_SPECIES.includes(speciesName)) {
+            sprite.classList.add("female");
+        }
+
         let span = document.createElement("span");
         if (isFirst) {
             bubble.append(span, sprite);
@@ -116,14 +125,15 @@ function updateInfoBubbles(mapEncounters, stats, targetTimers, lastEncounterType
 /**
  * @param {string} speciesName
  * @param {PokeBotApi.GetStatsResponse} stats
+ * @param {"male" | "female" | null} [encounterGender]
  */
-function updateEncounterInfoBubble(speciesName, stats) {
+function updateEncounterInfoBubble(speciesName, stats, encounterGender) {
     if (!targetTimerBubbles.hasOwnProperty(speciesName)) {
         return;
     }
 
     if (!stats.pokemon.hasOwnProperty(speciesName)) {
-        targetTimerBubbles[speciesName][1].style.display = "none";
+        targetTimerBubbles[speciesName][0].style.display = "none";
         targetTimerBubbles[speciesName][1].innerText = "?";
         return;
     }
@@ -132,7 +142,20 @@ function updateEncounterInfoBubble(speciesName, stats) {
         window.clearTimeout(targetTimerBubbles[speciesName][3]);
     }
 
-    const diffInMS = new Date().getTime() - new Date(stats.pokemon[speciesName].last_encounter_time).getTime();
+    let lastEncounterTime = new Date(stats.pokemon[speciesName].last_encounter_time);
+    if (FOSSIL_SPECIES.includes(speciesName)) {
+        if (encounterGender === "female") {
+            lastFemale = new Date();
+        }
+        lastEncounterTime = lastFemale;
+
+        if (lastEncounterTime === null) {
+            targetTimerBubbles[speciesName][1].innerText = "?";
+            return;
+        }
+    }
+
+    const diffInMS = new Date().getTime() - lastEncounterTime.getTime();
     const diffInMinutes = Math.floor(diffInMS / 60000);
     if (targetTimerBubbles[speciesName][2] !== diffInMinutes) {
         targetTimerBubbles[speciesName][2] = diffInMinutes;
@@ -149,7 +172,9 @@ function updateEncounterInfoBubble(speciesName, stats) {
     }
 
     const msUntilNextMinute = ((diffInMinutes + 1) * 60000) - diffInMS;
-    window.setTimeout(() => updateEncounterInfoBubble(speciesName, stats), msUntilNextMinute + 1)
+    targetTimerBubbles[speciesName][3] = window.setTimeout(
+        () => updateEncounterInfoBubble(speciesName, stats),
+        msUntilNextMinute + 1);
 }
 
 /**
@@ -183,4 +208,10 @@ function updatePokeNavInfoBubble(stats) {
     }
 }
 
-export {updateInfoBubbles, updateEncounterInfoBubble, updateFishingInfoBubble, hideFishingInfoBubble, updatePokeNavInfoBubble};
+export {
+    updateInfoBubbles,
+    updateEncounterInfoBubble,
+    updateFishingInfoBubble,
+    hideFishingInfoBubble,
+    updatePokeNavInfoBubble
+};

--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -141,7 +141,7 @@ const updateRouteEncountersList = (encounters, stats, encounterType, checklistCo
         }
 
         tbody.append(renderTableRow({
-            sprite: speciesSprite(encounter.species_name, "shiny", encounter.species_name === animateSpecies),
+            sprite: speciesSprite(encounter.species_name, "normal", encounter.species_name === animateSpecies),
             odds: encounter.encounter_rate > 0 ? Math.round(encounter.encounter_rate * 100) + "%" : "",
             svRecords: species && species.phase_lowest_sv && species.phase_highest_sv
                 ? [colouredShinyValue(species.phase_lowest_sv), br(), colouredShinyValue(species.phase_highest_sv)]

--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -115,7 +115,7 @@ const updateRouteEncountersList = (encounters, stats, encounterType, checklistCo
             }
             totalEncounters = [formatInteger(species.total_encounters)];
 
-            if (species.catches > 0) {
+            if (species.shiny_encounters > 0) {
                 const shinyRate = Math.round(species.total_encounters / species.shiny_encounters).toLocaleString("en");
                 const shinyRateLabel = document.createElement("span");
                 shinyRateLabel.classList.add("shiny-rate");

--- a/modules/web/static/stream-overlay/content/section-checklist.js
+++ b/modules/web/static/stream-overlay/content/section-checklist.js
@@ -38,6 +38,7 @@ const updateSectionChecklist = (checklistConfig, stats) => {
 
             elements.sprite.setAttribute("species", speciesName);
             elements.sprite.setAttribute("cropped", "cropped");
+            elements.sprite.setAttribute("shiny", "shiny");
 
             const span = document.createElement("span");
             span.append(elements.countSpan);

--- a/modules/web/static/stream-overlay/layout/info-bubbles.css
+++ b/modules/web/static/stream-overlay/layout/info-bubbles.css
@@ -52,6 +52,23 @@
                     background-size: contain;
                 }
             }
+
+            &.female {
+                position: relative;
+
+                &::after {
+                    content: "";
+                    height: 33%;
+                    width: 100%;
+                    position: absolute;
+                    bottom: 10%;
+                    right: 7px;
+                    background-image: url("/static/sprites/other/Female.png");
+                    background-position: center;
+                    background-repeat: no-repeat;
+                    background-size: contain;
+                }
+            }
         }
 
         item-sprite, overlay-sprite {

--- a/modules/web/static/stream-overlay/layout/info-bubbles.css
+++ b/modules/web/static/stream-overlay/layout/info-bubbles.css
@@ -25,6 +25,12 @@
             transform: scale(2.5);
         }
 
+        .icon-female {
+            height: 1.5vh;
+            margin-right: .75vh;
+            transform: translateY(.25vh);
+        }
+
         item-sprite, overlay-sprite, pokemon-sprite {
             display: inline-block;
             vertical-align: middle;
@@ -48,23 +54,6 @@
                     right: 0;
                     background-image: url("/static/sprites/stream-overlay/cross.png");
                     background-position: center right;
-                    background-repeat: no-repeat;
-                    background-size: contain;
-                }
-            }
-
-            &.female {
-                position: relative;
-
-                &::after {
-                    content: "";
-                    height: 33%;
-                    width: 100%;
-                    position: absolute;
-                    bottom: 10%;
-                    right: 7px;
-                    background-image: url("/static/sprites/other/Female.png");
-                    background-position: center;
                     background-repeat: no-repeat;
                     background-size: contain;
                 }

--- a/modules/web/static/stream-overlay/layout/party-list.css
+++ b/modules/web/static/stream-overlay/layout/party-list.css
@@ -1,7 +1,10 @@
 #party-list {
-    flex: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
 
     ul {
+        flex: 1;
         margin: -.5vh .5vw 1vh;
         padding: 0;
         display: flex;

--- a/modules/web/static/stream-overlay/overlay.js
+++ b/modules/web/static/stream-overlay/overlay.js
@@ -168,7 +168,7 @@ function handleWildEncounter(event, state) {
     updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies, event.pokemon.species_name_for_stats);
     updatePhaseStats(state.stats);
     updateTotalStats(state.stats, state.encounterRate);
-    updateEncounterInfoBubble(event.pokemon.species_name_for_stats, state.stats);
+    updateEncounterInfoBubble(event.pokemon.species_name_for_stats, state.stats, event.pokemon.gender);
     updateInfoBubbles(state.mapEncounters, state.stats, config.targetTimers, event.type, state.party);
     updateEncounterLog(state.encounterLog);
     showCurrentEncounterStats(event);


### PR DESCRIPTION
### Description

- Timers no longer go crazy
- Timers for fossil species (Lileep, Anorith, Omanyte, Kabuto, and Aerodactyl) only advance for female encounters and get an extra 'female' icon   
  ![image](https://github.com/user-attachments/assets/9dce862e-e190-4eb3-ba3c-de080e6b3d83)
- Shiny average is displayed even if all shiny encounters were missed (right now the number of _catches_ must be 1+, which doesn't work with the Anorith hunt)
- Route encounters (box at the very top) now uses non-shiny sprites, and the section checklist (box below, with the 'tiles') shows shiny sprites instead. Seems to make more sense to me.
- Party box now always uses all available height, instead of shrinking depending on the size of the sprites and leaving a gap in the Phase Stats box
![image](https://github.com/user-attachments/assets/5aa88c1e-2e1a-4cca-9269-0912fa8f4a91)


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
