### PR TITLE
Slightly speed up pathfinding by adding some caching

### DIFF
--- a/modules/modes/util/walking.py
+++ b/modules/modes/util/walking.py
@@ -113,7 +113,7 @@ class TimedOutTryingToReachWaypointError(BotModeError):
 
 @debug.track
 def follow_waypoints(
-    path: Iterable[Waypoint], run: bool = True, final_facing_direction: Direction | None = None
+    path: Iterable[Waypoint | None], run: bool = True, final_facing_direction: Direction | None = None
 ) -> Generator:
     """
     Follows a given set of waypoints.
@@ -161,6 +161,10 @@ def follow_waypoints(
     current_position = get_map_data_for_current_position()
     last_waypoint = None
     for waypoint in path:
+        if waypoint is None:
+            yield
+            continue
+
         # For the first waypoint it is possible that the player avatar is not facing the same way as it needs to
         # walk. This leads to the first navigation step to actually become two: Turning around, then doing the step.
         # When in tall grass, that could lead to an encounter starting mid-step which messes up the battle handling.


### PR DESCRIPTION
### Description

Originally I was trying to make `calculate_path()` asynchronous, i.e. run in a different thread, so the game wouldn't briefly freeze up while finding the best path.

Unfortunately, that didn't really make much of a difference. There was still a very noticeable stutter. Too bad.

But while working on that, I've tweaked the routines a little bit and found two places where caching improved things.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
