### PR TITLE
Overlay: Fix alignment of tiles in section checklist

### DIFF
--- a/modules/web/static/stream-overlay/layout/section-checklist.css
+++ b/modules/web/static/stream-overlay/layout/section-checklist.css
@@ -34,13 +34,14 @@
             display: inline-block;
             border: 1px solid var(--separator-line-colour);
             border-radius: 10px;
-            width: 5.58vh;
+            box-sizing: border-box;
+            width: 5.75vh;
             text-align: center;
             margin: 3px;
             padding: .4vh 0;
 
             @media screen and (min-width: 2560px) {
-                width: 5.7vh;
+                width: 5.86vh;
             }
 
             > pokemon-sprite img {
@@ -77,7 +78,6 @@
             &.completed {
                 background-color: var(--success-background-colour);
                 border: 3px var(--success-border-colour) solid;
-                margin: 2px;
 
                 .tick {
                     display: inline-block;
@@ -86,7 +86,6 @@
 
             &.in-progress {
                 border: 3px var(--in-progress-border-colour) solid;
-                margin: 2px;
             }
         }
     }


### PR DESCRIPTION
### Description

Ensures that the tiles in the section checklist are always the same width, regardless of their state (regular / in progress / completed)

So that WhiskyPapa can be happy again

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
