### PR TITLE
Allow modifying a Pokémon's contest stats in debug utilities

### DIFF
--- a/modules/debug_utilities.py
+++ b/modules/debug_utilities.py
@@ -42,6 +42,7 @@ from modules.pokemon import (
     get_nature_by_name,
     get_species_by_national_dex,
     LearnedMove,
+    ContestConditions,
 )
 from modules.pokemon_party import get_party
 from modules.roms import ROMLanguage
@@ -126,6 +127,7 @@ def debug_create_pokemon(
     evs: StatsValues | None = None,
     current_hp: int | None = None,
     status_condition: StatusCondition = StatusCondition.Healthy,
+    contest_conditions: ContestConditions | None = None,
 ) -> Pokemon:
     """
     Generates a Pokémon data block given a set of criteria.
@@ -271,6 +273,17 @@ def debug_create_pokemon(
     if is_egg and friendship > species.egg_cycles:
         friendship = species.egg_cycles
 
+    contest_conditions_data = decrypted_data[62:68]
+    if contest_conditions is not None:
+        contest_conditions_data = (
+            pack_uint8(contest_conditions.coolness)
+            + pack_uint8(contest_conditions.beauty)
+            + pack_uint8(contest_conditions.cuteness)
+            + pack_uint8(contest_conditions.smartness)
+            + pack_uint8(contest_conditions.toughness)
+            + pack_uint8(contest_conditions.feel)
+        )
+
     data_to_encrypt = (
         pack_uint16(species.index)
         + pack_uint16(held_item.index if held_item is not None else 0)
@@ -292,7 +305,8 @@ def debug_create_pokemon(
         + pack_uint8(evs.speed)
         + pack_uint8(evs.special_attack)
         + pack_uint8(evs.special_defence)
-        + decrypted_data[62:72]
+        + contest_conditions_data
+        + decrypted_data[68:72]
         + pack_uint32(iv_egg_ability)
         + decrypted_data[76:80]
     )

--- a/modules/gui/debug_edit_party.py
+++ b/modules/gui/debug_edit_party.py
@@ -16,6 +16,7 @@ from modules.pokemon import (
     get_move_by_name,
     get_species_by_name,
     LearnedMove,
+    ContestConditions,
 )
 from modules.pokemon_party import get_party
 
@@ -126,6 +127,15 @@ class PokemonEditFrame:
             "special_defence": tkinter.IntVar(value=pokemon.evs.special_defence),
         }
 
+        self._contest_conditions = {
+            "coolness": tkinter.IntVar(value=pokemon.contest_conditions.coolness),
+            "beauty": tkinter.IntVar(value=pokemon.contest_conditions.beauty),
+            "cuteness": tkinter.IntVar(value=pokemon.contest_conditions.cuteness),
+            "smartness": tkinter.IntVar(value=pokemon.contest_conditions.smartness),
+            "toughness": tkinter.IntVar(value=pokemon.contest_conditions.toughness),
+            "feel": tkinter.IntVar(value=pokemon.contest_conditions.feel),
+        }
+
         self._moves = (
             tkinter.StringVar(value=pokemon.moves[0].move.name if pokemon.moves[0] is not None else "(None)"),
             tkinter.StringVar(value=pokemon.moves[1].move.name if pokemon.moves[1] is not None else "(None)"),
@@ -211,6 +221,14 @@ class PokemonEditFrame:
             ),
             current_hp=self._current_hp_var.get(),
             status_condition=status_name_map[self._status_condition.get()],
+            contest_conditions=ContestConditions(
+                self._contest_conditions["coolness"].get(),
+                self._contest_conditions["beauty"].get(),
+                self._contest_conditions["cuteness"].get(),
+                self._contest_conditions["smartness"].get(),
+                self._contest_conditions["toughness"].get(),
+                self._contest_conditions["feel"].get(),
+            ),
         )
 
     def _build_frame(self) -> ttk.Frame:
@@ -436,6 +454,19 @@ class PokemonEditFrame:
         self._status_condition.current(list(status_name_map.values()).index(self._pokemon.status_condition))
         self._status_condition.grid(sticky="W", column=0, row=1)
         status_frame.grid(sticky="W", column=0, row=8, padx=5, pady=(0, 5))
+
+        contest_frame = ttk.Frame(right_box)
+        label = ttk.Label(contest_frame, text="Contest Conditions:")
+        label.grid(sticky="W", column=0, row=0)
+        n = 1
+        for condition in ["coolness", "beauty", "cuteness", "smartness", "toughness", "feel"]:
+            ttk.Label(contest_frame, text=condition.title()).grid(sticky="W", column=0, row=n)
+            condition_field = ttk.Spinbox(
+                contest_frame, from_=0, to=255, width=3, textvariable=self._contest_conditions[condition]
+            )
+            condition_field.grid(sticky="W", column=1, row=n, padx=5)
+            n += 1
+        contest_frame.grid(sticky="W", column=0, row=9, padx=5, pady=(8, 5))
 
         def recalculate_max_hp(var=None, index=None, mode=None):
             if self._species is None:


### PR DESCRIPTION
### Description

This adds some input fields for the contest stats (Coolness, Beauty, etc.) to the 'Edit Party' debug utility.
<img width="668" height="626" alt="image" src="https://github.com/user-attachments/assets/a1045f66-8fad-479f-8f30-2909a8a7b9b7" />

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
