### PR TITLE
Support fishing in PokecenterLoop utility

### DIFF
--- a/modules/modes/util/higher_level_actions.py
+++ b/modules/modes/util/higher_level_actions.py
@@ -144,6 +144,7 @@ def fish(stop_condition: Callable[[], bool] | None = None, loop: bool = False) -
             break
 
 
+@debug.track
 def spin(stop_condition: Callable[[], bool] | None = None, counter_clockwise: bool = False):
     directions = ["Up", "Left", "Down", "Right"] if counter_clockwise else ["Up", "Right", "Down", "Left"]
     while True:

--- a/modules/modes/util/pokecenter_loop.py
+++ b/modules/modes/util/pokecenter_loop.py
@@ -1,8 +1,9 @@
 from collections.abc import Callable
-from typing import Optional
+from typing import Optional, Literal
 
 from modules.battle_strategies import BattleStrategy, DefaultBattleStrategy
 from modules.context import context
+from modules.debug import debug
 from modules.encounter import handle_encounter
 from modules.map import get_map_data_for_current_position, get_effective_encounter_rates_for_current_map
 from modules.map_data import MapFRLG, get_map_enum
@@ -13,6 +14,7 @@ from modules.modes.util import (
     navigate_to,
     heal_in_pokemon_center,
     spin,
+    fish,
 )
 from modules.player import get_player_location
 from modules.pokemon_party import get_party
@@ -72,7 +74,8 @@ class PokecenterLoopController:
         # Pokémon Center.
         find_closest_pokemon_center(current_location)
 
-    def run(self, stop_condition: Optional[Callable[[], bool]] = None):
+    @debug.track
+    def run(self, stop_condition: Optional[Callable[[], bool]] = None, activity: Literal["spin", "fish"] = "spin"):
         encounter_spot = get_map_data_for_current_position()
         pokemon_center = find_closest_pokemon_center(encounter_spot)
 
@@ -99,9 +102,16 @@ class PokecenterLoopController:
             self._needs_healing = False
 
             yield from navigate_to(get_map_enum(encounter_spot), encounter_spot.local_position)
-            yield from apply_white_flute_if_available()
-            yield from spin(
-                stop_condition=lambda: self._needs_healing
-                or self._leave_pokemon_center
-                or (stop_condition is not None and stop_condition())
-            )
+
+            def activity_stop_condition() -> bool:
+                return (
+                    self._needs_healing
+                    or self._leave_pokemon_center
+                    or (stop_condition is not None and stop_condition())
+                )
+
+            if activity == "fish":
+                yield from fish(stop_condition=activity_stop_condition, loop=True)
+            else:
+                yield from apply_white_flute_if_available()
+                yield from spin(stop_condition=activity_stop_condition)


### PR DESCRIPTION
### Description

The PokecenterLoop utility is used internally for modes like Level Grind and EV-train.

So far, the utility only supported spinning but there are cases where fishing might be useful to (for example when farming speed EVs without gaining a lot of EXP, Magikarp is a good target)

So this adds a switch to that mode. The bot itself doesn't use it (yet)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
