### PR TITLE
Add utility function for using a Rare Candy

### DIFF
--- a/modules/battle_evolution_scene.py
+++ b/modules/battle_evolution_scene.py
@@ -14,7 +14,7 @@ from modules.tasks import get_task, task_is_active
 
 
 @debug.track
-def handle_evolution_scene(strategy: BattleStrategy) -> Generator:
+def handle_evolution_scene(strategy: BattleStrategy, allow_evolution: bool | None = None) -> Generator:
     queried_stategy = False
     should_stop = True
     while context.bot_mode != "Manual":
@@ -32,7 +32,10 @@ def handle_evolution_scene(strategy: BattleStrategy) -> Generator:
         if not queried_stategy:
             if task_state >= 4:
                 party_index = task.data_value(10)
-                should_stop = not strategy.should_allow_evolution(get_party()[party_index], party_index)
+                if allow_evolution is None:
+                    should_stop = not strategy.should_allow_evolution(get_party()[party_index], party_index)
+                else:
+                    should_stop = not allow_evolution
                 queried_stategy = True
 
         context.emulator.press_button("B" if should_stop else "A")

--- a/modules/menu_parsers.py
+++ b/modules/menu_parsers.py
@@ -3,7 +3,7 @@ from enum import IntEnum
 
 from modules.context import context
 from modules.game import decode_string
-from modules.memory import get_symbol_name, read_symbol, unpack_uint32
+from modules.memory import get_symbol_name, read_symbol, unpack_uint32, unpack_uint16
 from modules.pokemon import Move, Pokemon, get_move_by_index, parse_pokemon
 from modules.pokemon_party import get_party
 from modules.tasks import get_task, task_is_active
@@ -158,6 +158,8 @@ def get_party_menu_cursor_pos(party_length: int) -> dict:
             context.emulator.read_bytes(0x0202002F + party_length * 136 + 3, length=1), "little"
         )
         party_menu["slot_id_2"] = party_menu["slot_id"]
+        # 0x0201C00 is the location of `gPartyMenu`
+        party_menu["data1"] = unpack_uint16(context.emulator.read_bytes(0x0201C000 + 8, length=2))
 
     if party_menu["slot_id"] == -1:
         context.message = "Error detecting cursor position, switching to manual mode..."


### PR DESCRIPTION
### Description

This adds a `apply_rare_candy(pokemon)` functions that custom modes can use to increase a Pokémon's level.

It handles both move learning and evolution (which can be allowed or interrupted automatically.)

@ThibaultLassiaz Just as an FYI, this makes use of a few new symbols. But since the bot itself is not using this function, we don't necessarily need to map them for other languages. They are needed for when a Pokémon learns a new move after applying a Rare Candy.

- `Task_HandleReplaceMoveYesNoInput` (Emerald, FR/LG)
- `Task_HandleStopLearningMoveYesNoInput` (Emerald, FR/LG)
- `sub_806F390` (R/S)
- `StopTryingToTeachMove_806F6B4` (R/S)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
