### PR TITLE
Add missing FR/LG symbols for Daycare Pokémon release

### DIFF
--- a/modules/data/symbols/patches/language/pokefirered.yml
+++ b/modules/data/symbols/patches/language/pokefirered.yml
@@ -548,6 +548,12 @@ gPokemonStoragePtr:
   I: 0x3004f60
   J: 0x3005050
   S: 0x3004f60
+gStorage:
+  J: 0x20396fc
+sCursorArea:
+  J: 0x203976c
+sCursorPosition:
+  J: 0x203976d
 #-------------------------#
 
 #--------------#

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -543,6 +543,12 @@ gPokemonStoragePtr:
   I: 0x3004f60
   J: 0x3005050
   S: 0x3004f60
+gStorage:
+  J: 0x20396fc
+sCursorArea:
+  J: 0x203976c
+sCursorPosition:
+  J: 0x203976d
 #-------------------------#
 
 #--------------#


### PR DESCRIPTION
### Description

Not pointing fingers about who broke JP daycare compatibility, but let’s just say it wasn’t me 🤓 

### Changes

- Add missing FR/LG symbols for Daycare Pokémon release.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
