### PR TITLE
Prevent bot listeners from triggering any actions in manual mode

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -102,7 +102,6 @@ def main_loop() -> None:
                 context.bot_listeners = get_bot_listeners(context.rom)
 
             if context.bot_mode == "Manual":
-                context.controller_stack = []
                 if not isinstance(context.bot_mode_instance, ManualBotMode):
                     context.emulator.reset_held_buttons()
                 context.bot_mode_instance = ManualBotMode()
@@ -113,6 +112,8 @@ def main_loop() -> None:
             try:
                 for listener in context.bot_listeners.copy():
                     listener.handle_frame(context.bot_mode_instance, frame_info)
+                if context.bot_mode == "Manual":
+                    context.controller_stack = []
                 if len(context.controller_stack) > 0:
                     next(context.controller_stack[-1])
             except (StopIteration, GeneratorExit):


### PR DESCRIPTION
### Description

A recent fix (#706) was supposed to make bot listener actions (such as dismissing a PokéNav call, or trainer pre-battle dialogue) more reliable.

But unfortunately, that made it _so_ reliable that it would even do that in manual mode.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
