### PR TITLE
Fix `follow_waypoints()` so it doesn't press B when underwater

### DIFF
--- a/modules/modes/util/walking.py
+++ b/modules/modes/util/walking.py
@@ -278,7 +278,12 @@ def follow_waypoints(
                     context.emulator.hold_button(waypoint.walking_direction)
                 else:
                     context.emulator.hold_button(waypoint.walking_direction)
-                    if run and not waypoint.is_water_tile and not AvatarFlags.OnAcroBike in get_player_avatar().flags:
+                    if (
+                        run
+                        and not waypoint.is_water_tile
+                        and not AvatarFlags.OnAcroBike in get_player_avatar().flags
+                        and not AvatarFlags.Underwater in get_player_avatar().flags
+                    ):
                         context.emulator.hold_button("B")
             else:
                 context.emulator.reset_held_buttons()


### PR DESCRIPTION
This avoids the bot getting stuck on the 'would you like to resurface?' message while walking around on underwater routes.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
