### PR TITLE
Fix crash when trying to compute Repel Level during a white-out

### DIFF
--- a/modules/pokemon_party.py
+++ b/modules/pokemon_party.py
@@ -66,8 +66,12 @@ class Party:
         return list(filter(lambda pokemon: not pokemon.is_egg and pokemon.current_hp > 0, self._pokemon))
 
     @property
-    def first_non_fainted(self) -> PartyPokemon:
-        return self.non_fainted_pokemon[0]
+    def first_non_fainted(self) -> PartyPokemon | None:
+        non_fainted_pokemon = self.non_fainted_pokemon
+        if len(non_fainted_pokemon) > 0:
+            return self.non_fainted_pokemon[0]
+        else:
+            return None
 
     def has_pokemon_with_move(self, move: Move | str, with_pp_remaining: bool = False) -> bool:
         return any(pokemon.knows_move(move, with_pp_remaining) and not pokemon.is_egg for pokemon in self._pokemon)
@@ -179,4 +183,8 @@ def get_current_repel_level() -> int:
     :return: The minimum level that wild encounters can have, given the current Repel
              state and the level of the first non-fainted Pokémon.
     """
-    return get_party().first_non_fainted.level if get_event_var("REPEL_STEP_COUNT") > 0 else 0
+    first_non_fainted_party_member = get_party().first_non_fainted
+    if first_non_fainted_party_member is None:
+        return 0
+    else:
+        return get_party().first_non_fainted.level if get_event_var("REPEL_STEP_COUNT") > 0 else 0


### PR DESCRIPTION
### Description

When whiting out, there are briefly no non-fainted Pokémon in the player's party.

This leads to a crash in `get_current_repel_level()` because it tries to access a level of a Pokémon that doesn't exist.


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
