### PR TITLE
Kecleon Mode: Support using the Mach Bike as well

### DIFF
--- a/modules/map_path.py
+++ b/modules/map_path.py
@@ -21,6 +21,7 @@ class Direction(IntEnum):
     def opposite(self):
         return Direction((self.value + 2) % 4)
 
+    @property
     def button_name(self):
         if self is Direction.North:
             return "Up"

--- a/modules/modes/kecleon.py
+++ b/modules/modes/kecleon.py
@@ -1,12 +1,11 @@
 from typing import Generator
 
 from modules.context import context
-from modules.debug import debug
 from modules.encounter import handle_encounter, EncounterInfo
 from modules.items import get_item_by_name
 from modules.map_data import MapRSE
 from modules.memory import get_event_flag
-from modules.player import get_player_avatar, get_player, AvatarFlags
+from modules.player import get_player_avatar, get_player, get_player_location
 from modules.pokemon_party import get_party_size
 from modules.save_data import get_last_heal_location
 from . import BattleAction
@@ -16,9 +15,10 @@ from ._asserts import (
     assert_boxes_or_party_can_fit_pokemon,
 )
 from ._interface import BotMode, BotModeError
-from .util import ensure_facing_direction, navigate_to
+from .util import ensure_facing_direction, navigate_to, mount_bicycle, follow_waypoints
 from ..battle_strategies import BattleStrategy
 from ..battle_strategies.lose_on_purpose import LoseOnPurposeBattleStrategy
+from ..map_path import calculate_path, Direction
 
 
 class KecleonMode(BotMode):
@@ -37,7 +37,6 @@ class KecleonMode(BotMode):
     def __init__(self):
         super().__init__()
         self._has_whited_out = False
-        self._using_bike = False
 
     def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | BattleStrategy | None:
         handle_encounter(encounter, disable_auto_catch=True, enable_auto_battle=True)
@@ -46,13 +45,6 @@ class KecleonMode(BotMode):
     def on_whiteout(self) -> bool:
         self._has_whited_out = True
         return True
-
-    @debug.track
-    def mount_bicycle(self) -> Generator:
-        while AvatarFlags.OnAcroBike not in get_player_avatar().flags:
-            context.emulator.press_button("Select")
-            yield
-        yield
 
     def run(self) -> Generator:
         assert_player_has_poke_balls()
@@ -71,15 +63,27 @@ class KecleonMode(BotMode):
         if get_party_size() > 1:
             raise BotModeError("This mode requires only one Pokémon in the party.")
 
+        use_bicycle = False
+        use_mach_bike = False
         registered = get_player().registered_item
         if registered == get_item_by_name("Acro Bike"):
-            self._using_bike = True
+            use_bicycle = True
+        elif registered == get_item_by_name("Mach Bike"):
+            use_bicycle = True
+            use_mach_bike = True
 
         while context.bot_mode != "Manual":
             self._has_whited_out = False
-            if self._using_bike:
-                yield from self.mount_bicycle()
-            yield from navigate_to(MapRSE.ROUTE119, (31, 7))
+            if use_bicycle:
+                yield from mount_bicycle()
+            if use_mach_bike:
+                yield from follow_waypoints(
+                    calculate_path(get_player_location(), (MapRSE.ROUTE119, (31, 7))),
+                    final_facing_direction=Direction.North,
+                )
+            else:
+                yield from navigate_to(MapRSE.ROUTE119, (31, 7))
+                yield from ensure_facing_direction("Up")
             yield from ensure_facing_direction("Up")
             while not self._has_whited_out:
                 context.emulator.press_button("A")

--- a/wiki/pages/Mode - Kecleon.md
+++ b/wiki/pages/Mode - Kecleon.md
@@ -17,7 +17,7 @@ The mode checks that you have not already defeated this one, if you have, you wi
 
 ### Recommendations
 
-- Have the Acro Bike registered
+- Have the Mach Bike or Acro Bike as your registered item
 
 ### Where to start
 


### PR DESCRIPTION
### Description

This PR (a) updates the Kecleon mode to use the Mach Bike when available (so far it only used the Acro Bike) and (b) adds an optional parameter to `follow_waypoints()` to specify the final facing direction, which can be used to make the player bump into an obstacle when using the Mach Bike.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
