### PR TITLE
Fix Psyduck safari location

### DIFF
--- a/modules/safari_strategy.py
+++ b/modules/safari_strategy.py
@@ -268,7 +268,7 @@ class SafariPokemonRSE(Enum):
     PSYDUCK = SafariCatchingLocation(
         get_species_by_name("Psyduck"),
         MapRSE.SAFARI_ZONE_SOUTHWEST,
-        (20, 19),
+        (7, 31),
         SafariHuntingMode.SURF,
     )
     GOLDUCK = SafariCatchingLocation(


### PR DESCRIPTION
### Description

Psyduck should only require Surf. The previous location required the Mach Bike, even though the code didn’t include a check for it. This was because the previous location was on the southwest map, but accessing it required passing through the northwest map, which did require the Mach Bike.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)
