### PR TITLE
Overlay: Make completed entries in section checklist more visible

### DIFF
--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -169,6 +169,11 @@ const updateRouteEncountersList = (encounters, stats, encounterType, checklistCo
                 tick.src = "/static/sprites/stream-overlay/tick.png";
                 tick.classList.add("tick");
                 catches.push(tick);
+            } else if (goal) {
+                const tick = document.createElement("img")
+                tick.src = "/static/sprites/stream-overlay/target.png";
+                tick.classList.add("tick");
+                catches.push(tick);
             }
         }
 

--- a/modules/web/static/stream-overlay/layout/section-checklist.css
+++ b/modules/web/static/stream-overlay/layout/section-checklist.css
@@ -30,6 +30,7 @@
         padding: 0;
 
         li {
+            position: relative;
             display: inline-block;
             border: 1px solid var(--separator-line-colour);
             border-radius: 10px;
@@ -48,13 +49,12 @@
             }
 
             > span {
-                position: relative;
                 display: block;
                 font-size: .75rem;
 
                 img {
                     position: absolute;
-                    bottom: 0;
+                    top: .1em;
                     right: .2em;
                     height: 1em;
                     width: 1em;
@@ -76,10 +76,17 @@
 
             &.completed {
                 background-color: var(--success-background-colour);
+                border: 3px var(--success-border-colour) solid;
+                margin: 2px;
 
                 .tick {
                     display: inline-block;
                 }
+            }
+
+            &.in-progress {
+                border: 3px var(--in-progress-border-colour) solid;
+                margin: 2px;
             }
         }
     }

--- a/modules/web/static/stream-overlay/overlay.css
+++ b/modules/web/static/stream-overlay/overlay.css
@@ -19,7 +19,10 @@
     --video-overlay-background-colour: #000000f6;
     --separator-line-colour: #ffffff2a;
     --lighter-background-colour: #66666655;
-    --success-background-colour: #00800085;
+    --success-background-colour: #00800066;
+
+    --success-border-colour: #018f01;
+    --in-progress-border-colour: #8c8c0d;
 
     --health-bar-red-colour: #ff424288;
     --health-bar-yellow-colour: #ffd70088;

--- a/modules/web/static/stream-overlay/overlay.js
+++ b/modules/web/static/stream-overlay/overlay.js
@@ -46,7 +46,7 @@ async function doFullUpdate(state) {
 
     updateMapName(state.map);
     updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
-    updateSectionChecklist(config.sectionChecklist, state.stats);
+    updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
     updateShinyLog(state.shinyLog);
     updateEncounterLog(state.encounterLog);
     updatePartyList(state.party);
@@ -70,8 +70,9 @@ async function doUpdateAfterEncounter(state) {
         state.shinyLog = shinyLog;
 
         updateShinyLog(state.shinyLog);
-        updateSectionChecklist(config.sectionChecklist, state.stats);
+        updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
         updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
+        updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
         updatePhaseStats(state.stats);
         updateTotalStats(state.stats, state.encounterRate);
         updatePokeNavInfoBubble(null);
@@ -157,6 +158,7 @@ function handleBotMode(event, state) {
     if (previousModeWasDaycare !== newModeIsDaycare) {
         updateDaycareBox(event, state);
         updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
+        updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
     }
 }
 
@@ -190,6 +192,7 @@ function handleWildEncounter(event, state) {
     }
 
     updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, event.pokemon.species_name_for_stats);
+    updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
     updatePhaseStats(state.stats);
     updateTotalStats(state.stats, state.encounterRate);
     updateEncounterInfoBubble(event.pokemon.species_name_for_stats, state.stats, event.pokemon.gender);
@@ -220,6 +223,7 @@ function handleMapChange(event, state) {
 function handleMapEncounters(event, state) {
     state.mapEncounters = event;
     updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
+    updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
 }
 
 /**
@@ -229,6 +233,7 @@ function handleMapEncounters(event, state) {
 function handlePlayerAvatar(event, state) {
     if (state.logPlayerAvatarChange(event)) {
         updateRouteEncountersList(state.mapEncounters, state.stats, state.lastEncounterType, config.sectionChecklist, state.emulator.bot_mode, state.encounterLog, state.additionalRouteSpecies, getLastEncounterSpecies(state.encounterLog));
+        updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
     }
 }
 


### PR DESCRIPTION
### Description

Also:
- add a yellow outline to section checklist for entries that are incomplete but available on the current route
- add a target icon next to incomplete entries in the route encounter list

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
