### PR TITLE
Expose pretty map names via API and use them in overlay

### DIFF
--- a/modules/map.py
+++ b/modules/map.py
@@ -1047,10 +1047,23 @@ class MapLocation:
         return result
 
     def dict_for_map(self) -> dict:
+        pretty_name = self.map_name
+        try:
+            from modules.map_data import MapFRLG, MapRSE
+
+            if context.rom.is_frlg:
+                map_enum = MapFRLG(*self.map_group_and_number)
+            else:
+                map_enum = MapRSE(*self.map_group_and_number)
+            pretty_name = map_enum.pretty_name
+        except:
+            pass
+
         return {
             "map_group": self.map_group,
             "map_number": self.map_number,
             "name": self.map_name,
+            "pretty_name": pretty_name,
             "size": self.map_size,
             "type": self.map_type,
             "weather": self.weather,

--- a/modules/web/static/pokemon.d.ts
+++ b/modules/web/static/pokemon.d.ts
@@ -472,8 +472,12 @@ type MapData = {
     map_group: number;
     map_number: number;
 
-    // In-game name of the current map.
+    // In-game name of the current map. For indoor routes, this is the name
+    // of the city/town/route associated with it.
     name: string;
+
+    // A more accurate name based on the pret project's map name constants.
+    pretty_name: string;
 
     // Size in tiles.
     size: [number, number];

--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -18,7 +18,7 @@ const noEncountersMessage = document.querySelector("#no-encounters-on-this-route
  * @param {PokeBotApi.GetMapResponse} map
  */
 const updateMapName = map => {
-    mapNameSpan.innerText = map.map.name;
+    mapNameSpan.innerText = map.map.pretty_name;
 };
 
 /**

--- a/modules/web/static/stream-overlay/index.html
+++ b/modules/web/static/stream-overlay/index.html
@@ -167,7 +167,7 @@
                 <th>Phase<br>Encounters</th>
                 <th>Total<br>Encounters</th>
                 <th><img src="/static/sprites/stream-overlay/sparkles.png">Shinies<img
-                        src="/static/sprites/stream-overlay/sparkles.png"><br>caught
+                        src="/static/sprites/stream-overlay/sparkles.png"><br>obtained
                 </th>
             </tr>
             </thead>


### PR DESCRIPTION
### Description

There is already a function that generates a 'pretty' name for a map -- rather than using the in-game map name (which for indoor areas is just whatever city/route that building is on) it uses a name based on the map name constant from the pret project.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
