### PR TITLE
API/Overlay: Show the real level of Daycare Pokémon

### DIFF
--- a/modules/daycare.py
+++ b/modules/daycare.py
@@ -73,11 +73,25 @@ class DaycareData:
     compatibility: tuple[DaycareCompatibility, str]
 
     def to_dict(self) -> dict:
+        pokemon1_new_level = None
+        if self.pokemon1 is not None:
+            pokemon1_new_level = self.pokemon1.species.level_up_type.get_level_from_total_experience(
+                self.pokemon1.total_exp + self.pokemon1_steps
+            )
+
+        pokemon2_new_level = None
+        if self.pokemon2 is not None:
+            pokemon2_new_level = self.pokemon2.species.level_up_type.get_level_from_total_experience(
+                self.pokemon2.total_exp + self.pokemon2_steps
+            )
+
         return {
             "pokemon1": self.pokemon1.to_dict() if self.pokemon1 else None,
             "pokemon1_steps": self.pokemon1_steps,
+            "pokemon1_new_level": pokemon1_new_level,
             "pokemon2": self.pokemon2.to_dict() if self.pokemon2 else None,
             "pokemon2_steps": self.pokemon1_steps,
+            "pokemon2_new_level": pokemon1_new_level,
             "compatibility": self.compatibility[0].name,
             "compatibility_explanation": self.compatibility[1],
             "step_counter": self.step_counter,

--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -621,7 +621,7 @@ class LevelUpType(Enum):
         :return: The level a Pokémon would have with that amount of EXP
         """
         level = 0
-        while total_experience >= self.get_experience_needed_for_level(level + 1):
+        while level < 100 and total_experience >= self.get_experience_needed_for_level(level + 1):
             level += 1
         return level
 

--- a/modules/web/static/routes.d.ts
+++ b/modules/web/static/routes.d.ts
@@ -116,9 +116,11 @@ declare module PokeBotApi {
     export type GetDaycareResponse = {
         pokemon1: Pokemon;
         pokemon1_steps: number;
+        pokemon1_new_level: number;
 
         pokemon2: Pokemon;
         pokemon2_steps: number;
+        pokemon2_new_level: number;
 
         compatibility: string;
         compatibility_explanation: string;

--- a/modules/web/static/stream-overlay/content/daycare.js
+++ b/modules/web/static/stream-overlay/content/daycare.js
@@ -47,7 +47,12 @@ const updateDaycareBox = (botMode, state) => {
 
     daycareInfoList.innerHTML = "";
 
-    const createPokemonBox = (pokemon) => {
+    /**
+     * @param {Pokemon} pokemon
+     * @param {number} newLevel
+     * @returns {HTMLLIElement}
+     */
+    const createPokemonBox = (pokemon, newLevel) => {
         const li = document.createElement("li");
 
         const sprite = speciesSprite(pokemon.species.name, pokemon.is_shiny ? "shiny-cropped" : "normal-cropped");
@@ -73,7 +78,7 @@ const updateDaycareBox = (botMode, state) => {
         const level = document.createElement("div");
         const levelLabel = document.createElement("small");
         levelLabel.innerText = "Level: ";
-        level.innerText = pokemon.level.toString();
+        level.innerText = newLevel.toString();
         level.prepend(levelLabel);
         li.append(level);
 
@@ -88,11 +93,11 @@ const updateDaycareBox = (botMode, state) => {
     };
 
     if (state.daycare.pokemon1 !== null) {
-        daycareInfoList.append(createPokemonBox(state.daycare.pokemon1));
+        daycareInfoList.append(createPokemonBox(state.daycare.pokemon1, state.daycare.pokemon1_new_level));
     }
 
     if (state.daycare.pokemon2 !== null) {
-        daycareInfoList.append(createPokemonBox(state.daycare.pokemon2));
+        daycareInfoList.append(createPokemonBox(state.daycare.pokemon2, state.daycare.pokemon2_new_level));
     }
 };
 


### PR DESCRIPTION
### Description

It seems like the game only updates the level of Daycare Pokémon once the player tries to pick them up.

So instead, we now calculate the level based on the Pokémon's EXP and steps taken.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
