### PR TITLE
Fix error for unmapped symbol names in language patches

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.yml
+++ b/modules/data/symbols/patches/language/pokeemerald.yml
@@ -314,14 +314,14 @@ sCursorArea:
   J: 0x2039a18
 sCursorPosition:
   J: 0x2039a19
-gPlayerPCItemPageInfo:
-EventScript_PCMainMenu:
-EventScript_AccessPokemonStorage:
-EventScript_AccessPlayersPC:
-ItemStorageMenuProcessInput:
-Task_ChooseHowManyToDeposit:
-ItemStorage_ProcessInput:
-ItemStorage_HandleQuantityRolling:
+gPlayerPCItemPageInfo: {}
+EventScript_PCMainMenu: {}
+EventScript_AccessPokemonStorage: {}
+EventScript_AccessPlayersPC: {}
+ItemStorageMenuProcessInput: {}
+Task_ChooseHowManyToDeposit: {}
+ItemStorage_ProcessInput: {}
+ItemStorage_HandleQuantityRolling: {}
 #-------------------------#
 
 Task_ExitDoor:

--- a/modules/data/symbols/patches/language/pokefirered.yml
+++ b/modules/data/symbols/patches/language/pokefirered.yml
@@ -554,14 +554,14 @@ sCursorArea:
   J: 0x203976c
 sCursorPosition:
   J: 0x203976d
-sListMenuState:
-EventScript_PCMainMenu:
-EventScript_AccessPokemonStorage:
-EventScript_AccessPlayersPC:
-Task_TopMenu_ItemStorageSubmenu_HandleInput:
-Task_SelectQuantityToDeposit:
-Task_ItemPcMain:
-Task_ItemPcHandleWithdrawMultiple:
+sListMenuState: {}
+EventScript_PCMainMenu: {}
+EventScript_AccessPokemonStorage: {}
+EventScript_AccessPlayersPC: {}
+Task_TopMenu_ItemStorageSubmenu_HandleInput: {}
+Task_SelectQuantityToDeposit: {}
+Task_ItemPcMain: {}
+Task_ItemPcHandleWithdrawMultiple: {}
 #-------------------------#
 
 #--------------#

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -549,14 +549,14 @@ sCursorArea:
   J: 0x203976c
 sCursorPosition:
   J: 0x203976d
-sListMenuState:
-EventScript_PCMainMenu:
-EventScript_AccessPokemonStorage:
-EventScript_AccessPlayersPC:
-Task_TopMenu_ItemStorageSubmenu_HandleInput:
-Task_SelectQuantityToDeposit:
-Task_ItemPcMain:
-Task_ItemPcHandleWithdrawMultiple:
+sListMenuState: {}
+EventScript_PCMainMenu: {}
+EventScript_AccessPokemonStorage: {}
+EventScript_AccessPlayersPC: {}
+Task_TopMenu_ItemStorageSubmenu_HandleInput: {}
+Task_SelectQuantityToDeposit: {}
+Task_ItemPcMain: {}
+Task_ItemPcHandleWithdrawMultiple: {}
 #-------------------------#
 
 #--------------#

--- a/modules/data/symbols/patches/language/pokeruby.yml
+++ b/modules/data/symbols/patches/language/pokeruby.yml
@@ -203,13 +203,13 @@ sBoxCursorArea:
   J: 0x2038200
 sBoxCursorPosition:
   J: 0x2038201
-ItemStorage_ProcessInput:
-EventScript_PCMainMenu:
-EventScript_AccessPokemonStorage:
-EventScript_AccessPlayersPC:
-ItemStorageMenuProcessInput:
-sub_80A6BE0:
-ItemStorage_HandleQuantityRolling:
+ItemStorage_ProcessInput: {}
+EventScript_PCMainMenu: {}
+EventScript_AccessPokemonStorage: {}
+EventScript_AccessPlayersPC: {}
+ItemStorageMenuProcessInput: {}
+sub_80A6BE0: {}
+ItemStorage_HandleQuantityRolling: {}
 #-------------------------#
 
 #--------------#

--- a/modules/data/symbols/patches/language/pokeruby_rev1.yml
+++ b/modules/data/symbols/patches/language/pokeruby_rev1.yml
@@ -251,13 +251,13 @@ gPokemonStorageSystemPtr:
   F: 0x83be798
   I: 0x83b7a08
   S: 0x83bae18
-ItemStorage_ProcessInput:
-EventScript_PCMainMenu:
-EventScript_AccessPokemonStorage:
-EventScript_AccessPlayersPC:
-ItemStorageMenuProcessInput:
-sub_80A6BE0:
-ItemStorage_HandleQuantityRolling:
+ItemStorage_ProcessInput: {}
+EventScript_PCMainMenu: {}
+EventScript_AccessPokemonStorage: {}
+EventScript_AccessPlayersPC: {}
+ItemStorageMenuProcessInput: {}
+sub_80A6BE0: {}
+ItemStorage_HandleQuantityRolling: {}
 #-------------------------#
 
 #--------------#

--- a/modules/data/symbols/patches/language/pokesapphire.yml
+++ b/modules/data/symbols/patches/language/pokesapphire.yml
@@ -201,13 +201,13 @@ sBoxCursorArea:
   J: 0x2038200
 sBoxCursorPosition:
   J: 0x2038201
-ItemStorage_ProcessInput:
-EventScript_PCMainMenu:
-EventScript_AccessPokemonStorage:
-EventScript_AccessPlayersPC:
-ItemStorageMenuProcessInput:
-sub_80A6BE0:
-ItemStorage_HandleQuantityRolling:
+ItemStorage_ProcessInput: {}
+EventScript_PCMainMenu: {}
+EventScript_AccessPokemonStorage: {}
+EventScript_AccessPlayersPC: {}
+ItemStorageMenuProcessInput: {}
+sub_80A6BE0: {}
+ItemStorage_HandleQuantityRolling: {}
 #-------------------------#
 
 #--------------#

--- a/modules/data/symbols/patches/language/pokesapphire_rev1.yml
+++ b/modules/data/symbols/patches/language/pokesapphire_rev1.yml
@@ -255,13 +255,13 @@ gPokemonStorageSystemPtr:
   F: 0x83be2c8
   I: 0x83b76ac
   S: 0x83bab54
-ItemStorage_ProcessInput:
-EventScript_PCMainMenu:
-EventScript_AccessPokemonStorage:
-EventScript_AccessPlayersPC:
-ItemStorageMenuProcessInput:
-sub_80A6BE0:
-ItemStorage_HandleQuantityRolling:
+ItemStorage_ProcessInput: {}
+EventScript_PCMainMenu: {}
+EventScript_AccessPokemonStorage: {}
+EventScript_AccessPlayersPC: {}
+ItemStorageMenuProcessInput: {}
+sub_80A6BE0: {}
+ItemStorage_HandleQuantityRolling: {}
 #-------------------------#
 
 #--------------#


### PR DESCRIPTION
### Description

A user on Discord pointed out an error that sounds like something is choking up by the new unmapped symbols. YAML defaults these to `None` which probably offends a `for` loop somewhere.

I couldn't reproduce the error, but hopefully these changes should make the keys iterable despite being empty.

Report on Discord: https://discord.com/channels/1057088810950860850/1139190426834833528/1478056154180616396

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
