### PR TITLE
Fix Feebas mode starting to search for the tile again when the in-game day changes

### DIFF
--- a/modules/web/static/stream-overlay/config.dist.js
+++ b/modules/web/static/stream-overlay/config.dist.js
@@ -280,7 +280,7 @@ const config = {
 
             "Wynaut": {
                 goal: 2,
-                similarSpecies: [],
+                similarSpecies: ["Wobbuffet"],
                 hidden: false,
             },
 

--- a/modules/web/static/stream-overlay/config.dist.js
+++ b/modules/web/static/stream-overlay/config.dist.js
@@ -260,6 +260,12 @@ const config = {
                 hidden: false,
             },
 
+            "Phanpy": {
+                goal: 2,
+                similarSpecies: ["Donphan"],
+                hidden: false,
+            },
+
             "Pichu": {
                 goal: 1,
                 similarSpecies: [],
@@ -293,7 +299,7 @@ const config = {
             "Vileplume": {
                 goal: 3,
                 similarSpecies: ["Oddish", "Gloom"],
-                hidden: false,
+                hidden: true,
             },
         },
 

--- a/modules/web/static/stream-overlay/config.dist.js
+++ b/modules/web/static/stream-overlay/config.dist.js
@@ -266,6 +266,18 @@ const config = {
                 hidden: false,
             },
 
+            "Snorunt": {
+                goal: 2,
+                similarSpecies: ["Glalie"],
+                hidden: false,
+            },
+
+            "Spheal": {
+                goal: 3,
+                similarSpecies: ["Sealeo", "Walrein"],
+                hidden: false,
+            },
+
             "Pichu": {
                 goal: 1,
                 similarSpecies: [],
@@ -299,7 +311,7 @@ const config = {
             "Vileplume": {
                 goal: 3,
                 similarSpecies: ["Oddish", "Gloom"],
-                hidden: true,
+                hidden: false,
             },
         },
 

--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -27,10 +27,11 @@ const updateMapName = map => {
  * @param {EncounterType} encounterType
  * @param {StreamOverlay.SectionChecklist} checklistConfig
  * @param {string} botMode
+ * @param {Encounter[]} [encounterLog]
  * @param {Set<string>} [additionalRouteSpecies]
  * @param {string} [animateSpecies]
  */
-const updateRouteEncountersList = (encounters, stats, encounterType, checklistConfig, botMode, additionalRouteSpecies = null, animateSpecies = null) => {
+const updateRouteEncountersList = (encounters, stats, encounterType, checklistConfig, botMode, encounterLog = [], additionalRouteSpecies = null, animateSpecies = null) => {
     /** @type {MapEncounter[]} encounterList */
     let encounterList;
     /** @type {MapEncounter[]} regularEncounterList */
@@ -56,10 +57,6 @@ const updateRouteEncountersList = (encounters, stats, encounterType, checklistCo
     } else {
         encounterList = [...encounters.effective.land_encounters];
         regularEncounterList = [...encounters.regular.land_encounters];
-    }
-
-    if (botMode.toLowerCase().includes("feebas") && ["surfing", "fishing_old_rod", "fishing_good_rod", "fishing_super_rod"].includes(encounterType)) {
-        additionalRouteSpecies.add("Feebas");
     }
 
     // Add species that could appear on this map but are currently blocked by Repel and
@@ -93,6 +90,33 @@ const updateRouteEncountersList = (encounters, stats, encounterType, checklistCo
 
         if (!alreadyInList) {
             encounterList.push({species_name: speciesName, encounter_rate: 0});
+        }
+    }
+
+    if (botMode.toLowerCase().includes("feebas") && ["surfing", "fishing_old_rod", "fishing_good_rod", "fishing_super_rod"].includes(encounterType)) {
+        let hasRecentlySeenFeebas = false;
+        for (const recentEncounter of encounterLog) {
+            if (recentEncounter.pokemon.species.name === "Feebas") {
+                hasRecentlySeenFeebas = true;
+                break;
+            }
+        }
+
+        if (hasRecentlySeenFeebas) {
+            let newEncounterList = [];
+            for (const encounter of encounterList) {
+                const newEncounter = {...encounter};
+                newEncounter.encounter_rate /= 2;
+                newEncounterList.push(newEncounter);
+            }
+            newEncounterList.push({
+                species_id: 328,
+                species_name: "Feebas",
+                min_level: 20,
+                max_level: 25,
+                encounter_rate: 0.5
+            });
+            encounterList = newEncounterList;
         }
     }
 

--- a/modules/web/static/stream-overlay/layout/party-list.css
+++ b/modules/web/static/stream-overlay/layout/party-list.css
@@ -30,6 +30,11 @@
                     transform: scale(1.2);
                     height: 100%;
                     object-fit: contain;
+                    object-position: bottom;
+
+                    @media screen and (min-height: 1440px) {
+                        max-height: 5vh;
+                    }
                 }
 
                 &.fainted img {

--- a/modules/web/static/stream-overlay/layout/section-checklist.css
+++ b/modules/web/static/stream-overlay/layout/section-checklist.css
@@ -33,7 +33,7 @@
             display: inline-block;
             border: 1px solid var(--separator-line-colour);
             border-radius: 10px;
-            width: 6.1vh;
+            width: 5.59vh;
             text-align: center;
             margin: 3px;
             padding: .4vh 0;

--- a/modules/web/static/stream-overlay/layout/section-checklist.css
+++ b/modules/web/static/stream-overlay/layout/section-checklist.css
@@ -33,10 +33,14 @@
             display: inline-block;
             border: 1px solid var(--separator-line-colour);
             border-radius: 10px;
-            width: 5.59vh;
+            width: 5.58vh;
             text-align: center;
             margin: 3px;
             padding: .4vh 0;
+
+            @media screen and (min-width: 2560px) {
+                width: 5.7vh;
+            }
 
             > pokemon-sprite img {
                 height: 4vh;

--- a/modules/web/static/stream-overlay/overlay.js
+++ b/modules/web/static/stream-overlay/overlay.js
@@ -44,7 +44,7 @@ async function doFullUpdate(state) {
     isInMainMenu = state.gameState === "MAIN_MENU" || state.gameState === "TITLE_SCREEN";
 
     updateMapName(state.map);
-    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
+    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
     updateSectionChecklist(config.sectionChecklist, state.stats);
     updateShinyLog(state.shinyLog);
     updateEncounterLog(state.encounterLog);
@@ -70,7 +70,7 @@ async function doUpdateAfterEncounter(state) {
 
         updateShinyLog(state.shinyLog);
         updateSectionChecklist(config.sectionChecklist, state.stats);
-        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
+        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
         updatePhaseStats(state.stats);
         updateTotalStats(state.stats, state.encounterRate);
         updatePokeNavInfoBubble(null);
@@ -155,7 +155,7 @@ function handleBotMode(event, state) {
 
     if (previousModeWasDaycare !== newModeIsDaycare) {
         updateDaycareBox(event, state);
-        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
+        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
     }
 }
 
@@ -188,7 +188,7 @@ function handleWildEncounter(event, state) {
         wasShinyEncounter = true;
     }
 
-    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.additionalRouteSpecies, event.pokemon.species_name_for_stats);
+    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, event.pokemon.species_name_for_stats);
     updatePhaseStats(state.stats);
     updateTotalStats(state.stats, state.encounterRate);
     updateEncounterInfoBubble(event.pokemon.species_name_for_stats, state.stats, event.pokemon.gender);
@@ -218,7 +218,7 @@ function handleMapChange(event, state) {
  */
 function handleMapEncounters(event, state) {
     state.mapEncounters = event;
-    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
+    updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
 }
 
 /**
@@ -227,7 +227,7 @@ function handleMapEncounters(event, state) {
  */
 function handlePlayerAvatar(event, state) {
     if (state.logPlayerAvatarChange(event)) {
-        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
+        updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
     }
 }
 


### PR DESCRIPTION
### Description

The Feebas mode is programmed on the assumption that the Feebas tiles change once the in-game clock changes to a new day.

That is, apparently, not the case. So this PR removes that behaviour and replaces it with a safeguard that will restart the search for a Feebas tile if, for whatever reason, it has not seen a Feebas within 20 encounters.

It also fixes the overlay to show the correct encounter rates after a Feebas tile has been found.
![image](https://github.com/user-attachments/assets/56437404-2d4c-4799-9e57-7484d8488bcc)


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
