### PR TITLE
Overlay: Add Feebas to route encounters on Route119

### DIFF
--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -58,6 +58,10 @@ const updateRouteEncountersList = (encounters, stats, encounterType, checklistCo
         regularEncounterList = [...encounters.regular.land_encounters];
     }
 
+    if (botMode.toLowerCase().includes("feebas") && ["surfing", "fishing_old_rod", "fishing_good_rod", "fishing_super_rod"].includes(encounterType)) {
+        additionalRouteSpecies.add("Feebas");
+    }
+
     // Add species that could appear on this map but are currently blocked by Repel and
     // therefore not part of the 'effective encounters' list.
     for (const regularEncounter of regularEncounterList) {


### PR DESCRIPTION
### Description

Adds Feebas to the route encounters when surfing/fishing on Route 119. The encounter rates are a bit misleading then, but it works as a quick fix.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
