### PR TITLE
Add some more RTC controls

### DIFF
--- a/modules/gui/debug_menu.py
+++ b/modules/gui/debug_menu.py
@@ -1,6 +1,7 @@
 import tkinter
 import webbrowser
 import zlib
+from datetime import datetime
 from tkinter import Tk, Menu
 
 import PIL.PngImagePlugin
@@ -115,9 +116,10 @@ def _give_test_item_pack() -> None:
     context.message = "✅ Added some goodies to your item bag."
 
 
-def _advance_rtc() -> None:
-    context.emulator._core.rtc.advance_time(3_600_000)
-    context.message = "Time has passed!"
+def _advance_rtc_hours(hours: int) -> None:
+    context.emulator._core.rtc.advance_time(60 * 60 * 1000 * hours)
+    rtc_value = datetime.fromtimestamp(datetime.now().timestamp() + context.emulator._core.rtc._core.rtc.value / 1000)
+    context.message = f"RTC has been adjusted to {rtc_value.isoformat()}!"
 
 
 def _export_flags_and_vars() -> None:
@@ -298,7 +300,11 @@ class DebugMenu(Menu):
         self.add_checkbutton(label="Infinite Safari Zone", variable=toggleable_listener(InfiniteSafariZoneListener))
         self.add_checkbutton(label="Force Shiny Encounter", variable=toggleable_listener(ForceShinyEncounterListener))
         self.add_checkbutton(label="Force PokeNav Call", variable=toggleable_listener(ForcePokenavCallListener))
-        self.add_command(label="Advance RTC by one hour", command=_advance_rtc)
+        self.add_separator()
+        self.add_command(label="Advance RTC by one hour", command=lambda: _advance_rtc_hours(1))
+        self.add_command(label="Advance RTC by one day", command=lambda: _advance_rtc_hours(24))
+        self.add_command(label="Turn back RTC by one hour", command=lambda: _advance_rtc_hours(-1))
+        self.add_command(label="Turn back RTC by one day", command=lambda: _advance_rtc_hours(-24))
         self.add_separator()
         self.add_command(label="Export events and vars", command=_export_flags_and_vars)
         self.add_command(label="Import events and vars", command=_import_flags_and_vars)

--- a/modules/gui/debug_tabs.py
+++ b/modules/gui/debug_tabs.py
@@ -1,6 +1,7 @@
 import contextlib
 import time
 import tkinter
+from datetime import datetime
 from enum import Enum
 from tkinter import ttk, Canvas
 from typing import TYPE_CHECKING, Union, Optional
@@ -1150,6 +1151,19 @@ class EmulatorTab(DebugTab):
         session_seconds = int(session_total_seconds % 60)
         session_time_at_1x = f"{session_hours:,}:{session_minutes:02}:{session_seconds:02}"
 
+        rtc_core = context.emulator._core.rtc._core.rtc
+        match rtc_core.override:
+            case 0:
+                rtc = datetime.now()
+            case 1:
+                rtc = datetime.fromtimestamp(rtc_core.value / 1000)
+            case 2:
+                rtc = datetime.fromtimestamp(rtc_core.value / 1000)
+            case 3:
+                rtc = datetime.fromtimestamp(datetime.now().timestamp() + rtc_core.value / 1000)
+            case _:
+                rtc = None
+
         return {
             "Inputs": inputs_dict,
             "Emulator Frame": f"{context.emulator.get_frame_count():,}",
@@ -1157,6 +1171,8 @@ class EmulatorTab(DebugTab):
             "Session Time at 1×": f"{session_time_at_1x}",
             "RNG Seed": hex(unpack_uint32(read_symbol("gRngValue"))),
             "Encounters/h (at 1×)": context.stats.encounter_rate_at_1x,
+            "Controller Stack": [controller.__qualname__ for controller in context.controller_stack],
+            "RTC": rtc.isoformat() if rtc is not None else None,
             "Currently Running Actions": debug.action_stack,
             "Debug Values": debug.debug_values,
         }

--- a/modules/gui/emulator_controls.py
+++ b/modules/gui/emulator_controls.py
@@ -327,7 +327,7 @@ class EmulatorControls:
                 as encounters, IV/SV records, fishing attempts etc. -- to zero.
                 
                 That can be useful if for example you have changed location and
-                would like tostart hunting on this route with a clean slate
+                would like to start hunting on this route with a clean slate
                 instead of having some random encounters from the way to get
                 here show up.
                 


### PR DESCRIPTION
### Description

- adds the current RTC time to the 'Emulator' debug tab
- adds more RTC-manipulating options to the debug menu (+1h, +24h, -1h, -24h)

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
