### PR TITLE
Support defining a final facing direction in `navigate_to()`

### DIFF
--- a/modules/modes/util/higher_level_actions.py
+++ b/modules/modes/util/higher_level_actions.py
@@ -40,7 +40,7 @@ from .._interface import BotModeError
 from ...game import get_symbol_name_before
 from ...items import Item, get_item_bag, ItemPocket, Pokeblock, get_pokeblocks
 from ...map import get_map_objects, get_map_data_for_current_position
-from ...map_path import calculate_path, PathFindingError
+from ...map_path import calculate_path, PathFindingError, Direction
 from ...mart import get_mart_buyable_items, get_mart_buy_menu_scroll_position, get_mart_main_menu_scroll_position
 from ...pokeblock_feeder import get_active_pokeblock_feeder_for_location
 
@@ -547,7 +547,7 @@ def talk_to_npc(local_object_id: int):
             raise BotModeError(f"Could not find an empty tile around local object #{local_object_id}")
 
         try:
-            yield from navigate_to(*nearest_tile)
+            yield from navigate_to(*nearest_tile, final_facing_direction=Direction.from_string(nearest_tile_facing))
             yield from ensure_facing_direction(nearest_tile_facing)
         except (PathFindingError, BotModeError):
             pass

--- a/modules/modes/util/walking.py
+++ b/modules/modes/util/walking.py
@@ -313,6 +313,7 @@ def navigate_to(
     avoid_encounters: bool = True,
     avoid_scripted_events: bool = True,
     expecting_script: bool = False,
+    final_facing_direction: Direction | None = None,
 ) -> Generator:
     """
     Tries to walk the player to a given location while circumventing obstacles.
@@ -333,6 +334,9 @@ def navigate_to(
                                   still navigate via those tiles of there is no other option.
     :param expecting_script: This will accept if a script is triggered during navigation (presumably at the destination)
                              and will not show an error about that.
+    :param final_facing_direction: A direction that the player avatar should face after reaching its
+                                   destination. This can be useful to make it bump into an obstacle with
+                                   the Mach Bike.
     """
 
     def waypoint_generator():
@@ -367,7 +371,7 @@ def navigate_to(
 
     while True:
         try:
-            yield from follow_waypoints(waypoint_generator(), run)
+            yield from follow_waypoints(waypoint_generator(), run, final_facing_direction=final_facing_direction)
             break
         except TimedOutTryingToReachWaypointError:
             # If we run into a timeout while trying to follow the waypoints, this is likely because of either of


### PR DESCRIPTION
### Description

This is relevant for the stream Daycare mode because it can force the bot to turn towards the Daycare Man.

Otherwise it would just keep going 3 more tiles due to Mach Bike momentum.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
