### PR TITLE
Add utilities for dealing with Berry Trees

### DIFF
--- a/modules/berry_trees.py
+++ b/modules/berry_trees.py
@@ -1,0 +1,100 @@
+from enum import Enum, auto
+from modules.context import context
+from modules.items import Item, get_item_by_index
+from modules.memory import unpack_uint16, get_save_block
+
+
+class BerryTreeStage(Enum):
+    Empty = 0
+    Planted = 1
+    Sprouted = 2
+    Taller = 3
+    Flowering = 4
+    Berries = 5
+
+
+class BerryTree:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    @property
+    def berry(self) -> Item | None:
+        if self._data[0] == 0 or self._data[0] > 43 or self.stage is BerryTreeStage.Empty:
+            return None
+        return get_item_by_index(132 + self._data[0])
+
+    @property
+    def stage(self) -> BerryTreeStage:
+        return BerryTreeStage(self._data[1] & 0b0111_1111)
+
+    @property
+    def is_sparkling(self) -> bool:
+        return bool(self._data[1] & 0b1000_0000)
+
+    @property
+    def stop_growth(self) -> bool:
+        return bool(self._data[1] & 0b1000_0000)
+
+    @property
+    def minutes_until_next_stage(self) -> int:
+        return unpack_uint16(self._data[2:4])
+
+    @property
+    def berry_yield(self) -> int:
+        return self._data[4]
+
+    @property
+    def regrowth_count(self) -> int:
+        return self._data[5] & 0b0000_1111
+
+    @property
+    def watered_stages(self) -> tuple[bool, bool, bool, bool]:
+        return (
+            bool(self._data[5] & (1 << 4)),
+            bool(self._data[5] & (1 << 5)),
+            bool(self._data[5] & (1 << 6)),
+            bool(self._data[5] & (1 << 7)),
+        )
+
+    @property
+    def current_stage_is_unwatered(self) -> bool:
+        match self.stage:
+            case BerryTreeStage.Planted:
+                return not self.watered_stages[0]
+            case BerryTreeStage.Sprouted:
+                return not self.watered_stages[1]
+            case BerryTreeStage.Taller:
+                return not self.watered_stages[2]
+            case BerryTreeStage.Flowering:
+                return not self.watered_stages[3]
+            case _:
+                return False
+
+    def to_dict(self) -> dict:
+        return {
+            "berry": self.berry.name if self.berry is not None else None,
+            "stage": self.stage.name,
+            "stage_id": self.stage.value,
+            "is_sparkling": self.is_sparkling,
+            "minutes_until_next_stage": self.minutes_until_next_stage,
+            "berry_yield": self.berry_yield,
+            "regrowth_count": self.regrowth_count,
+            "watered_stages": self.watered_stages,
+            "current_stage_is_unwatered": self.current_stage_is_unwatered,
+            "stop_growth": self.stop_growth,
+        }
+
+
+def get_all_berry_trees() -> list[BerryTree]:
+    if context.rom.is_frlg:
+        return []
+    offset = 0x169C if context.rom.is_emerald else 0x1608
+    data = get_save_block(1, offset=offset, size=8 * 89)
+    return [BerryTree(data[i * 8 : i * 8 + 6]) for i in range(89)]
+
+
+def get_berry_tree_by_id(berry_tree_id) -> BerryTree | None:
+    if context.rom.is_frlg or berry_tree_id < 0 or berry_tree_id >= 128:
+        return None
+    offset = 0x169C if context.rom.is_emerald else 0x1608
+    return BerryTree(get_save_block(1, offset=offset + berry_tree_id * 8, size=6))

--- a/modules/gui/debug_menu.py
+++ b/modules/gui/debug_menu.py
@@ -115,6 +115,11 @@ def _give_test_item_pack() -> None:
     context.message = "✅ Added some goodies to your item bag."
 
 
