### PR TITLE
Prevent notification for duplicate encounters

### DIFF
--- a/modules/config/schemas_v1.py
+++ b/modules/config/schemas_v1.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Literal
 
 from confz import BaseConfig
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field
 from pydantic.types import Annotated, ClassVar, NonNegativeInt, PositiveInt
 
 
@@ -191,6 +190,7 @@ class Logging(BaseConfig):
 
     filename: ClassVar = "logging.yml"
     save_pk3: LoggingSavePK3 = Field(default_factory=lambda: LoggingSavePK3())
+    create_save_state_for_shiny: bool = True
     log_encounters: bool = False
     log_encounters_to_console: bool = True
     desktop_notifications: bool = True


### PR DESCRIPTION
### Description

Previously, if you loaded one of the save states that is automatically created when encountering a shiny, the bot would immediately send a desktop notification and create a save state because the battle/egg listener would see it as a new encounter.

I've fixed this so it at least checks whether the encounter equals the previously last-seen encounter. So this won't help if you load an older save state, but at least the typical testing scenario of restarting the bot and then ending up with the auto save is covered.

In addition to that, I have added a (hidden) config option: Setting `create_save_state_for_shiny` to `false` in `logging.yml` will disable this automatic creation of save states entirely. Useful for testing when you cheat in a lot of shinies.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
