### PR TITLE
Fix issues with Surfing during pathfinding

### DIFF
--- a/modules/modes/util/walking.py
+++ b/modules/modes/util/walking.py
@@ -140,7 +140,7 @@ def follow_waypoints(path: Iterable[Waypoint], run: bool = True) -> Generator:
     # this flag will just be ignored.
     # Similarly, running is not possible when surfing or swimming underwater, but pressing B can
     # cause the game to try and dive/emerge which we don't want.
-    if run and (get_player_avatar().is_on_bike or get_player_avatar().is_in_water):
+    if run and get_player_avatar().is_on_bike:
         run = False
 
     # For each waypoint (i.e. each step of the path) we set a timeout. If the player avatar does not reach the
@@ -269,7 +269,7 @@ def follow_waypoints(path: Iterable[Waypoint], run: bool = True) -> Generator:
                     context.emulator.hold_button(waypoint.walking_direction)
                 else:
                     context.emulator.hold_button(waypoint.walking_direction)
-                    if run and not AvatarFlags.OnAcroBike in get_player_avatar().flags:
+                    if run and not waypoint.is_water_tile and not AvatarFlags.OnAcroBike in get_player_avatar().flags:
                         context.emulator.hold_button("B")
             else:
                 context.emulator.reset_held_buttons()


### PR DESCRIPTION
### Description

When using the pathfinding utilities, if the player avatar was on a water tile (i.e. surfing) at the start of the path, this would disable running for the entirety of the path.

The reason was that 'running' involves pressing `B`, which on a deep sea tile would lead to the player diving.

That's been fixed now. The bot will not try to run while surfing, but start as soon as the player avatar reaches land.

Also, this fixes a bug where the pathfinding algorithm wouldn't take into account dynamic obstacles (NPCs, overworld items, etc.) during a transition from water to land.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
