### PR TITLE
Add 'release Pokémon from box' action for PC interaction

### DIFF
--- a/modules/modes/util/pc_interaction.py
+++ b/modules/modes/util/pc_interaction.py
@@ -56,7 +56,7 @@ class PCAction:
 
     @classmethod
     def release_pokemon_from_box(cls, pokemon: Pokemon) -> "PCAction":
-        return cls(PCStorageSection.WithdrawPokemon, PCStorageActionType.ReleaseFromBox, pokemon)
+        return cls(PCStorageSection.MovePokemon, PCStorageActionType.ReleaseFromBox, pokemon)
 
 
 @dataclass
@@ -267,32 +267,6 @@ def _do_withdraw_actions(actions: list[PCAction]) -> Generator:
                 yield
             yield
 
-        if action.action is PCStorageActionType.ReleaseFromBox:
-            box, slot = get_pokemon_storage().get_slot_for_pokemon(action.pokemon)
-
-            yield from _select_box(box)
-            yield from _select_box_slot(slot)
-            while _get_storage_state().state != (2 if not context.rom.is_rs else 1):
-                context.emulator.press_button("A")
-                yield
-            yield from _select_menu_option("RELEASE", _get_storage_menu())
-            context.emulator.press_button("A")
-            yield
-            yield
-            yield
-            if context.rom.is_frlg:
-                yield
-            context.emulator.press_button("Up")
-            yield
-            if context.rom.is_frlg:
-                yield
-            while _get_storage_state().state != 7:
-                context.emulator.press_button("A")
-                yield
-            while _get_storage_state().state != 0:
-                yield
-            yield
-
     yield from _close_pc_menu()
 
 
@@ -391,6 +365,37 @@ def _do_deposit_actions(actions: list[PCAction]) -> Generator:
     yield from _close_pc_menu()
 
 
+def _do_move_pokemon_actions(actions: list[PCAction]) -> Generator:
+    yield from _open_pc_menu(2)
+    for action in actions:
+        if action.action is PCStorageActionType.ReleaseFromBox:
+            box, slot = get_pokemon_storage().get_slot_for_pokemon(action.pokemon)
+
+            yield from _select_box(box)
+            yield from _select_box_slot(slot)
+            while _get_storage_state().state != (2 if not context.rom.is_rs else 1):
+                context.emulator.press_button("A")
+                yield
+            yield from _select_menu_option("RELEASE", _get_storage_menu())
+            context.emulator.press_button("A")
+            yield
+            yield
+            yield
+            if context.rom.is_frlg:
+                yield
+            context.emulator.press_button("Up")
+            yield
+            if context.rom.is_frlg:
+                yield
+            while _get_storage_state().state != 7:
+                context.emulator.press_button("A")
+                yield
+            while _get_storage_state().state != 0:
+                yield
+            yield
+    yield from _close_pc_menu()
+
+
 def interact_with_pc(actions: list[PCAction]) -> Generator:
     targeted_tile = get_player_avatar().map_location_in_front
     if targeted_tile.tile_type != "PC":
@@ -409,6 +414,10 @@ def interact_with_pc(actions: list[PCAction]) -> Generator:
     actions_for_deposit_menu = [action for action in actions if action.section is PCStorageSection.DepositPokemon]
     if len(actions_for_deposit_menu) > 0:
         yield from _do_deposit_actions(actions_for_deposit_menu)
+
+    actions_for_move_pokemon_menu = [action for action in actions if action.section is PCStorageSection.MovePokemon]
+    if len(actions_for_move_pokemon_menu) > 0:
+        yield from _do_move_pokemon_actions(actions_for_move_pokemon_menu)
 
     yield from wait_for_no_script_to_run("B")
     yield from wait_for_player_avatar_to_be_controllable("B")


### PR DESCRIPTION
### Description

Allows bot modes to release Pokémon from a box in the `interact_with_pc()` function.

I'll need that for a mode that gets rid of all the filler Pokémon we're about to catch because of Castform.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
