### PR TITLE
Overlay: Fix Daycare target always being shown with an anti sprite

### DIFF
--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -545,7 +545,7 @@ const updateRouteEncountersList = (state, checklistConfig) => {
 
         if (encounter.encounter_rate > 0) {
             numberOfPossibleEncounters++;
-        } else if (numberOfAntis === numberOfPossibleEncounters) {
+        } else if (numberOfAntis === numberOfPossibleEncounters && numberOfPossibleEncounters > 0) {
             // Show the entire list (including encounters that are dropped due to Repel) as
             // anti-shiny if all possible encounters have been encountered as an anti already.
             isAnti = true;


### PR DESCRIPTION
### Description

This was caused by the code that is supposed to make the entire encounter list anti if all 'possible' encounters have been seen as an anti during the current phase.

The check for 'possible' encounters is whether the encounter has an encounter rate percentage.

In Daycare mode, there are no other possible encounters, only the Daycare target -- and that does not have a percentage.

So technically, we got 0/0 or 100% of all encounters-with-a-percentage as antis, thus the anti sprite.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
