### PR TITLE
Fix scrolling in party menu with incomplete party

### DIFF
--- a/modules/menuing.py
+++ b/modules/menuing.py
@@ -342,6 +342,13 @@ class PokemonPartySubMenuNavigator(BaseMenuNavigator):
             for _ in range(5):
                 yield
 
+        # TAKE_ITEM
+        chosen_option = self.party_menu_internal["actions"][self.desired_option]
+        if chosen_option == 5:
+            while not task_is_active("Task_HandleChooseMonInput"):
+                context.emulator.press_button("A")
+                yield
+
     def get_next_func(self):
         match self.current_step:
             case "None":
@@ -435,8 +442,11 @@ class PokemonPartyMenuNavigator(BaseMenuNavigator):
 
     def navigate_to_mon(self):
         party_size = get_party_size()
-        while (current_slot := get_party_menu_cursor_pos(len(self.party))["slot_id"]) != self.idx:
-            context.emulator.press_button(get_scroll_direction(current_slot, self.idx, total_items=party_size + 1))
+        direction = get_scroll_direction(
+            min(party_size, get_party_menu_cursor_pos(len(self.party))["slot_id"]), self.idx, total_items=party_size + 1
+        )
+        while get_party_menu_cursor_pos(len(self.party))["slot_id"] != self.idx:
+            context.emulator.press_button(direction)
             yield
 
     def navigate_to_lead(self):


### PR DESCRIPTION
### Description

A recent fix (#709) updated the party menu handler so it can scroll in either direction, whichever is faster.

This didn't work properly if the party had less than 6 Pokémon, though, because the 'Cancel' button always has index=6 which threw off the scroll direction calculation.

It would then end up pressing 'Up,' get to the 'Cancel' button, and switch to pressing 'Down' 'again.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
