### PR TITLE
Overlay: Correctly mark targets that have never been encountered

### DIFF
--- a/modules/web/static/stream-overlay/content/info-bubbles.js
+++ b/modules/web/static/stream-overlay/content/info-bubbles.js
@@ -251,8 +251,8 @@ function updateEncounterInfoBubble(speciesName, stats, encounterGender) {
     }
 
     if (!stats.pokemon.hasOwnProperty(speciesName)) {
-        targetTimerBubbles[speciesName][0].style.display = "none";
-        targetTimerBubbles[speciesName][1].innerText = "?";
+        // targetTimerBubbles[speciesName][0].style.display = "none";
+        targetTimerBubbles[speciesName][1].innerText = "never";
         return;
     }
 

--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -6,7 +6,7 @@ import {
     renderTableRow,
     br,
     small,
-    getSpeciesGoal, overlaySprite
+    getSpeciesGoal, overlaySprite, getEmptySpeciesEntry
 } from "../helper.js";
 
 const mapNameSpan = document.querySelector("#route-encounters > h2 > span");
@@ -134,48 +134,47 @@ const updateRouteEncountersList = (encounters, stats, encounterType, checklistCo
     tbody.innerHTML = "";
 
     for (const encounter of encounterList) {
-        const species = stats.pokemon[encounter.species_name] ?? null;
+        const species = stats.pokemon[encounter.species_name] ?? getEmptySpeciesEntry(encounter.species_id, encounter.species_name);
         const currentPhase = stats.current_phase;
 
         let catches = "0";
         let totalEncounters = "0";
-        if (species) {
-            const goal = getSpeciesGoal(encounter.species_name, checklistConfig, stats);
-            if (goal) {
-                catches = [species.catches, small(`/${goal}`)];
-            } else {
-                catches = [formatInteger(species.catches)];
-            }
-            totalEncounters = [formatInteger(species.total_encounters)];
 
-            if (species.shiny_encounters > 0) {
-                const shinyRate = Math.round(species.total_encounters / species.shiny_encounters).toLocaleString("en");
-                const shinyRateLabel = document.createElement("span");
-                shinyRateLabel.classList.add("shiny-rate");
-                const sparkles = overlaySprite("sparkles");
-                shinyRateLabel.append("(", sparkles, ` 1/${shinyRate})`);
-                totalEncounters.push(shinyRateLabel);
-            }
+        const goal = getSpeciesGoal(encounter.species_name, checklistConfig, stats);
+        if (goal) {
+            catches = [species.catches, small(`/${goal}`)];
+        } else {
+            catches = [formatInteger(species.catches)];
+        }
+        totalEncounters = [formatInteger(species.total_encounters)];
 
-            if (species.shiny_encounters > species.catches) {
-                const missedShinies = species.shiny_encounters - species.catches;
-                const missedShiniesLabel = document.createElement("span");
-                missedShiniesLabel.classList.add("missed-shinies")
-                missedShiniesLabel.textContent = `(${formatInteger(missedShinies)} missed)`;
-                catches.push(missedShiniesLabel);
-            }
+        if (species.shiny_encounters > 0) {
+            const shinyRate = Math.round(species.total_encounters / species.shiny_encounters).toLocaleString("en");
+            const shinyRateLabel = document.createElement("span");
+            shinyRateLabel.classList.add("shiny-rate");
+            const sparkles = overlaySprite("sparkles");
+            shinyRateLabel.append("(", sparkles, ` 1/${shinyRate})`);
+            totalEncounters.push(shinyRateLabel);
+        }
 
-            if (goal && species.catches >= goal) {
-                const tick = document.createElement("img")
-                tick.src = "/static/sprites/stream-overlay/tick.png";
-                tick.classList.add("tick");
-                catches.push(tick);
-            } else if (goal) {
-                const tick = document.createElement("img")
-                tick.src = "/static/sprites/stream-overlay/target.png";
-                tick.classList.add("tick");
-                catches.push(tick);
-            }
+        if (species.shiny_encounters > species.catches) {
+            const missedShinies = species.shiny_encounters - species.catches;
+            const missedShiniesLabel = document.createElement("span");
+            missedShiniesLabel.classList.add("missed-shinies")
+            missedShiniesLabel.textContent = `(${formatInteger(missedShinies)} missed)`;
+            catches.push(missedShiniesLabel);
+        }
+
+        if (goal && species.catches >= goal) {
+            const tick = document.createElement("img")
+            tick.src = "/static/sprites/stream-overlay/tick.png";
+            tick.classList.add("tick");
+            catches.push(tick);
+        } else if (goal) {
+            const tick = document.createElement("img")
+            tick.src = "/static/sprites/stream-overlay/target.png";
+            tick.classList.add("tick");
+            catches.push(tick);
         }
 
         let spriteType = "normal";

--- a/modules/web/static/stream-overlay/helper.js
+++ b/modules/web/static/stream-overlay/helper.js
@@ -467,3 +467,24 @@ export function getLastEncounterSpecies(encounterLog) {
         return null;
     }
 }
+
+
+export function getEmptySpeciesEntry(speciesID, speciesName) {
+    return {
+        species_id: speciesID,
+        species_name: speciesName,
+        total_encounters: 0,
+        shiny_encounters: 0,
+        catches: 0,
+        total_highest_iv_sum: null,
+        total_lowest_iv_sum: null,
+        total_highest_sv: null,
+        total_lowest_sv: null,
+        phase_encounters: 0,
+        phase_highest_iv_sum: null,
+        phase_lowest_iv_sum: null,
+        phase_highest_sv: null,
+        phase_lowest_sv: null,
+        last_encounter_time: null,
+    }
+}


### PR DESCRIPTION
### Description

If a target has not been encountered yet (i.e. has no entry in the `encounter_summaries` table), the overlay would not mark it as a target.

It would also not show the target timer if the species was configured to have one.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
