### PR TITLE
Fix Johto Starters for Emerald

### DIFF
--- a/modules/modes/starters.py
+++ b/modules/modes/starters.py
@@ -191,7 +191,11 @@ def run_rse_johto(get_active_encounter: Callable[[], EncounterInfo]):
         yield from StartMenuNavigator("POKEMON").step()
         yield from PokemonPartyMenuNavigator(get_party_size() - 1, "summary").step()
 
-        handle_encounter(get_active_encounter(), disable_auto_catch=True, do_not_log_battle_action=True)
+        handle_encounter(
+            EncounterInfo.create(get_party()[-1], EncounterType.Gift),
+            disable_auto_catch=True,
+            do_not_log_battle_action=True,
+        )
 
 
 class StartersMode(BotMode):


### PR DESCRIPTION
### Description

Since the changes did to not log encounters again when loading a savestate, Johto starters wasn't working anymore because the gifted starter is not a proper encounter and was causing a crash.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [X] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [X] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
