### PR TITLE
Fix RS JP version encounter logging

### DIFF
--- a/modules/data/symbols/patches/language/pokeruby.yml
+++ b/modules/data/symbols/patches/language/pokeruby.yml
@@ -110,8 +110,9 @@ gBattlescriptCurrInstr:
   J: 0x2024970
 GTASKS:
   J: 0x3004a50
+## The Window struct doesn't contain the language value in JP, so we read at address -2 (language struct is 0x2)
 gWindowTemplate_Contest_MoveDescription:
-  J: 0x3004160
+  J: 0x300415e
 gEnemyParty:
   J: 0x30044f0
 gBattleTypeFlags:

--- a/modules/data/symbols/patches/language/pokesapphire.yml
+++ b/modules/data/symbols/patches/language/pokesapphire.yml
@@ -110,8 +110,9 @@ gBattlescriptCurrInstr:
   J: 0x2024970
 GTASKS:
   J: 0x3004a50
+## The Window struct doesn't contain the language value in JP, so we read at address -2 (language struct is 0x2)
 gWindowTemplate_Contest_MoveDescription:
-  J: 0x3004160
+  J: 0x300415e
 gEnemyParty:
   J: 0x30044f0
 gBattleTypeFlags:


### PR DESCRIPTION
### Description

The Japanese version of Ruby and Sapphire uses a struct that does not include a language value. Previously, the code was reading from the wrong offset in the struct, which caused encounter logging to behave inconsistently.

This PR corrects the symbol location to read the proper data, ensuring that the text state is read correctly.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
