### PR TITLE
Faster berry blending

### DIFF
--- a/wiki/pages/Mode - Berry Blender.md
+++ b/wiki/pages/Mode - Berry Blender.md
@@ -11,6 +11,9 @@ one with 1-3 NPCs around it as the empty ones are for multiplayer only.)
 
 ![image](../images/berry_blender_table.png)
 
+It is recommended to use the "L=A" button setting, which allows the bot
+to make more hits in quick succession.
+
 ## Game Support
 |          | 🟥 Ruby | 🔷 Sapphire | 🟢 Emerald |
 |:---------|:-------:|:-----------:|:----------:|


### PR DESCRIPTION
### Description

Uses a wider hit range since hits at the start increase speed in addition to perfects.

Alternates between A and L presses, since with the L=A setting you can do a full A press on every frame, including hitting 2 perfects on some early passes.

Intentionally misses at the end of the blend to slow the blender down, which brings up the results screen faster.  It uses the memory which diplays the red bar at the top to know when the blend is close to done.

### Changes

<!-- In depth changes per file, if feasible -->

### Notes

<!-- Anything to be considered by reviewers -->

### Checklist

<!-- Pre-merge checks that should be completed -->

- [ X ] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [ X ] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->

Side-by-side comparison of changes: https://discord.com/channels/1057088810950860850/1111076425559199787/1400677092173152359