### PR TITLE
Fix releasing pokemon on daycare mode for Ruby / Sapphire

### DIFF
--- a/modules/data/symbols/patches/language/pokeruby_rev1.yml
+++ b/modules/data/symbols/patches/language/pokeruby_rev1.yml
@@ -247,6 +247,10 @@ SUB_8096B38:
   F: 0x8096d70
   I: 0x8096c7c
   S: 0x8096d68
+gPokemonStorageSystemPtr:
+  F: 0x83be798
+  I: 0x83b7a08
+  S: 0x83bae18
 #-------------------------#
 
 #--------------#

--- a/modules/data/symbols/patches/language/pokesapphire_rev1.yml
+++ b/modules/data/symbols/patches/language/pokesapphire_rev1.yml
@@ -251,6 +251,10 @@ SUB_8096B38:
   F: 0x8096d70
   I: 0x8096c7c
   S: 0x8096d68
+gPokemonStorageSystemPtr:
+  F: 0x83be2c8
+  I: 0x83b76ac
+  S: 0x83bab54
 #-------------------------#
 
 #--------------#


### PR DESCRIPTION
### Description

Fix release of Pokémon in Daycare mode for R/S. 

In Ruby and Sapphire, the storage system works differently, so this adds a manual release while still using the storage system’s cursor positions and party indexes.

The fix is applied to all supported languages, including European and Japanese versions.

This fixes issue [#762](https://github.com/40Cakes/pokebot-gen3/issues/762)

### Checklist

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

