### PR TITLE
Overlay: Add support for setting info bubbles via custom events

### DIFF
--- a/modules/web/static/stream-overlay/component/info-bubble.js
+++ b/modules/web/static/stream-overlay/component/info-bubble.js
@@ -1,5 +1,52 @@
-export default class InfoBubble extends HTMLDivElement {
-    static observedAttributes = ["sprite-location"];
+import {formatInteger} from "../helper.js";
+
+export default class InfoBubble extends HTMLElement {
+    static observedAttributes = ["sprite-location", "sprite-type", "sprite-icon", "quantity", "quantity-target", "content"];
+
+    constructor() {
+        super();
+
+        /** @type {HTMLImageElement | PokemonSprite | ItemSprite | OverlaySprite | null} */
+        this.sprite = null;
+
+        /** @type {"item" | "pokemon" | "shiny-pokemon" | "anti-pokemon" | "overlay" | null} */
+        this.spriteType = null;
+
+        /** @type {string | null} */
+        this.spriteIcon = null;
+
+        /** @type {number | null} */
+        this.updateInterval = null;
+
+        /** @type {HTMLSpanElement | null} */
+        this.content = null;
+
+        /** @type {number | null} */
+        this.quantity = null;
+
+        /** @type {number | null} */
+        this.quantityTarget = null;
+    }
+
+    connectedCallback() {
+        this.spriteType = this.getAttribute("sprite-type");
+        this.spriteIcon = this.getAttribute("sprite-icon");
+        this.content = this.querySelector("span");
+        if (this.content === null) {
+            this.content = document.createElement("span");
+            this.append(this.content);
+        }
+        if (this.hasAttribute("quantity")) {
+            const quantity = Number.parseInt(this.getAttribute("quantity"));
+            if (!isNaN(quantity)) {
+                this.content.innerText = formatInteger(quantity);
+            }
+        } else if (this.hasAttribute("content")) {
+            this.content.innerText = this.getAttribute("content");
+        }
+        this.updateSprite();
+        this.updateCounter();
+    }
 
     attributeChangedCallback(name, oldValue, newValue) {
         if (name === "sprite-location") {
@@ -9,5 +56,146 @@ export default class InfoBubble extends HTMLDivElement {
                 self.classList.remove("sprite-right");
             }
         }
+
+        let spriteNeedsUpdating = false;
+
+        if (name === "sprite-type") {
+            this.spriteType = newValue;
+            if (this.spriteType && this.spriteIcon) {
+                spriteNeedsUpdating = true;
+            }
+        }
+
+        if (name === "sprite-icon") {
+            this.spriteIcon = newValue;
+            if (this.spriteType && this.spriteIcon) {
+                spriteNeedsUpdating = true;
+            }
+        }
+
+        if (name === "quantity") {
+            const newQuantity = Number.parseInt(newValue);
+            if (!isNaN(newQuantity)) {
+                this.quantity = newQuantity;
+                this.updateCounter();
+            } else {
+                this.quantity = null;
+            }
+        }
+
+        if (name === "quantity-target") {
+            const newTarget = Number.parseInt(newValue);
+            let small = this.querySelector("small");
+            if (!isNaN(newTarget) && newTarget > 0) {
+                this.quantityTarget = newTarget;
+                if (!small) {
+                    small = document.createElement("small");
+                    this.append(small);
+                }
+                small.innerText = "/" + formatInteger(newValue)
+            } else if (small) {
+                this.quantityTarget = null;
+                small.remove();
+            }
+        }
+
+        if (name === "content") {
+            this.content.innerText = newValue;
+        }
+
+        if (spriteNeedsUpdating) {
+            this.updateSprite();
+        }
+    }
+
+    updateSprite() {
+        if (this.sprite) {
+            this.sprite.remove();
+            this.sprite = null;
+        }
+
+        if (this.spriteType === "item") {
+            this.sprite = document.createElement("item-sprite");
+            this.sprite.setAttribute("item", this.spriteIcon);
+        } else if (this.spriteType === "overlay") {
+            this.sprite = document.createElement("overlay-sprite");
+            this.sprite.setAttribute("icon", this.spriteIcon);
+        } else if (this.spriteType === "pokemon") {
+            this.sprite = document.createElement("pokemon-sprite");
+            this.sprite.setAttribute("species", this.spriteIcon);
+        } else if (this.spriteType === "shiny-pokemon") {
+            this.sprite = document.createElement("pokemon-sprite");
+            this.sprite.setAttribute("species", this.spriteIcon);
+            this.sprite.setAttribute("shiny", "shiny");
+        } else if (this.spriteType === "anti-pokemon") {
+            this.sprite = document.createElement("pokemon-sprite");
+            this.sprite.setAttribute("species", this.spriteIcon);
+            this.sprite.setAttribute("shiny", "anti");
+        }
+
+        if (this.sprite) {
+            this.prepend(this.sprite);
+        }
+    }
+
+    updateCounter() {
+        if (this.updateInterval) {
+            window.clearInterval(this.updateInterval);
+            this.updateInterval = null;
+        }
+
+        if (!this.quantity) {
+            return;
+        }
+
+        let currentCounter = Number.parseInt(this.content.innerText);
+        if (isNaN(currentCounter) || this.content.innerText === "") {
+            this.content.innerText = formatInteger(this.quantity);
+            return;
+        }
+
+        const diff = Math.abs(this.quantity - currentCounter);
+        const sign = Math.sign(this.quantity - currentCounter);
+
+        if (diff === 0) {
+            return;
+        }
+
+        let increasePerStep = Math.floor(diff / 12);
+        let intervalLength = 250;
+        let intervalsLeft = 12;
+        if (diff <= 6) {
+            increasePerStep = 1;
+            intervalLength = 500;
+            intervalsLeft = diff;
+        } else if (increasePerStep === 0) {
+            increasePerStep = 1;
+            intervalLength = Math.floor(3000 / diff);
+            intervalsLeft = diff;
+        }
+
+        const quantityTarget = Number.parseInt(this.getAttribute("quantity-target"));
+
+        this.updateInterval = window.setInterval(
+            () => {
+                if (intervalsLeft <= 1) {
+                    this.content.innerText = formatInteger(this.quantity);
+                    window.clearInterval(this.updateInterval);
+                    this.updateInterval = null;
+                } else {
+                    currentCounter += sign * increasePerStep;
+                    this.content.innerText = formatInteger(currentCounter);
+                }
+                if (quantityTarget && !isNaN(quantityTarget)) {
+                    let small = this.querySelector("small");
+                    if (!small) {
+                        small = document.createElement("small");
+                        this.append(small);
+                    }
+                    small.innerText = "/" + formatInteger(quantityTarget);
+                }
+                intervalsLeft--;
+            },
+            intervalLength);
     }
 }

--- a/modules/web/static/stream-overlay/connection.js
+++ b/modules/web/static/stream-overlay/connection.js
@@ -100,5 +100,6 @@ export function getEventSource() {
     url.searchParams.append("topic", "Inputs");
     url.searchParams.append("topic", "PokenavCall");
     url.searchParams.append("topic", "FishingAttempt");
+    url.searchParams.append("topic", "CustomEvent");
     return new EventSource(url);
 }

--- a/modules/web/static/stream-overlay/content/info-bubbles.js
+++ b/modules/web/static/stream-overlay/content/info-bubbles.js
@@ -18,6 +18,9 @@ const infoBubblePokeNavCalls = document.querySelector("#info-bubble-pokenav span
 const infoBubblePCStorage = document.querySelector("#info-bubble-pc-storage");
 const infoBubblePCStorageNumber = document.querySelector("#info-bubble-pc-storage span");
 
+/** @type {array<InfoBubble>} */
+const customInfoBubbles = [];
+
 const FOSSIL_SPECIES = ["Anorith", "Lileep", "Omanyte", "Kabuto", "Aerodactyl"];
 
 let lastSetAbility = null;
@@ -228,10 +231,42 @@ function updatePokeNavInfoBubble(stats) {
     }
 }
 
+/**
+ * @param {{info_bubble_id: string, info_bubble_type?: string | null, info_bubble_icon?: string | null, quantity?: number, quantityTarget?: number, content?: string}} data
+ */
+function addInfoBubble(data) {
+    if (!customInfoBubbles[data.info_bubble_id]) {
+        customInfoBubbles[data.info_bubble_id] = document.createElement("info-bubble");
+        bubbleContainer.prepend(customInfoBubbles[data.info_bubble_id]);
+    }
+    let infoBubble = customInfoBubbles[data.info_bubble_id];
+
+    if (data.info_bubble_type && data.info_bubble_icon && infoBubble.getAttribute("sprite-type") !== data.info_bubble_type && infoBubble.getAttribute("sprite-icon") !== data.info_bubble_icon) {
+        customInfoBubbles[data.info_bubble_id].setAttribute("sprite-type", data.info_bubble_type);
+        customInfoBubbles[data.info_bubble_id].setAttribute("sprite-icon", data.info_bubble_icon);
+    }
+    if (data.quantity) {
+        customInfoBubbles[data.info_bubble_id].setAttribute("quantity", data.quantity);
+        if (data.quantity_target) {
+            customInfoBubbles[data.info_bubble_id].setAttribute("quantity-target", data.quantity_target);
+        }
+    } else if (data.content) {
+        customInfoBubbles[data.info_bubble_id].setAttribute("content", data.content);
+    }
+}
+
+function hideInfoBubble(infoBubbleID) {
+    if (customInfoBubbles[infoBubbleID]) {
+        customInfoBubbles[infoBubbleID].remove();
+    }
+}
+
 export {
     updateInfoBubbles,
     updateEncounterInfoBubble,
     updateFishingInfoBubble,
     hideFishingInfoBubble,
-    updatePokeNavInfoBubble
+    updatePokeNavInfoBubble,
+    addInfoBubble,
+    hideInfoBubble,
 };

--- a/modules/web/static/stream-overlay/index.html
+++ b/modules/web/static/stream-overlay/index.html
@@ -15,7 +15,7 @@
         import ShinyValue from "./component/shiny-value.js";
 
         customElements.define("crossed-out", CrossedOut);
-        customElements.define("info-bubble", InfoBubble, {extends: "div"});
+        customElements.define("info-bubble", InfoBubble);
         customElements.define("item-sprite", ItemSprite);
         // customElements.define("iv", IV, {extends: "span"});
         customElements.define("iv-sum", IVSum, {extends: "span"});

--- a/modules/web/static/stream-overlay/overlay.js
+++ b/modules/web/static/stream-overlay/overlay.js
@@ -10,7 +10,8 @@ import {updateBadgeList} from "./content/badge-list.js";
 import {updatePhaseStats} from "./content/phase-stats.js";
 import {updatePCStorage, updateTotalStats} from "./content/total-stats.js";
 import {
-    hideFishingInfoBubble,
+    addInfoBubble,
+    hideFishingInfoBubble, hideInfoBubble,
     updateEncounterInfoBubble,
     updateFishingInfoBubble,
     updateInfoBubbles,
@@ -257,6 +258,28 @@ function handleInputs(event, state) {
 }
 
 
+/**
+ * @param {*} event
+ * @param {OverlayState} state
+ */
+function handleCustomEvent(event, state) {
+    console.log(event);
+    if (typeof event !== "object" || !event["action"]) {
+        return;
+    }
+
+    switch (event["action"]) {
+        case "show_info_bubble":
+            addInfoBubble(event);
+            break;
+
+        case "hide_info_bubble":
+            hideInfoBubble(event.info_bubble_id);
+            break;
+    }
+}
+
+
 export default async function runOverlay() {
     const state = new OverlayState();
     window.overlayState = state;
@@ -286,6 +309,7 @@ export default async function runOverlay() {
     eventSource.addEventListener("PokenavCall", event => handlePokenavCall(state));
     eventSource.addEventListener("FishingAttempt", event => handleFishingAttempt(JSON.parse(event.data), state));
     eventSource.addEventListener("Inputs", event => handleInputs(JSON.parse(event.data), state));
+    eventSource.addEventListener("CustomEvent", event => handleCustomEvent(JSON.parse(event.data), state));
 
     if (config.gymMode) {
         document.getElementById("route-encounters").style.display = "none";
@@ -321,4 +345,6 @@ export default async function runOverlay() {
                 .replace("’", "'");
         });
     }
+
+    window.handleCustomEvent = handleCustomEvent;
 }


### PR DESCRIPTION
### Description

This allows bot plugins to send custom HTTP Stream API events for adding, updating, and removing info bubbles in the overlay.

That'll make it a bit easier to show some information without having to update the overlay each time.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
