### PR TITLE
Fix move selection for Pokémon with <4 moves

### DIFF
--- a/modules/battle_menuing.py
+++ b/modules/battle_menuing.py
@@ -29,14 +29,14 @@ def _select_in_menu(cursor_symbol: str, target_index: int, use_third_byte: bool 
                 yield
             break
         else:
-            if current_index > 1 and target_index <= 1:
-                context.emulator.press_button("Up")
-            elif current_index <= 1 and target_index > 1:
-                context.emulator.press_button("Down")
-            elif current_index in (1, 3):
+            if current_index in (1, 3) and target_index in (0, 2):
                 context.emulator.press_button("Left")
-            else:
+            elif current_index in (0, 2) and target_index in (1, 3):
                 context.emulator.press_button("Right")
+            elif current_index > 1 and target_index <= 1:
+                context.emulator.press_button("Up")
+            else:
+                context.emulator.press_button("Down")
         yield
         yield
         first_iteration = False


### PR DESCRIPTION
### Description

There was a case where the battle handler would get stuck. The following scenario:

1. A Pokémon with 3 moves is in battle.
2. For one or more turns, the battle handler uses move #2 (top right)
3. Now, this move should no longer be used for some reason (out of PP, disabled, ...)
4. Bot wants to use move #3 (bottom left)
5. It would now try to reach that menu entry by pressing `Down` and then `Left` -- but because there is no 4th move, pressing `Down` doesn't to anything.

This has been fixed by prioritising Left/Right over Up/Down.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
