### PR TITLE
Fix overlay occasionally showing wrong encounter info

### DIFF
--- a/modules/web/http_stream.py
+++ b/modules/web/http_stream.py
@@ -329,7 +329,7 @@ def run_watcher():
                     send_message(DataSubscription.Map, data=current_coords, event_type="MapTileChange")
                     previous_game_state["map_local_coordinates"] = current_coords
 
-        if subscriptions["MapEncounters"] > 0:
+        if subscriptions["MapEncounters"] > 0 and current_game_state is GameState.OVERWORLD:
             if state_cache.effective_wild_encounters.age_in_frames >= 300:
                 # If the cached encounter data is too old, tell the main thread to update it at the next
                 # possible opportunity.


### PR DESCRIPTION
### Description

The HTTP stream API regularly checks for updates to the map encounters table, but does not verify that the game is in the overworld during that check.

Due to that, occasionally the API sent invalid data.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