+def _advance_rtc() -> None:
+    context.emulator._core.rtc.advance_time(3_600_000)
+    context.message = "Time has passed!"
+
+
 def _export_flags_and_vars() -> None:
     target_path = plyer.filechooser.save_file(
         path=str(context.profile.path / "event_vars_and_flags.txt"),
@@ -293,6 +298,7 @@ class DebugMenu(Menu):
         self.add_checkbutton(label="Infinite Safari Zone", variable=toggleable_listener(InfiniteSafariZoneListener))
         self.add_checkbutton(label="Force Shiny Encounter", variable=toggleable_listener(ForceShinyEncounterListener))
         self.add_checkbutton(label="Force PokeNav Call", variable=toggleable_listener(ForcePokenavCallListener))
+        self.add_command(label="Advance RTC by one hour", command=_advance_rtc)
         self.add_separator()
         self.add_command(label="Export events and vars", command=_export_flags_and_vars)
         self.add_command(label="Import events and vars", command=_import_flags_and_vars)

--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Union, Optional
 from PIL import Image, ImageDraw, ImageTk, ImageOps
 
 from modules.battle_state import get_battle_state, battle_is_active
+from modules.berry_trees import get_all_berry_trees, get_berry_tree_by_id
 from modules.clock import get_clock_time, get_play_time
 from modules.context import context
 from modules.daycare import get_daycare_data
@@ -1335,10 +1336,14 @@ class MapTab(DebugTab):
                 "flag": get_event_flag_name(obj.flag_id),
             }
             if obj.kind == "normal":
-                object_templates_list[key]["movement_type"] = obj.movement_type
-                object_templates_list[key]["movement_range"] = obj.movement_range
-                object_templates_list[key]["trainer_type"] = obj.trainer_type
-                object_templates_list[key]["trainer_range"] = obj.trainer_range
+                if obj.movement_type == "BERRY_TREE_GROWTH":
+                    object_templates_list[key]["berry_tree_id"] = obj.trainer_range
+                    object_templates_list[key]["berry_tree"] = get_berry_tree_by_id(obj.berry_tree_id).to_dict()
+                else:
+                    object_templates_list[key]["movement_type"] = obj.movement_type
+                    object_templates_list[key]["movement_range"] = obj.movement_range
+                    object_templates_list[key]["trainer_type"] = obj.trainer_type
+                    object_templates_list[key]["trainer_range"] = obj.trainer_range
             else:
                 object_templates_list[key]["target_local_id"] = obj.clone_target_local_id
                 target_map = obj.clone_target_map

--- a/modules/items.py
+++ b/modules/items.py
@@ -363,7 +363,7 @@ class ItemBag:
         offset = self.items_size + self.key_items_size + self.poke_balls_size + self.tms_hms_size
         return self._get_pocket(slot_offset=offset, number_of_slots=self.berries_size)
 
-    def has_space_for(self, item: Item) -> bool:
+    def has_space_for(self, item: Item, quantity: int = 1) -> bool:
         match item.pocket:
             case ItemPocket.Items:
                 pocket = self.items
@@ -393,7 +393,7 @@ class ItemBag:
         else:
             stack_size = 99
 
-        return any(slot.item == item and slot.quantity < stack_size for slot in pocket)
+        return any(slot.item == item and slot.quantity + quantity <= stack_size for slot in pocket)
 
     def pocket_for(self, item: Item) -> list[ItemSlot]:
         match item.pocket:

--- a/modules/map.py
+++ b/modules/map.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Literal, TYPE_CHECKING
 
+from modules.berry_trees import get_berry_tree_by_id
 from modules.context import context
 from modules.game import decode_string, get_event_flag_name, get_event_var_name
 from modules.items import get_item_by_name
@@ -1006,6 +1007,12 @@ class MapLocation:
             None,
         )
 
+    def object_by_coordinates(self, coordinates: tuple[int, int]) -> "ObjectEventTemplate | None":
+        return next(
+            (object_template for object_template in self.objects if object_template.local_coordinates == coordinates),
+            None,
+        )
+
     @property
     def coord_events(self) -> list[MapCoordEvent]:
         coord_event_count = self._event_list[2]
@@ -1722,6 +1729,12 @@ class ObjectEventTemplate:
                 return f"Buried Trainer {defeated} at {self.local_coordinates}"
             else:
                 return f"Trainer {defeated} at {self.local_coordinates}"
+        elif self.movement_type == "BERRY_TREE_GROWTH":
+            berry_tree = get_berry_tree_by_id(self.berry_tree_id)
+            if berry_tree.berry is not None:
+                return f"Berry Tree ({berry_tree.berry.name}, {berry_tree.stage.name})"
+            else:
+                return "Berry Tree Spot (empty)"
         else:
             return f"Entity at {self.local_coordinates}"
 

