### PR TITLE
Fix Daycare mode for other languages than English

### DIFF
--- a/modules/data/symbols/patches/language/pokeemerald.yml
+++ b/modules/data/symbols/patches/language/pokeemerald.yml
@@ -314,14 +314,50 @@ sCursorArea:
   J: 0x2039a18
 sCursorPosition:
   J: 0x2039a19
-gPlayerPCItemPageInfo: {}
-EventScript_PCMainMenu: {}
-EventScript_AccessPokemonStorage: {}
-EventScript_AccessPlayersPC: {}
-ItemStorageMenuProcessInput: {}
-Task_ChooseHowManyToDeposit: {}
-ItemStorage_ProcessInput: {}
-ItemStorage_HandleQuantityRolling: {}
+gPlayerPCItemPageInfo:
+  J: 0x203ca68
+EventScript_PCMainMenu:
+  D: 0x827d4b7
+  F: 0x8277072
+  I: 0x8271a03
+  J: 0x8242e38
+  S: 0x8275bb7
+EventScript_AccessPokemonStorage:
+  D: 0x827d507
+  F: 0x82770b2
+  I: 0x8271a68
+  J: 0x8242e96
+  S: 0x8275be8
+EventScript_AccessPlayersPC:
+  D: 0x827d507
+  F: 0x82770b2
+  I: 0x8271a43
+  J: 0x8242e58
+  S: 0x8275be8
+ItemStorageMenuProcessInput:
+  D: 0x816aea0
+  F: 0x816c09c
+  I: 0x816ae90
+  J: 0x816b06c
+  S: 0x816afa0
+Task_ChooseHowManyToDeposit:
+  D: 0x81ad5a0
+  F: 0x81ad6b4
+  I: 0x81ad580
+  J: 0x81ad890
+  S: 0x81ad698
+ItemStorage_ProcessInput:
+  D: 0x816bf74
+  F: 0x816c09c
+  I: 0x81adf60
+  J: 0x816c154
+  S: 0x81af124
+ItemStorage_HandleQuantityRolling:
+  D: 0x816c480
+  F: 0x816c5a8
+  I: 0x816c470
+  J: 0x816c630
+  S: 0x816c580
 #-------------------------#
 
 Task_ExitDoor:

--- a/modules/data/symbols/patches/language/pokefirered.yml
+++ b/modules/data/symbols/patches/language/pokefirered.yml
@@ -554,14 +554,50 @@ sCursorArea:
   J: 0x203976c
 sCursorPosition:
   J: 0x203976d
-sListMenuState: {}
-EventScript_PCMainMenu: {}
-EventScript_AccessPokemonStorage: {}
-EventScript_AccessPlayersPC: {}
-Task_TopMenu_ItemStorageSubmenu_HandleInput: {}
-Task_SelectQuantityToDeposit: {}
-Task_ItemPcMain: {}
-Task_ItemPcHandleWithdrawMultiple: {}
+sListMenuState:
+  J: 0x203ad5c
+EventScript_PCMainMenu:
+  D: 0x81a9849
+  F: 0x81a54e6
+  I: 0x81a42e4
+  J: 0x8194264
+  S: 0x81a6551
+EventScript_AccessPokemonStorage:
+  D: 0x81a98b6
+  F: 0x81a5553
+  I: 0x81a4351
+  J: 0x81942d1
+  S: 0x81a65be
+EventScript_AccessPlayersPC:
+  D: 0x81a98a1
+  F: 0x81a553e
+  I: 0x81a433c
+  J: 0x81942bc
+  S: 0x81a65a9
+Task_TopMenu_ItemStorageSubmenu_HandleInput:
+  D: 0x80ebcdc
+  F: 0x80ebd9c
+  I: 0x80ebcdc
+  J: 0x80eca64
+  S: 0x80ebdc4
+Task_SelectQuantityToDeposit:
+  D: 0x810ac08
+  F: 0x810acc8
+  I: 0x810ac4c
+  J: 0x810b684
+  S: 0x810ad34
+Task_ItemPcMain:
+  D: 0x8106f48
+  F: 0x810dfe0
+  I: 0x810df64
+  J: 0x810e96c
+  S: 0x810e04c
+Task_ItemPcHandleWithdrawMultiple:
+  D: 0x810e75c
+  F: 0x810e81c
+  I: 0x810e7a0
+  J: 0x810f1e8
+  S: 0x810e888
 #-------------------------#
 
 #--------------#
@@ -771,6 +807,10 @@ Route15_Text_MyaIntro:
   J: 0x0
 Route15_Text_MyaDefeat:
   J: 0x0
