### PR TITLE
Improve Pokéblock handling in battle handler

### DIFF
--- a/modules/battle_action_selection.py
+++ b/modules/battle_action_selection.py
@@ -182,7 +182,9 @@ def battle_action_use_item(battle_state: BattleState, item: Item, target_index: 
 @debug.track
 def battle_action_use_pokeblock(poke_block_index: int):
     yield from scroll_to_battle_action(1)
-    context.emulator.press_button("A")
+    while get_game_state_symbol() == "BATTLEMAINCB2":
+        context.emulator.press_button("A")
+        yield
     while get_game_state_symbol() not in ("CB2_POKEBLOCKMENU", "SUB_810B674"):
         yield
     for _ in range(22):
@@ -214,6 +216,11 @@ def battle_action_use_pokeblock(poke_block_index: int):
 
     while get_game_state_symbol() in ("CB2_POKEBLOCKMENU", "SUB_810B674"):
         context.emulator.press_button("A")
+        yield
+    while get_game_state_symbol() != "BATTLEMAINCB2":
+        context.emulator.press_button("B")
+        yield
+    while get_battle_controller_callback(0) == "CompleteWhenChosePokeblock":
         yield
     yield
 

--- a/modules/battle_state.py
+++ b/modules/battle_state.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum, Flag, KEEP, auto
+from typing import Literal
 
 from modules.context import context
 from modules.fishing import FishingRod
@@ -13,10 +14,12 @@ from modules.pokemon import (
     Move,
     LearnedMove,
     Item,
+    Nature,
     get_species_by_index,
     get_type_by_index,
     get_move_by_index,
     get_item_by_index,
+    get_nature_by_index,
     StatsValues,
     StatusCondition,
     get_opponent,
@@ -614,6 +617,23 @@ class BattlePokemon:
     @property
     def total_hp(self) -> int:
         return unpack_uint16(self._data[0x2C:0x2E])
+
+    @property
+    def nature(self) -> Nature:
+        return get_nature_by_index(self.personality_value % 25)
+
+    @property
+    def gender(self) -> Literal["male", "female", None]:
+        ratio = self.species.gender_ratio
+        if ratio == 0:
+            return "male"
+
+        elif ratio == 254:
+            return "female"
+        elif ratio == 255:
+            return None
+        value = self.personality_value & 0xFF
+        return "male" if value >= ratio else "female"
 
     @property
     def level(self) -> int:


### PR DESCRIPTION
### Description

I don't quite remember what this was supposed to fix, but I had it in my pending changes and it seems to work.

Also, adds a nature and gender lookup to the `BattlePokemon` structure for easier lookup

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
