### PR TITLE
Fix party sprite height in overlay at higher resolutions

### DIFF
--- a/modules/web/static/stream-overlay/layout/party-list.css
+++ b/modules/web/static/stream-overlay/layout/party-list.css
@@ -16,6 +16,7 @@
             flex: 1;
             position: relative;
             text-align: center;
+            height: 100%;
 
             &:first-child {
                 margin-left: 0;
@@ -27,6 +28,8 @@
                     max-height: 4.5vh;
                     margin-bottom: 4px;
                     transform: scale(1.2);
+                    height: 100%;
+                    object-fit: contain;
                 }
 
                 &.fainted img {


### PR DESCRIPTION
### Description

The party sprites in the new overlay got smaller and smaller the higher the resolution was.

At 1080p (which is what I'm testing at) it looks fine, but at 1440p that Cakes uses there's already some empty space:
![image](https://github.com/user-attachments/assets/703ed965-b9c4-461b-b8af-1ccead8bd9bd)


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