--- a/modules/modes/util/berry_tree_interaction.py
+++ b/modules/modes/util/berry_tree_interaction.py
@@ -1,0 +1,81 @@
+from typing import Generator
+
+from modules.berry_trees import get_berry_tree_by_id, BerryTreeStage
+from modules.context import context
+from modules.items import Item, ItemPocket, get_item_bag, get_item_by_name
+from modules.memory import get_game_state, GameState
+from modules.menuing import is_fade_active, scroll_to_item_in_bag
+from modules.modes._interface import BotModeError
+from modules.modes.util import (
+    wait_for_player_avatar_to_be_controllable,
+    wait_for_no_script_to_run,
+)
+from modules.player import player_avatar_is_controllable, get_player_avatar
+from modules.tasks import get_global_script_context
+
+
+def plant_berry(berry: Item) -> Generator:
+    if berry.pocket is not ItemPocket.Berries:
+        raise BotModeError(f"Item '{berry.name}' is not a berry.")
+    slot_index = get_item_bag().first_slot_index_for(berry)
+    if slot_index is None:
+        raise BotModeError(f"The player does not have '{berry.name}' in their inventory.")
+    if not player_avatar_is_controllable():
+        raise BotModeError("Cannot plant a berry while the player is not controllable.")
+    tile_in_front_of_player = get_player_avatar().map_location_in_front
+    map_object = tile_in_front_of_player.object_by_coordinates(tile_in_front_of_player.local_position)
+    if map_object is None or map_object.movement_type != "BERRY_TREE_GROWTH":
+        raise BotModeError("Player is not facing a berry patch. Cannot plant.")
+    berry_tree = get_berry_tree_by_id(map_object.berry_tree_id)
+    if berry_tree.stage is not BerryTreeStage.Empty:
+        raise BotModeError("There is already a berry planted in this spot.")
+
+    while get_game_state() is not GameState.BAG_MENU or is_fade_active():
+        context.emulator.press_button("A")
+        yield
+    yield from scroll_to_item_in_bag(berry)
+    while get_game_state() is not GameState.OVERWORLD or get_global_script_context().is_active:
+        context.emulator.press_button("A")
+        yield
+    yield from wait_for_player_avatar_to_be_controllable()
+
+
+def water_berry() -> Generator:
+    if not player_avatar_is_controllable():
+        raise BotModeError("Cannot water a berry while the player is not controllable.")
+    tile_in_front_of_player = get_player_avatar().map_location_in_front
+    map_object = tile_in_front_of_player.object_by_coordinates(tile_in_front_of_player.local_position)
+    if map_object is None or map_object.movement_type != "BERRY_TREE_GROWTH":
+        raise BotModeError("Player is not facing a berry patch. Cannot water.")
+    berry_tree = get_berry_tree_by_id(map_object.berry_tree_id)
+    if berry_tree.stage is BerryTreeStage.Empty:
+        raise BotModeError("There is no berry planted in this spot. Cannot water.")
+    if get_item_bag().quantity_of(get_item_by_name("Wailmer Pail")) == 0:
+        raise BotModeError("Cannot water berry because the player does not have the Wailmer Pail.")
+
+    if berry_tree.stage is BerryTreeStage.Berries or not berry_tree.current_stage_is_unwatered:
+        return
+
+    context.emulator.press_button("A")
+    yield
+    yield from wait_for_no_script_to_run("A")
+    yield from wait_for_player_avatar_to_be_controllable()
+
+
+def harvest_berry() -> Generator:
+    if not player_avatar_is_controllable():
+        raise BotModeError("Cannot harvest a berry while the player is not controllable.")
+    tile_in_front_of_player = get_player_avatar().map_location_in_front
+    map_object = tile_in_front_of_player.object_by_coordinates(tile_in_front_of_player.local_position)
+    if map_object is None or map_object.movement_type != "BERRY_TREE_GROWTH":
+        raise BotModeError("Player is not facing a berry patch. Cannot harvest.")
+    berry_tree = get_berry_tree_by_id(map_object.berry_tree_id)
+    if berry_tree.stage is not BerryTreeStage.Berries:
+        raise BotModeError("There are no berries to harvest in this patch.")
+    if not get_item_bag().has_space_for(berry_tree.berry, berry_tree.berry_yield):
+        raise BotModeError("The player's inventory does not have space for these berries.")
+
+    context.emulator.press_button("A")
+    yield
+    yield from wait_for_no_script_to_run("A")
+    yield from wait_for_player_avatar_to_be_controllable()


### PR DESCRIPTION
### Description

- adds a data class and lookup function for getting Berry Tree data
- integrates that into the `MapLocation` and `ObjectEventTemplate` classes so that they show and object's type as a Berry Tree and make the associated `BerryTree` object accessible
- adds utility functions for planting, watering, and harvesting that modes could use
- adds a helper to the Debug Menu that allows advancing the RTC by one hour (useful for testing)

(The bot doesn't really use this -- yet? -- but it might be useful for plugins with custom modes)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