+Route25_EventScript_FranklinRematch:
+  D: 0x0
+Route25_EventScript_KelseyRematch:
+  D: 0x0
 
 # Unused
 Task_ExitNonDoor:

--- a/modules/data/symbols/patches/language/pokeleafgreen.yml
+++ b/modules/data/symbols/patches/language/pokeleafgreen.yml
@@ -549,14 +549,50 @@ sCursorArea:
   J: 0x203976c
 sCursorPosition:
   J: 0x203976d
-sListMenuState: {}
-EventScript_PCMainMenu: {}
-EventScript_AccessPokemonStorage: {}
-EventScript_AccessPlayersPC: {}
-Task_TopMenu_ItemStorageSubmenu_HandleInput: {}
-Task_SelectQuantityToDeposit: {}
-Task_ItemPcMain: {}
-Task_ItemPcHandleWithdrawMultiple: {}
+sListMenuState:
+  J: 0x203ad5c
+EventScript_PCMainMenu:
+  D: 0x81a9825
+  F: 0x81a54c2
+  I: 0x81a42c0
+  J: 0x8194240
+  S: 0x81a652d
+EventScript_AccessPokemonStorage:
+  D: 0x81a9892
+  F: 0x81a552f
+  I: 0x81a432d
+  J: 0x81942ad
+  S: 0x81a659a
+EventScript_AccessPlayersPC:
+  D: 0x81a987d
+  F: 0x81a551a
+  I: 0x81a4318
+  J: 0x8194298
+  S: 0x81a6585
+Task_TopMenu_ItemStorageSubmenu_HandleInput:
+  D: 0x80ebcb4
+  F: 0x80ebd74
+  I: 0x80ebcb4
+  J: 0x80eca3c
+  S: 0x80ebd9c
+Task_SelectQuantityToDeposit:
+  D: 0x810abe0
+  F: 0x810aca0
+  I: 0x810ac24
+  J: 0x810b65c
+  S: 0x810ad0c
+Task_ItemPcMain:
+  D: 0x810def8
+  F: 0x810dfb8
+  I: 0x810df3c
+  J: 0x810e944
+  S: 0x810e024
+Task_ItemPcHandleWithdrawMultiple:
+  D: 0x810e734
+  F: 0x810e7f4
+  I: 0x810e778
+  J: 0x810f1c0
+  S: 0x810e860
 #-------------------------#
 
 #--------------#
@@ -715,6 +751,10 @@ Route15_Text_MyaIntro:
   J: 0x0
 Route15_Text_MyaDefeat:
   J: 0x0
+Route25_EventScript_FranklinRematch:
+  D: 0x0
+Route25_EventScript_KelseyRematch:
+  D: 0x0
 
 # Ununsed symbols that were conflicting with currently used symbols
 # We set them to 0x0 to 'get them out of our way' and correctly target the desired symbol

--- a/modules/data/symbols/patches/language/pokeruby.yml
+++ b/modules/data/symbols/patches/language/pokeruby.yml
@@ -203,13 +203,20 @@ sBoxCursorArea:
   J: 0x2038200
 sBoxCursorPosition:
   J: 0x2038201
-ItemStorage_ProcessInput: {}
-EventScript_PCMainMenu: {}
-EventScript_AccessPokemonStorage: {}
-EventScript_AccessPlayersPC: {}
-ItemStorageMenuProcessInput: {}
-sub_80A6BE0: {}
-ItemStorage_HandleQuantityRolling: {}
+ItemStorage_ProcessInput:
+  J: 0x8134ed8
+EventScript_PCMainMenu:
+  J: 0x817fc2d
+EventScript_AccessPokemonStorage:
+  J: 0x817fc8f
+EventScript_AccessPlayersPC:
+  J: 0x817fc7a
+ItemStorageMenuProcessInput:
+  J: 0x8134c3c
+sub_80A6BE0:
+  J: 0x80a2d70
+ItemStorage_HandleQuantityRolling:
+  J: 0x8135208
 #-------------------------#
 
 #--------------#

--- a/modules/data/symbols/patches/language/pokeruby_rev1.yml
+++ b/modules/data/symbols/patches/language/pokeruby_rev1.yml
@@ -251,13 +251,34 @@ gPokemonStorageSystemPtr:
   F: 0x83be798
   I: 0x83b7a08
   S: 0x83bae18
