### PR TITLE
Overlay: Detect connection loss and auto-reconnect

### DIFF
--- a/modules/web/static/stream-overlay/connection.js
+++ b/modules/web/static/stream-overlay/connection.js
@@ -89,8 +89,11 @@ export function loadAllData(state) {
     );
 }
 
-/** @return {EventSource} */
-export function getEventSource() {
+/**
+ * @param {{[k: string]: (MessageEvent) => any}} listeners
+ * @return {EventSource}
+ * */
+export function getEventSource(listeners) {
     const url = new URL(window.location.origin + "/stream_events");
     url.searchParams.append("topic", "PerformanceData");
     url.searchParams.append("topic", "BotMode");
@@ -105,5 +108,11 @@ export function getEventSource() {
     url.searchParams.append("topic", "PokenavCall");
     url.searchParams.append("topic", "FishingAttempt");
     url.searchParams.append("topic", "CustomEvent");
-    return new EventSource(url);
+    const eventSource = new EventSource(url);
+
+    for (const [eventName, eventHandler] of Object.entries(listeners)) {
+        eventSource.addEventListener(eventName, eventHandler);
+    }
+
+    return eventSource;
 }

--- a/modules/web/static/stream-overlay/helper.js
+++ b/modules/web/static/stream-overlay/helper.js
@@ -313,6 +313,16 @@ export function br() {
 }
 
 /**
+ * @param {number} durationInSeconds
+ * @returns {Promise<void>}
+ */
+export async function sleep(durationInSeconds) {
+    return new Promise((resolve, reject) => {
+        window.setTimeout(() => resolve(), Math.floor(durationInSeconds * 1000));
+    });
+}
+
+/**
  * @param {number} num
  * @param {number} min
  * @param {number} max


### PR DESCRIPTION
### Description

This adds a regular check to the overlay whether we have received any events recently and/or whether the connection has been closed.

If an interruption is detected, it attempts to reload all data and re-establish the event stream. If that fails (because the bot is not live, for example) it will repeat that every 5 seconds until it finally succeeds.

### Checklist

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)