### PR TITLE
Use anti-shiny sprites in new overlay

### DIFF
--- a/modules/web/static/stream-overlay/component/pokemon-sprite.js
+++ b/modules/web/static/stream-overlay/component/pokemon-sprite.js
@@ -425,6 +425,7 @@ export default class PokemonSprite extends HTMLElement {
         /** @type {HTMLImageElement | null} */
         this.sprite = null;
         this.shiny = false;
+        this.antiShiny = false;
         this.cropped = false;
         this.continuouslyAnimated = false;
         this.species = null;
@@ -439,6 +440,11 @@ export default class PokemonSprite extends HTMLElement {
 
         if (this.cropped) {
             console.error(`Cannot animate sprite of '${this.species}' because it is cropped.`);
+            return;
+        }
+
+        if (this.antiShiny) {
+            console.error(`Cannot animate sprite of '${this.species}' because it is anti-shiny.`);
             return;
         }
 
@@ -464,7 +470,16 @@ export default class PokemonSprite extends HTMLElement {
 
     attributeChangedCallback(name, oldValue, newValue) {
         if (name === "shiny") {
-            this.shiny = newValue !== null;
+            if (newValue === "anti") {
+                this.shiny = false;
+                this.antiShiny = true;
+            } else if (newValue !== null && newValue !== "no" && newValue !== "false") {
+                this.shiny = true;
+                this.antiShiny = false;
+            } else {
+                this.shiny = false;
+                this.antiShiny = false;
+            }
         }
 
         if (name === "cropped") {
@@ -482,6 +497,12 @@ export default class PokemonSprite extends HTMLElement {
         let type = this.shiny ? "shiny" : "normal";
         if (this.cropped && !this.continuouslyAnimated) {
             type += "-cropped";
+        }
+        if (this.antiShiny) {
+            console.log(this);
+        }
+        if (!this.cropped && !this.continuouslyAnimated && this.antiShiny) {
+            type = "anti-shiny";
         }
 
         let src = "";

--- a/modules/web/static/stream-overlay/content/encounter-log.js
+++ b/modules/web/static/stream-overlay/content/encounter-log.js
@@ -31,9 +31,16 @@ function updateEncounterLog(encounterLog) {
             entry.pokemon.ivs.special_defence +
             entry.pokemon.ivs.speed;
 
+        let speciesSpriteType = "normal";
+        if (entry.pokemon.is_shiny) {
+            speciesSpriteType = "shiny";
+        } else if (entry.pokemon.is_anti_shiny) {
+            speciesSpriteType = "anti-shiny";
+        }
+
         tbody.append(renderTableRow({
             sprite: [
-                speciesSprite(entry.pokemon.species_name_for_stats, entry.pokemon.is_shiny ? "shiny" : "normal"),
+                speciesSprite(entry.pokemon.species_name_for_stats, speciesSpriteType),
                 genderSprite(entry.pokemon.gender),
                 itemSprite(entry.pokemon.held_item),
             ],

--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -28,8 +28,9 @@ const updateMapName = map => {
  * @param {StreamOverlay.SectionChecklist} checklistConfig
  * @param {Set<string>} [additionalRouteSpecies]
  * @param {string} [animateSpecies]
+ * @param {Set<string>} [antiShinySpecies]
  */
-const updateRouteEncountersList = (encounters, stats, encounterType, checklistConfig, additionalRouteSpecies = null, animateSpecies = null) => {
+const updateRouteEncountersList = (encounters, stats, encounterType, checklistConfig, additionalRouteSpecies = null, animateSpecies = null, antiShinySpecies = null) => {
     /** @type {MapEncounter[]} encounterList */
     let encounterList;
     /** @type {MapEncounter[]} regularEncounterList */
@@ -140,8 +141,15 @@ const updateRouteEncountersList = (encounters, stats, encounterType, checklistCo
             }
         }
 
+        let spriteType = "normal";
+        let animate = encounter.species_name === animateSpecies;
+        if (antiShinySpecies && antiShinySpecies.has(encounter.species_name)) {
+            spriteType = "anti-shiny";
+            animate = false;
+        }
+
         tbody.append(renderTableRow({
-            sprite: speciesSprite(encounter.species_name, "normal", encounter.species_name === animateSpecies),
+            sprite: speciesSprite(encounter.species_name, spriteType, animate),
             odds: encounter.encounter_rate > 0 ? Math.round(encounter.encounter_rate * 100) + "%" : "",
             svRecords: species && species.phase_lowest_sv && species.phase_highest_sv
                 ? [colouredShinyValue(species.phase_lowest_sv), br(), colouredShinyValue(species.phase_highest_sv)]

--- a/modules/web/static/stream-overlay/helper.js
+++ b/modules/web/static/stream-overlay/helper.js
@@ -2,7 +2,7 @@ export const numberOfEncounterLogEntries = 8;
 
 /**
  * @param {string} speciesName
- * @param {"normal" | "shiny" | "normal-cropped" | "shiny-cropped"} [type]
+ * @param {"normal" | "shiny" | "anti-shiny" | "normal-cropped" | "shiny-cropped"} [type]
  * @param {boolean} [animated]
  * @return {string}
  */
@@ -35,7 +35,7 @@ export function eggSpritePath(animated = false) {
 
 /**
  * @param {string} speciesName
- * @param {"normal" | "shiny" | "normal-cropped" | "shiny-cropped"} [type]
+ * @param {"normal" | "shiny" | "anti-shiny" | "normal-cropped" | "shiny-cropped"} [type]
  * @param {boolean} [animated]
  * @return {PokemonSprite}
  */
@@ -44,6 +44,9 @@ export function speciesSprite(speciesName, type = "normal", animated = false) {
     sprite.setAttribute("species", speciesName);
     if (type === "shiny" || type === "shiny-cropped") {
         sprite.setAttribute("shiny", "shiny");
+    }
+    if (type === "anti-shiny") {
+        sprite.setAttribute("shiny", "anti");
     }
     if (type === "shiny-cropped" || type === "normal-cropped") {
         sprite.setAttribute("cropped", "cropped");
@@ -449,4 +452,30 @@ export function getSectionProgress(sectionChecklist, stats) {
     }
 
     return {caught, goal};
+}
+
+/**
+ * @param {Encounter[]|null} encounterLog
+ * @return {boolean}
+ */
+export function getLastEncounterSpecies(encounterLog) {
+    if (Array.isArray(encounterLog) && encounterLog.length > 0) {
+        return encounterLog[0].pokemon.species_name_for_stats;
+    } else {
+        return null;
+    }
+}
+
+/**
+ * @param {Encounter[]} encounterLog
+ * @returns {Set<string>}
+ */
+export function getRecentAntiShinies(encounterLog) {
+    let antiShinySpecies = new Set();
+    for (const previousEncounter of encounterLog) {
+        if (previousEncounter.pokemon.is_anti_shiny) {
+            antiShinySpecies.add(previousEncounter.pokemon.species_name_for_stats);
+        }
+    }
+    return antiShinySpecies;
 }

--- a/modules/web/static/stream-overlay/overlay.js
+++ b/modules/web/static/stream-overlay/overlay.js
@@ -19,6 +19,7 @@ import {
 import {hideCurrentEncounterStats, showCurrentEncounterStats} from "./content/current-encounter-stats.js";
 import {updateInputs} from "./content/inputs.js";
 import {updateClock} from "./content/clock.js";
+import {getLastEncounterSpecies, getRecentAntiShinies} from "./helper.js";
 
 const BATTLE_STATES = ["BATTLE_STARTING", "BATTLE", "BATTLE_ENDING"];
 
@@ -42,7 +43,7 @@ async function doFullUpdate(state) {
     isInMainMenu = state.gameState === "MAIN_MENU" || state.gameState === "TITLE_SCREEN";
 
     updateMapName(state.map);
-    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies);
+    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog), getRecentAntiShinies(state.encounterLog));
     updateSectionChecklist(config.sectionChecklist, state.stats);
     updateShinyLog(state.shinyLog);
     updateEncounterLog(state.encounterLog);
@@ -67,7 +68,7 @@ async function doUpdateAfterEncounter(state) {
 
         updateShinyLog(state.shinyLog);
         updateSectionChecklist(config.sectionChecklist, state.stats);
-        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies);
+        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog), getRecentAntiShinies(state.encounterLog));
         updatePhaseStats(state.stats);
         updateTotalStats(state.stats, state.encounterRate);
         updatePokeNavInfoBubble(null);
@@ -165,7 +166,7 @@ function handleWildEncounter(event, state) {
         wasShinyEncounter = true;
     }
 
-    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies, event.pokemon.species_name_for_stats);
+    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies, event.pokemon.species_name_for_stats, getRecentAntiShinies(state.encounterLog));
     updatePhaseStats(state.stats);
     updateTotalStats(state.stats, state.encounterRate);
     updateEncounterInfoBubble(event.pokemon.species_name_for_stats, state.stats, event.pokemon.gender);
@@ -195,7 +196,7 @@ function handleMapChange(event, state) {
  */
 function handleMapEncounters(event, state) {
     state.mapEncounters = event;
-    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies);
+    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog), getRecentAntiShinies(state.encounterLog));
 }
 
 /**
@@ -204,7 +205,7 @@ function handleMapEncounters(event, state) {
  */
 function handlePlayerAvatar(event, state) {
     if (state.logPlayerAvatarChange(event)) {
-        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies);
+        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog), getRecentAntiShinies(state.encounterLog));
     }
 }
 


### PR DESCRIPTION
### Description

I didn't know that, but apparently the old overlay used the anti-shiny sprite in the encounters list.

I guess I never saw that live, so I didn't implement that again.

Anyway, now that's back.
![image](https://github.com/user-attachments/assets/7a937ee5-8e6e-465c-bbfc-b5fbcc76c959)

And also, for as long as an anti-shiny of a species is visible in the encounter log, it will appear as anti-shiny in the route encounters list.
![image](https://github.com/user-attachments/assets/6ffde2f9-f5e7-45ee-9fa0-afd9310050be)
(It will revert back to the regular sprite after the anti-shiny has been pushed out of the last 8 encounters.)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
