### PR TITLE
Overlay: Listen to more custom events and observe custom state

### DIFF
--- a/modules/web/static/stream-overlay/config.dist.js
+++ b/modules/web/static/stream-overlay/config.dist.js
@@ -42,6 +42,12 @@ const config = {
     // in the PC storage system.
     showPCStorageCounter: false,
 
+    // An ISO date string (e.g. `2025-01-01T12:34:56` or a UNIX
+    // timestamp (in seconds or ms.) If set, the overlay will
+    // display an info bubble counting down to that moment in
+    // time.
+    countdownTarget: null,
+
     // These can be used to hardcode the longest phase in case
     // this data is incorrect in the stats database.
     overrideLongestPhase: {

--- a/modules/web/static/stream-overlay/connection.js
+++ b/modules/web/static/stream-overlay/connection.js
@@ -40,11 +40,14 @@ export const fetchers = {
 
     /** @return {Promise<PokeBotApi.GetDaycareResponse>} */
     daycare: () => fetch("/daycare").then(response => response.json()),
+
+    /** @return {Promise<object>} */
+    customState: () => fetch("/custom_state").then(response => response.json()),
 };
 
 /**
  * @param {OverlayState} state
- * @return {Promise<OverlayState>}
+ * @return {Promise<object>}
  */
 export function loadAllData(state) {
     return new Promise((resolve, reject) => {
@@ -62,6 +65,7 @@ export function loadAllData(state) {
                 fetchers.gameState(),
                 fetchers.pokemonStorage(),
                 fetchers.daycare(),
+                fetchers.customState(),
             ]).then(
                 data => {
                     state.stats = data[0];
@@ -78,7 +82,7 @@ export function loadAllData(state) {
                     state.pokemonStorage = data[11];
                     state.daycare = data[12];
                     state.reset();
-                    resolve();
+                    resolve(data[13]);
                 },
                 reject);
         }

--- a/modules/web/static/stream-overlay/content/effects.js
+++ b/modules/web/static/stream-overlay/content/effects.js
@@ -1,0 +1,22 @@
+function fireConfetti(booms, durationInSections) {
+    let remaining = booms;
+    const maxDelay = Math.round(1000 * 2 * durationInSections / booms);
+
+    const fireOneConfetti = () => {
+        let x, y;
+        do {
+            x = Math.floor(Math.random() * 100);
+            y = Math.floor(Math.random() * 100);
+        } while (x < 57 && y < 66);
+
+        confetti({position: {x, y}});
+
+        if (--remaining > 0) {
+            window.setTimeout(() => fireOneConfetti(), Math.floor(Math.random() * maxDelay));
+        }
+    };
+
+    fireOneConfetti();
+}
+
+export {fireConfetti};

--- a/modules/web/static/stream-overlay/content/info-bubbles.js
+++ b/modules/web/static/stream-overlay/content/info-bubbles.js
@@ -17,6 +17,8 @@ const infoBubblePokeNav = document.querySelector("#info-bubble-pokenav");
 const infoBubblePokeNavCalls = document.querySelector("#info-bubble-pokenav span");
 const infoBubblePCStorage = document.querySelector("#info-bubble-pc-storage");
 const infoBubblePCStorageNumber = document.querySelector("#info-bubble-pc-storage span");
+const infoBubbleCountdown = document.querySelector("#info-bubble-countdown");
+const infoBubbleCountdownText = document.querySelector("#info-bubble-countdown span");
 
 /** @type {array<InfoBubble>} */
 const customInfoBubbles = [];
@@ -31,6 +33,8 @@ const targetTimerBubbles = {};
 let lastFemale = null;
 /** @type {number | null} */
 let pcStorageTimer = null;
+/** @type {number | null} */
+let countdownTimer = null;
 
 /**
  * @param {StreamEvents.MapEncounters} mapEncounters
@@ -38,8 +42,9 @@ let pcStorageTimer = null;
  * @param {string[] | null} targetTimers
  * @param {EncounterType} lastEncounterType
  * @param {Pokemon[]} party
+ * @param {number | null} countdownTarget
  */
-function updateInfoBubbles(mapEncounters, stats, targetTimers, lastEncounterType, party) {
+function updateInfoBubbles(mapEncounters, stats, targetTimers, lastEncounterType, party, countdownTarget) {
     let activeAbility = mapEncounters.active_ability;
     if (lastEncounterType === "hatched") {
         for (const member of party) {
@@ -128,6 +133,15 @@ function updateInfoBubbles(mapEncounters, stats, targetTimers, lastEncounterType
         bubbleContainer.append(bubble);
         updateEncounterInfoBubble(speciesName, stats);
     }
+    for (const speciesName of Object.keys(targetTimerBubbles)) {
+        if (!targetTimers.includes(speciesName)) {
+            targetTimerBubbles[speciesName][0].remove();
+            if (targetTimerBubbles[speciesName][3]) {
+                window.clearTimeout(targetTimerBubbles[speciesName][3])
+            }
+            delete targetTimerBubbles[speciesName];
+        }
+    }
 
     updateFishingInfoBubble(stats);
     updatePokeNavInfoBubble(stats);
@@ -142,6 +156,87 @@ function updateInfoBubbles(mapEncounters, stats, targetTimers, lastEncounterType
         infoBubblePCStorage.style.display = "inline-block";
         updatePCStorageCounter();
         pcStorageTimer = window.setInterval(updatePCStorageCounter, 10000);
+    }
+
+    if (countdownTimer) {
+        window.clearInterval(countdownTimer);
+        countdownTimer = null;
+    }
+    if (countdownTarget) {
+        let targetTimestamp;
+        if (typeof countdownTarget === "string") {
+            targetTimestamp = new Date(countdownTarget).getTime();
+        } else if (countdownTarget < 10000000000) {
+            targetTimestamp = countdownTarget * 1000;
+        } else {
+            targetTimestamp = countdownTarget;
+        }
+
+        if (targetTimestamp > new Date().getTime()) {
+            infoBubbleCountdown.style.opacity = "1";
+            infoBubbleCountdown.style.display = "inline-block";
+            const updateCountdown = () => {
+                const now = new Date().getTime();
+                const diff = Math.floor((targetTimestamp - now) / 1000);
+                if (now < targetTimestamp) {
+                    const days = Math.floor(diff / 86400);
+                    const hours = Math.floor((diff % 86400) / 3600);
+                    const minutes = Math.floor((diff % 3600) / 60);
+                    const seconds = Math.floor(diff % 60);
+
+                    const timeString = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
+
+                    if (days > 0) {
+                        if (days > 9) {
+                            infoBubbleCountdownText.style.minWidth = "13vh";
+                        } else {
+                            infoBubbleCountdownText.style.minWidth = "12vh";
+                        }
+                        infoBubbleCountdownText.innerHTML = `${days.toLocaleString('en')} <small>day${days !== 1 ? 's' : ''}</small> ${timeString}`;
+                    } else {
+                        infoBubbleCountdownText.style.minWidth = "7.1vh";
+                        infoBubbleCountdownText.innerText = timeString;
+                    }
+                } else {
+                    const fadeOutInSeconds = 1.0;
+
+                    infoBubbleCountdownText.innerText = "00:00:00";
+                    infoBubbleCountdown.style.opacity = "1";
+                    const bbox = infoBubbleCountdown.getBoundingClientRect();
+                    infoBubbleCountdown.style.width = `${bbox.width}px`;
+                    infoBubbleCountdown.style.height = `${bbox.height}px`;
+                    infoBubbleCountdown.style.boxSizing = "border-box";
+                    infoBubbleCountdown.style.transition = `opacity ${fadeOutInSeconds}s, width ${fadeOutInSeconds}s, padding ${fadeOutInSeconds}s, margin ${fadeOutInSeconds}s`;
+                    infoBubbleCountdown.style.opacity = "0";
+                    window.clearInterval(countdownTimer);
+                    countdownTimer = null;
+
+                    window.setTimeout(
+                        () => {
+                            infoBubbleCountdown.style.overflow = "hidden";
+                            infoBubbleCountdown.style.width = "0";
+                            infoBubbleCountdown.style.padding = "0";
+                            infoBubbleCountdown.style.margin = "0 -.5vh";
+                        },
+                        Math.round(fadeOutInSeconds * 1000));
+
+                    window.setTimeout(
+                        () => {
+                            infoBubbleCountdown.style.display = "none";
+                            infoBubbleCountdown.style.transition = "";
+                            infoBubbleCountdown.style.opacity = "1";
+                        },
+                        Math.round(fadeOutInSeconds * 2000));
+                }
+            };
+
+            updateCountdown();
+            countdownTimer = window.setInterval(updateCountdown, 1000);
+        } else {
+            infoBubbleCountdown.style.display = "none";
+        }
+    } else {
+        infoBubbleCountdown.style.display = "none";
     }
 }
 
@@ -232,7 +327,7 @@ function updatePokeNavInfoBubble(stats) {
 }
 
 /**
- * @param {{info_bubble_id: string, info_bubble_type?: string | null, info_bubble_icon?: string | null, quantity?: number, quantityTarget?: number, content?: string}} data
+ * @param {{info_bubble_id: string, info_bubble_type?: string | null, info_bubble_icon?: string | null, quantity?: number, quantity_target?: number, content?: string}} data
  */
 function addInfoBubble(data) {
     if (!customInfoBubbles[data.info_bubble_id]) {
@@ -258,6 +353,14 @@ function addInfoBubble(data) {
 function hideInfoBubble(infoBubbleID) {
     if (customInfoBubbles[infoBubbleID]) {
         customInfoBubbles[infoBubbleID].remove();
+        delete customInfoBubbles[infoBubbleID];
+    }
+}
+
+function resetCustomInfoBubbles() {
+    for (const infoBubbleID of Object.keys(customInfoBubbles)) {
+        customInfoBubbles[infoBubbleID].remove();
+        delete customInfoBubbles[infoBubbleID];
     }
 }
 
@@ -269,4 +372,5 @@ export {
     updatePokeNavInfoBubble,
     addInfoBubble,
     hideInfoBubble,
+    resetCustomInfoBubbles,
 };

--- a/modules/web/static/stream-overlay/index.html
+++ b/modules/web/static/stream-overlay/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8">
     <title>Pokébot Stream Overlay</title>
     <link rel="stylesheet" href="./overlay.css">
+    <script
+            src="https://cdn.jsdelivr.net/npm/@tsparticles/confetti@3.8.1/tsparticles.confetti.bundle.min.js"
+            integrity="sha256-OhfF5yL+PiodJnHS2c4mELxcSTKmox6NepyYTmwVn+U="
+            crossorigin="anonymous"></script>
     <script type="module">
         import CrossedOut from "./component/crossed-out.js";
         import InfoBubble from "./component/info-bubble.js";
@@ -67,6 +71,11 @@
             <info-bubble id="info-bubble-repel" style="display: none">
                 <item-sprite item="Repel"></item-sprite>
                 Repel <small>Lvl.</small> <span></span>
+            </info-bubble>
+
+            <info-bubble id="info-bubble-countdown" style="display: none">
+                <overlay-sprite icon="clock" style="transform: scale(2)"></overlay-sprite>
+                <span style="display: inline-block"></span>
             </info-bubble>
         </div>
 

--- a/modules/web/static/stream-overlay/state.js
+++ b/modules/web/static/stream-overlay/state.js
@@ -1,3 +1,5 @@
+import config from "./config.js";
+
 export const WILD_ENCOUNTER_TYPES = [
     "land",
     "surfing",
@@ -106,6 +108,12 @@ export default class OverlayState {
         step_counter: 0,
     };
 
+    /** @type {number | null} */
+    countdownTarget = config.countdownTarget ?? null;
+
+    /** @type {Set<string>} */
+    additionalTargetTimers = new Set();
+
     /** @type {Set<string>} */
     additionalRouteSpecies = new Set();
 
@@ -126,6 +134,18 @@ export default class OverlayState {
         if (this.lastEncounter && ["hatched", "gift", "static"].includes(this.lastEncounter.type)) {
             this.additionalRouteSpecies.add(this.lastEncounter.pokemon.species_name_for_stats);
         }
+    }
+
+    /** @returns {string[]} */
+    get targetTimers() {
+        const timers = new Set();
+        for (const speciesName of config.targetTimers) {
+            timers.add(speciesName);
+        }
+        for (const speciesName of this.additionalTargetTimers) {
+            timers.add(speciesName);
+        }
+        return [...timers];
     }
 
     /** @return {Encounter|null} */

--- a/modules/web/static/stream-overlay/stream-overlay-config.d.ts
+++ b/modules/web/static/stream-overlay/stream-overlay-config.d.ts
@@ -23,6 +23,7 @@ declare namespace StreamOverlay {
 
         showPokeNavCallCounter: boolean;
         showPCStorageCounter: boolean;
+        countdownTarget: string | number;
 
         overrideLongestPhase?: {
             species_name: string;


### PR DESCRIPTION
### Description

This makes use of the (relatively new) HTTP custom state/events API to allow plugins to do some things in the overlay:

- add/remove custom info bubbles (was already sort of possible before, but I improved on it)
- add/remove species timer
- add countdown info bubble
- trigger confetti 🎊

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
