### PR TITLE
Overlay: Fix anti shiny animation, and don't show shiny rate as `1/∞`

### DIFF
--- a/modules/web/static/stream-overlay/component/info-bubble.js
+++ b/modules/web/static/stream-overlay/component/info-bubble.js
@@ -92,7 +92,7 @@ export default class InfoBubble extends HTMLElement {
                     small = document.createElement("small");
                     this.append(small);
                 }
-                small.innerText = "/" + formatInteger(newValue)
+                small.innerText = "/" + formatInteger(newTarget)
             } else if (small) {
                 this.quantityTarget = null;
                 small.remove();

--- a/modules/web/static/stream-overlay/component/pokemon-sprite.js
+++ b/modules/web/static/stream-overlay/component/pokemon-sprite.js
@@ -447,8 +447,17 @@ export default class PokemonSprite extends HTMLElement {
             return;
         }
 
+        let spriteType;
+        if (this.shiny) {
+            spriteType = "shiny";
+        } else if (this.antiShiny) {
+            spriteType = "anti-shiny";
+        } else {
+            spriteType = "normal";
+        }
+
         const spritePath = this.species !== "Egg"
-            ? speciesSpritePath(this.species, this.shiny ? "shiny" : "normal", true)
+            ? speciesSpritePath(this.species, spriteType, true)
             : eggSpritePath(true);
         this.sprite.src = spritePath;
         const fileNameWithoutExtension = spritePath.substring(spritePath.lastIndexOf("/") + 1, spritePath.lastIndexOf("."))
@@ -456,7 +465,7 @@ export default class PokemonSprite extends HTMLElement {
         this.animationTimeout = window.setTimeout(
             () => {
                 this.sprite.src = this.species !== "Egg"
-                    ? speciesSpritePath(this.species, this.shiny ? "shiny" : "normal", false)
+                    ? speciesSpritePath(this.species, spriteType, false)
                     : eggSpritePath(false);
                 this.animationTimeout = null;
             },

--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -388,7 +388,7 @@ const renderRouteEncountersList = (encountersList) => {
     };
 
     const renderTotalEncounters = (totalEncounters, shinyRateDivisor) => {
-        if (shinyRateDivisor === null) {
+        if (shinyRateDivisor === null || shinyRateDivisor === Infinity) {
             return [formatInteger(totalEncounters)];
         } else {
             const shinyRateLabel = document.createElement("span");


### PR DESCRIPTION
### Description

- Fixes a bug where in the route encounters list, if a species has an anti-shiny sprite and gets animated (which happens each time this species is encountered) the _regular_ animated sprite would be used rather than the anti.
- Also, for species that we have never encountered as a shiny it would show the shiny rate as `1/∞`

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
