### PR TITLE
Reset the phase start time when resetting phase stats

### DIFF
--- a/modules/stats.py
+++ b/modules/stats.py
@@ -699,6 +699,15 @@ class StatsDatabase:
 
         self._execute_write(
             """
+            UPDATE shiny_phases
+            SET start_time = ?
+            WHERE shiny_phase_id = ?
+            """,
+            (self.current_shiny_phase.start_time, self.current_shiny_phase.shiny_phase_id),
+        )
+
+        self._execute_write(
+            """
             UPDATE encounter_summaries
             SET phase_encounters = 0,
                 phase_highest_iv_sum = NULL,


### PR DESCRIPTION
### Description

When resetting the phase stats, the bot should also set the phase start time to the current time.

Due to an oversight, this has only been done in memory, i.e. after a bot restart it would show the old value again.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
