### PR TITLE
Overlay: Also check pre-evolutions for counting caught Pokémon of a species

### DIFF
--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -6,7 +6,7 @@ import {
     renderTableRow,
     br,
     small,
-    getSpeciesGoal, overlaySprite, getEmptySpeciesEntry
+    getSpeciesGoal, overlaySprite, getEmptySpeciesEntry, getSpeciesCatches
 } from "../helper.js";
 
 const mapNameSpan = document.querySelector("#route-encounters > h2 > span");
@@ -144,7 +144,7 @@ const updateRouteEncountersList = (encounters, stats, encounterType, checklistCo
 
         const goal = getSpeciesGoal(encounter.species_name, checklistConfig, stats);
         if (goal) {
-            catches = [species.catches, small(`/${goal}`)];
+            catches = [getSpeciesCatches(encounter.species_name, checklistConfig, stats), small(`/${goal}`)];
         } else {
             catches = [formatInteger(species.catches)];
         }

--- a/modules/web/static/stream-overlay/content/section-checklist.js
+++ b/modules/web/static/stream-overlay/content/section-checklist.js
@@ -1,5 +1,5 @@
 import config from "../config.js";
-import {formatInteger, getSectionProgress} from "../helper.js";
+import {formatInteger, getSectionProgress, getSpeciesCatches} from "../helper.js";
 
 /** @type {HTMLUListElement} */
 const ul = document.querySelector("#section-checklist ul");
@@ -67,17 +67,7 @@ const updateSectionChecklist = (checklistConfig, stats, mapEncounters, additiona
         const configEntry = checklistConfig[speciesName];
         const elements = speciesListElements[speciesName];
 
-        let completion = 0;
-        if (stats.pokemon.hasOwnProperty(speciesName)) {
-            completion += stats.pokemon[speciesName].catches;
-        }
-        if (Array.isArray(configEntry.similarSpecies)) {
-            for (const similarSpecies of configEntry.similarSpecies) {
-                if (stats.pokemon.hasOwnProperty(similarSpecies)) {
-                    completion += stats.pokemon[similarSpecies].catches;
-                }
-            }
-        }
+        let completion = getSpeciesCatches(speciesName, checklistConfig, stats);
 
         const isCompleted = configEntry.goal && completion >= configEntry.goal;
         elements.countSpan.innerText = formatInteger(completion);
@@ -102,13 +92,13 @@ const updateSectionChecklist = (checklistConfig, stats, mapEncounters, additiona
         }
 
         for (const encounter of routeEncounters) {
-            if (encounter.species_name === speciesName) {
+            if (encounter.species_name === speciesName || (Array.isArray(configEntry.similarSpecies) && configEntry.similarSpecies.includes(encounter.species_name))) {
                 isAvailableOnThisRoute = true;
                 break;
             }
         }
         for (const additionalSpeciesName of additionalRouteSpecies) {
-            if (additionalSpeciesName === speciesName) {
+            if (additionalSpeciesName === speciesName || (Array.isArray(configEntry.similarSpecies) && configEntry.similarSpecies.includes(additionalSpeciesName))) {
                 isAvailableOnThisRoute = true;
                 break;
             }

--- a/modules/web/static/stream-overlay/helper.js
+++ b/modules/web/static/stream-overlay/helper.js
@@ -438,6 +438,34 @@ export function getSpeciesGoal(speciesName, checklistConfig, stats) {
 }
 
 /**
+ * @param {string} speciesName
+ * @param {StreamOverlay.SectionChecklist} checklistConfig
+ * @param {PokeBotApi.GetStatsResponse} stats
+ * @return {number}
+ */
+export function getSpeciesCatches(speciesName, checklistConfig, stats) {
+    if (typeof checklistConfig[speciesName] !== "undefined") {
+        let result = stats.pokemon[speciesName]?.catches ?? 0;
+        for (const similarSpeciesName of checklistConfig[speciesName].similarSpecies) {
+            result += stats.pokemon[similarSpeciesName]?.catches ?? 0;
+        }
+        return result;
+    }
+
+    for (const [checklistSpeciesName, checklistEntry] of Object.entries(checklistConfig)) {
+        if (Array.isArray(checklistEntry.similarSpecies) && checklistEntry.similarSpecies.includes(speciesName)) {
+            let result = stats.pokemon[checklistSpeciesName]?.catches ?? 0;
+            for (const similarSpeciesName of checklistEntry.similarSpecies) {
+                result += stats.pokemon[similarSpeciesName]?.catches ?? 0;
+            }
+            return result;
+        }
+    }
+
+    return 0;
+}
+
+/**
  * @param {StreamOverlay.SectionChecklist} sectionChecklist
  * @param {PokeBotApi.GetStatsResponse} stats
  * @return {{caught: number; goal: number}}


### PR DESCRIPTION
### Description

This changes the overlay so that

1. in the route encounters box (top right) the caught Carvanha will be counted towards Sharpedo's target, and
2. in the section checklist (the box below that) Carvanha will be highlighted as a target because Sharpedo is available on this route.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
