### PR TITLE
Overlay: Fix checklist not being updated

### DIFF
--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -5,7 +5,7 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Callable, TYPE_CHECKING
 
-from modules.battle_state import get_encounter_type, EncounterType
+from modules.battle_state import get_encounter_type, EncounterType, BattleOutcome
 from modules.console import console, print_stats
 from modules.context import context
 from modules.files import save_pk3, make_string_safe_for_file_name
@@ -37,6 +37,7 @@ class EncounterInfo:
     bot_mode: str
     catch_filters_result: str | None
     battle_action: "BattleAction | None" = None
+    battle_outcome: "BattleOutcome | None" = None
     gif_path: Path | None = None
     tcg_card_path: Path | None = None
 

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -663,6 +663,9 @@ class StatsDatabase:
         self._commit()
         self._next_encounter_id += 1
 
+        if encounter_info.battle_outcome is not None:
+            self.log_end_of_battle(encounter_info.battle_outcome, encounter_info)
+
         return encounter
 
     def clear_current_shiny_phase(self):

--- a/modules/web/static/stream-overlay/content/section-checklist.js
+++ b/modules/web/static/stream-overlay/content/section-checklist.js
@@ -57,30 +57,30 @@ const updateSectionChecklist = (checklistConfig, stats) => {
             ul.append(elements.li);
             speciesListElements[speciesName] = elements;
         }
+    }
 
-        // Updates the data inside the entries.
-        for (const speciesName in checklistConfig) {
-            const configEntry = checklistConfig[speciesName];
-            const elements = speciesListElements[speciesName];
+    // Updates the data inside the entries.
+    for (const speciesName in checklistConfig) {
+        const configEntry = checklistConfig[speciesName];
+        const elements = speciesListElements[speciesName];
 
-            let completion = 0;
-            if (stats.pokemon.hasOwnProperty(speciesName)) {
-                completion += stats.pokemon[speciesName].catches;
-            }
-            if (Array.isArray(configEntry.similarSpecies)) {
-                for (const similarSpecies of configEntry.similarSpecies) {
-                    if (stats.pokemon.hasOwnProperty(similarSpecies)) {
-                        completion += stats.pokemon[similarSpecies].catches;
-                    }
+        let completion = 0;
+        if (stats.pokemon.hasOwnProperty(speciesName)) {
+            completion += stats.pokemon[speciesName].catches;
+        }
+        if (Array.isArray(configEntry.similarSpecies)) {
+            for (const similarSpecies of configEntry.similarSpecies) {
+                if (stats.pokemon.hasOwnProperty(similarSpecies)) {
+                    completion += stats.pokemon[similarSpecies].catches;
                 }
             }
+        }
 
-            elements.countSpan.innerText = formatInteger(completion);
-            if (configEntry.goal && completion >= configEntry.goal && !elements.li.classList.contains("completed")) {
-                elements.li.classList.add("completed");
-            } else if (elements.li.classList.contains("completed")) {
-                elements.li.classList.remove("completed");
-            }
+        elements.countSpan.innerText = formatInteger(completion);
+        if (configEntry.goal && completion >= configEntry.goal && !elements.li.classList.contains("completed")) {
+            elements.li.classList.add("completed");
+        } else if (elements.li.classList.contains("completed")) {
+            elements.li.classList.remove("completed");
         }
 
         // Updates the progress bar.

--- a/modules/web/static/stream-overlay/overlay.js
+++ b/modules/web/static/stream-overlay/overlay.js
@@ -98,6 +98,8 @@ function handleGameState(event, state) {
     // game mode ended.
     if (isInEggHatch && state.gameState !== "EGG_HATCH") {
         updatePartyList(state.party);
+        doUpdateAfterEncounter(state).then(() => {
+        });
         isInEggHatch = false;
     } else if (!isInEggHatch && state.gameState === "EGG_HATCH") {
         isInEggHatch = true;

--- a/modules/web/static/stream-overlay/state.js
+++ b/modules/web/static/stream-overlay/state.js
@@ -290,6 +290,11 @@ export default class OverlayState {
             this.stats.totals.shiny_encounters++;
             this.stats.pokemon[speciesName].shiny_encounters++;
 
+            if (["hatched", "gift", "static"].includes(encounter.type)) {
+                this.stats.totals.catches++;
+                this.stats.pokemon[speciesName].catches++;
+            }
+
             for (const species in this.stats.pokemon) {
                 this.stats.pokemon[species].phase_encounters = 0;
                 this.stats.pokemon[species].phase_highest_iv_sum = null;


### PR DESCRIPTION
### Description

Due to a wrongly scoped `if`, the section checklist in the overlay never got updated. This has been fixed.

In the process of fixing that I've also added some better internal API for plugins to mark hatch/gift encounters as 'caught' (which is important for the overlay)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
