### PR TITLE
Fix glitching Box Fill State info bubble in overlay

### DIFF
--- a/modules/web/static/stream-overlay/content/info-bubbles.js
+++ b/modules/web/static/stream-overlay/content/info-bubbles.js
@@ -138,7 +138,7 @@ function updateInfoBubbles(mapEncounters, stats, targetTimers, lastEncounterType
 
         infoBubblePCStorage.style.display = "inline-block";
         updatePCStorageCounter();
-        window.setInterval(updatePCStorageCounter, 10000);
+        pcStorageTimer = window.setInterval(updatePCStorageCounter, 10000);
     }
 }
 


### PR DESCRIPTION
### Description

Thanks to a missing assignment, the timer interval for updating the box fill state bubble would not only be initialised once, but instead a new timer would be created each time the info bubbles were updated -- which happens once for every wild encounter.

So after a few thousand encounters, you'd end up with thousands of timers all trying to update the box bubble. Which leads to visual glitching.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
