### PR TITLE
Overlay: Fix section checklist on underwater routes

### DIFF
--- a/modules/web/static/stream-overlay/state.js
+++ b/modules/web/static/stream-overlay/state.js
@@ -178,10 +178,14 @@ export default class OverlayState {
                 this.#cachedLastEncounterType = this.lastEncounter.type;
             }
 
-            if (this.#cachedLastEncounterType === "land" && this.playerAvatar && this.playerAvatar.flags.Surfing) {
+            if (this.#cachedLastEncounterType === "land" && this.playerAvatar && (this.playerAvatar.flags.Surfing || this.playerAvatar.flags.Underwater)) {
                 this.#cachedLastEncounterType = "surfing";
-            } else if (this.#cachedLastEncounterType === "surfing" && this.playerAvatar && !this.playerAvatar.flags.Surfing) {
+            } else if (this.#cachedLastEncounterType === "surfing" && this.playerAvatar && !this.playerAvatar.flags.Surfing && !this.playerAvatar.flags.Underwater) {
                 this.#cachedLastEncounterType = "land";
+            }
+
+            if (this.#cachedLastEncounterType === "land" && this.lastEncounter.map.toLowerCase().includes("underwater")) {
+                this.#cachedLastEncounterType = "surfing";
             }
         }
 
@@ -193,6 +197,9 @@ export default class OverlayState {
         this.#cachedLastEncounter = encounter;
         if (WILD_ENCOUNTER_TYPES.includes(encounter.type)) {
             this.#cachedLastEncounterType = encounter.type;
+            if (this.#cachedLastEncounterType === "land" && encounter.map.toLowerCase().includes("underwater")) {
+                this.#cachedLastEncounterType = "surfing";
+            }
         }
 
         const speciesName = encounter.pokemon.species_name_for_stats;
@@ -377,10 +384,10 @@ export default class OverlayState {
      * */
     logPlayerAvatarChange(data) {
         this.playerAvatar = data;
-        if (this.lastEncounterType === "land" && data.flags.Surfing) {
+        if (this.lastEncounterType === "land" && (data.flags.Surfing || data.flags.Underwater)) {
             this.#cachedLastEncounterType = "surfing";
             return true;
-        } else if (this.lastEncounterType === "surfing" && !data.flags.Surfing) {
+        } else if (this.lastEncounterType === "surfing" && !data.flags.Surfing && !data.flags.Underwater) {
             this.#cachedLastEncounterType = "land";
             return true;
         }


### PR DESCRIPTION
### Description

The encounter table on underwater routes is considered a 'surfing' table, but the player avatar does not have the 'Surfing' flag at that point (probably due to the different underwater sprite.)

So the overlay assumed that the player was currently hunting _land_ animals and therefore trying to use the (empty) land encounters table to mark potential encounters in the section checklist yellow.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