-ItemStorage_ProcessInput: {}
-EventScript_PCMainMenu: {}
-EventScript_AccessPokemonStorage: {}
-EventScript_AccessPlayersPC: {}
-ItemStorageMenuProcessInput: {}
-sub_80A6BE0: {}
-ItemStorage_HandleQuantityRolling: {}
+ItemStorage_ProcessInput:
+  F: 0x813a768
+  I: 0x813a6a4
+  S: 0x813a7a4
+EventScript_PCMainMenu:
+  F: 0x81a5428
+  I: 0x81a09cd
+  S: 0x81a32ed
+EventScript_AccessPokemonStorage:
+  F: 0x81a548a
+  I: 0x81a0a2f
+  S: 0x81a334f
+EventScript_AccessPlayersPC:
+  F: 0x81a5475
+  I: 0x81a0a1a
+  S: 0x81a333a
+ItemStorageMenuProcessInput:
+  F: 0x813a4bc
+  I: 0x813a3f8
+  S: 0x813a4f8
+sub_80A6BE0:
+  F: 0x80a6e18
+  I: 0x80a6d24
+  S: 0x80a6e28
+ItemStorage_HandleQuantityRolling:
+  F: 0x813aa6c
+  I: 0x813a9a8
+  S: 0x813aaa8
 #-------------------------#
 
 #--------------#

--- a/modules/data/symbols/patches/language/pokesapphire.yml
+++ b/modules/data/symbols/patches/language/pokesapphire.yml
@@ -201,13 +201,20 @@ sBoxCursorArea:
   J: 0x2038200
 sBoxCursorPosition:
   J: 0x2038201
-ItemStorage_ProcessInput: {}
-EventScript_PCMainMenu: {}
-EventScript_AccessPokemonStorage: {}
-EventScript_AccessPlayersPC: {}
-ItemStorageMenuProcessInput: {}
-sub_80A6BE0: {}
-ItemStorage_HandleQuantityRolling: {}
+ItemStorage_ProcessInput:
+  J: 0x8134ed8
+EventScript_PCMainMenu:
+  J: 0x817fbbd
+EventScript_AccessPokemonStorage:
+  J: 0x817fc1f
+EventScript_AccessPlayersPC:
+  J: 0x817fc0a
+ItemStorageMenuProcessInput:
+  J: 0x8134c3c
+sub_80A6BE0:
+  J: 0x80a2d70
+ItemStorage_HandleQuantityRolling:
+  J: 0x8135208
 #-------------------------#
 
 #--------------#

--- a/modules/data/symbols/patches/language/pokesapphire_rev1.yml
+++ b/modules/data/symbols/patches/language/pokesapphire_rev1.yml
@@ -255,13 +255,34 @@ gPokemonStorageSystemPtr:
   F: 0x83be2c8
   I: 0x83b76ac
   S: 0x83bab54
-ItemStorage_ProcessInput: {}
-EventScript_PCMainMenu: {}
-EventScript_AccessPokemonStorage: {}
-EventScript_AccessPlayersPC: {}
-ItemStorageMenuProcessInput: {}
-sub_80A6BE0: {}
-ItemStorage_HandleQuantityRolling: {}
+ItemStorage_ProcessInput:
+  F: 0x813a768
+  I: 0x813a6a4
+  S: 0x813a7a4
+EventScript_PCMainMenu:
+  F: 0x81a53b8
+  I: 0x81a095d
+  S: 0x81a327d
+EventScript_AccessPokemonStorage:
+  F: 0x81a541a
+  I: 0x81a09bf
+  S: 0x81a32df
+EventScript_AccessPlayersPC:
+  F: 0x81a5405
+  I: 0x81a09aa
+  S: 0x81a32ca
+ItemStorageMenuProcessInput:
+  F: 0x813a4bc
+  I: 0x813a3f8
+  S: 0x813a4f8
+sub_80A6BE0:
+  F: 0x80a6e18
+  I: 0x80a6d24
+  S: 0x80a6e28
+ItemStorage_HandleQuantityRolling:
+  F: 0x813aa6c
+  I: 0x813a9a8
+  S: 0x813aaa8
 #-------------------------#
 
 #--------------#


### PR DESCRIPTION
### Description

Fix Daycare support for multiple languages:

| Game        | French | Spanish | Italian | Japanese | German |
|------------|:------:|:------:|:------:|:--------:|:------:|
| Ruby       | ✅     | ✅     | ✅     | ✅       |    Already supported    |
| Sapphire   | ✅     | ✅     | ✅     | ✅       |     Already supported   |
| Fire Red   | ✅     | ✅     | ✅     | ✅       | ✅     |
| Leaf Green | ✅     | ✅     | ✅     | ✅       | ✅     |
| Emerald    | ✅     | ✅     | ✅     | ✅       | ✅     |
### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
