### PR TITLE
Overlay: Fix section checklist losing any 'completed' marks after a shiny

### DIFF
--- a/modules/web/static/stream-overlay/content/section-checklist.js
+++ b/modules/web/static/stream-overlay/content/section-checklist.js
@@ -79,7 +79,7 @@ const updateSectionChecklist = (checklistConfig, stats) => {
         elements.countSpan.innerText = formatInteger(completion);
         if (configEntry.goal && completion >= configEntry.goal && !elements.li.classList.contains("completed")) {
             elements.li.classList.add("completed");
-        } else if (elements.li.classList.contains("completed")) {
+        } else if ((!configEntry.goal || completion < configEntry.goal) && elements.li.classList.contains("completed")) {
             elements.li.classList.remove("completed");
         }
 


### PR DESCRIPTION
### Description

Due to a logic error in an `else if` block, any already completed entry in the section checklist would lose its green background and tick mark after another shiny was encountered.

It would then regain it after the _next_ shiny.
![image](https://github.com/user-attachments/assets/14af8c9e-69ab-4ad4-981f-54fd9b243f39)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
