### PR TITLE
Fix crash in GenerateEncounterMedia plugin

### DIFF
--- a/modules/built_in_plugins/generate_encounter_media.py
+++ b/modules/built_in_plugins/generate_encounter_media.py
@@ -75,7 +75,8 @@ class GenerateEncounterMediaPlugin(BotPlugin):
 
     def on_battle_started(self, encounter: "EncounterInfo | None") -> Generator | None:
         if self._listener is not None:
-            context.bot_listeners.remove(self._listener)
+            if self._listener in context.bot_listeners:
+                context.bot_listeners.remove(self._listener)
             self._listener = None
 
         if context.config.logging.shiny_gifs:

--- a/modules/modes/_interface.py
+++ b/modules/modes/_interface.py
@@ -142,7 +142,7 @@ class BotMode:
         """
         pass
 
-    def on_repel_effect_ended(self) -> None:
+    def on_repel_effect_ended(self) -> Generator | None:
         """
         When the Repel effect expires (number of steps have been reached), the game will
         display a message.

--- a/modules/modes/util/higher_level_actions.py
+++ b/modules/modes/util/higher_level_actions.py
@@ -556,7 +556,8 @@ def talk_to_npc(local_object_id: int):
 
 @debug.track
 def mount_bicycle():
-    if get_player_avatar().is_on_bike:
+    avatar = get_player_avatar()
+    if avatar.is_on_bike or avatar.is_in_water:
         return
 
     registered_item = get_player().registered_item
@@ -577,7 +578,8 @@ def mount_bicycle():
 
 @debug.track
 def unmount_bicycle():
-    if not get_player_avatar().is_on_bike:
+    avatar = get_player_avatar()
+    if not avatar.is_on_bike or avatar.is_in_water:
         return
 
     registered_item = get_player().registered_item

--- a/modules/pokemon_party.py
+++ b/modules/pokemon_party.py
@@ -54,11 +54,11 @@ class Party:
         return any([pokemon.is_egg for pokemon in self._pokemon])
 
     @property
-    def eggs(self) -> list[Pokemon]:
+    def eggs(self) -> list[PartyPokemon]:
         return [pokemon for pokemon in self._pokemon if pokemon.is_egg]
 
     @property
-    def non_eggs(self) -> list[Pokemon]:
+    def non_eggs(self) -> list[PartyPokemon]:
         return [pokemon for pokemon in self._pokemon if not pokemon.is_egg]
 
     @property
@@ -99,7 +99,7 @@ class Party:
                 return party_index
         raise RuntimeError("This Pokémon is not in the player's party.")
 
-    def to_list(self) -> list[PartyPokemon]:
+    def to_list(self) -> list[dict]:
         return [pokemon.to_dict() for pokemon in self._pokemon]
 
 


### PR DESCRIPTION
### Description

If the bot is started and the save state is _during_ a shiny encounter, then for the next encounter the `GenerateEncounterMedia` plugin will raise an error because it cannot find its listener in the controller stack even though it has seen a shiny encounter.

That usually only happened during development, but it was mildly annoying.

Also, this PR fixes a few type hints.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
