### PR TITLE
Overlay: Make the 'time ago' column in the shiny log show days at 24+ hours

### DIFF
--- a/modules/web/static/stream-overlay/content/shiny-log.js
+++ b/modules/web/static/stream-overlay/content/shiny-log.js
@@ -34,7 +34,7 @@ function updateShinyLog(shinyLog) {
         }
 
         tbody.append(renderTableRow({
-            timeSinceEncounter: diffTime(entry.phase.end_time),
+            timeSinceEncounter: diffTime(entry.phase.end_time, null, true),
             sprite: [
                 sprite,
                 genderSprite(entry.shiny_encounter.pokemon.gender),

--- a/modules/web/static/stream-overlay/helper.js
+++ b/modules/web/static/stream-overlay/helper.js
@@ -359,9 +359,11 @@ export function diffHoursMinutes(fromTimestamp, toTimestamp = null) {
 /**
  * @param {Date|string|number} fromTimestamp
  * @param {Date|string|number|null} toTimestamp
+ * @param {boolean} [max24Hours] If true, anything longer than 24 hours will be shown in days.
+ *                               If false, days are only used at 100+ hours.
  * @returns {string}
  */
-export function diffTime(fromTimestamp, toTimestamp = null) {
+export function diffTime(fromTimestamp, toTimestamp = null, max24Hours = false) {
     fromTimestamp = getTimeFromArg(fromTimestamp);
     toTimestamp = getTimeFromArg(toTimestamp);
 
@@ -376,7 +378,7 @@ export function diffTime(fromTimestamp, toTimestamp = null) {
     } else if (deltaInSeconds < 36000) {
         duration = (deltaInSeconds / 3600).toLocaleString("en", {maximumFractionDigits: 1});
         durationUnit = "hr";
-    } else if (deltaInSeconds < 360000) {
+    } else if (deltaInSeconds < (max24Hours ? 3600 * 24 : 360000)) {
         duration = Math.round(deltaInSeconds / 3600);
         durationUnit = "hr";
     } else if (deltaInSeconds < 864000) {


### PR DESCRIPTION
### Description

In the old overlay, there are two different cutoff points for when it will start showing durations as days rather than hours:

- The duration of a phase ('Timer' column) would show up to 99 hours and only then switch to days.
- The 'time ago' (first column) would show days starting at 24+ hours.

The new overlay didn't make this distinction and would use the 100+ rule for both.

This PR reverts that inadvertent change.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
