### PR TITLE
Overlay: Fix reload loop in connection checking code

### DIFF
--- a/modules/web/http_stream.py
+++ b/modules/web/http_stream.py
@@ -212,17 +212,20 @@ def run_watcher():
         current_second = int(time())
         current_game_state = get_game_state()
 
-        if current_second != previous_second and subscriptions["PerformanceData"] > 0:
-            send_message(
-                DataSubscription.PerformanceData,
-                data={
-                    "fps": context.emulator.get_current_fps(),
-                    "frame_count": context.emulator.get_frame_count(),
-                    "current_time_spent_in_bot_fraction": context.emulator.get_current_time_spent_in_bot_fraction(),
-                    "encounter_rate": context.stats.encounter_rate,
-                },
-                event_type="PerformanceData",
-            )
+        if current_second != previous_second:
+            send_message(None, data=None, event_type="Ping")
+
+            if subscriptions["PerformanceData"] > 0:
+                send_message(
+                    DataSubscription.PerformanceData,
+                    data={
+                        "fps": context.emulator.get_current_fps(),
+                        "frame_count": context.emulator.get_frame_count(),
+                        "current_time_spent_in_bot_fraction": context.emulator.get_current_time_spent_in_bot_fraction(),
+                        "encounter_rate": context.stats.encounter_rate,
+                    },
+                    event_type="PerformanceData",
+                )
 
         if subscriptions["Player"] > 0:
             if state_cache.player.age_in_frames >= 60:
@@ -406,7 +409,7 @@ def run_watcher():
 
 
 def send_message(
-    subscription_flag: DataSubscription,
+    subscription_flag: DataSubscription | None,
     data: str | list | tuple | dict | int | float | None,
     event_type: str | None = None,
     do_not_json_encode: bool = False,
@@ -417,7 +420,7 @@ def send_message(
         message = f"data: {json.dumps(data)}"
 
     for index in reversed(range(len(subscribers))):
-        if subscribers[index][2] & subscription_flag:
+        if subscription_flag is None or subscribers[index][2] & subscription_flag:
             try:
                 subscribers[index][1].put_nowait(message)
                 subscribers[index][4].set()


### PR DESCRIPTION
### Description

The overlay listened to the wrong event to see if it received any messages. (Turns out, the `message` event is a special one and is not triggered for custom events.) That meant that after 15 seconds, the overlay would assume that it hadn't received anything and would attempt to reconnect. And it would do so once a second which causes significant lag.

A second issue was that after noticing that the connection may have been lost, it would run `doFullUpdate()` which now has auto-retry behaviour. So for each second that the connection was lost, it would run _another_ instance of `doFullUpdate()` which would quickly lead to a massive list of concurrent requests. And once the connection was re-established, each instance would then start its own event stream, meaning that each event would be handled multiple times.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
