### PR TITLE
Overlay: Add water bubble effect on underwater routes

### DIFF
--- a/modules/web/static/stream-overlay/content/effects.js
+++ b/modules/web/static/stream-overlay/content/effects.js
@@ -25,4 +25,32 @@ function fireConfetti(booms, durationInSections) {
     }
 }
 
-export {fireConfetti};
+function fireWaterBubbleBurst() {
+    const spawnBubbles = (n) => {
+        const viewpointWidth = window.innerWidth;
+
+        let elements = [];
+        for (let index = 0; index < n; index++) {
+            const element = document.createElement("div");
+            element.className = "water-bubble";
+
+            const width = Math.round(Math.random() * 7 + 3);
+            const diameter = width * 7 + 2;
+            element.style.fontSize = `${width}px`;
+            element.style.left = Math.round(Math.random() * viewpointWidth - diameter / 2) + "px";
+            element.style.bottom = `-${diameter + Math.round(Math.random() * 500)}px`;
+            element.style.animationDuration = `${Math.round(Math.random() * 1000 + 500)}ms`;
+
+            document.body.appendChild(element);
+            elements.push(element);
+        }
+
+        window.setTimeout(() => elements.forEach(element => document.body.removeChild(element)), 2500);
+    }
+
+    window.setTimeout(() => spawnBubbles(35), 100);
+    window.setTimeout(() => spawnBubbles(45), 250);
+    window.setTimeout(() => spawnBubbles(55), 500);
+}
+
+export {fireConfetti, fireWaterBubbleBurst};

--- a/modules/web/static/stream-overlay/layout/water-bubbles.css
+++ b/modules/web/static/stream-overlay/layout/water-bubbles.css
@@ -1,0 +1,36 @@
+@keyframes water-bubble-rise {
+    from {
+        transform: translateY(0);
+        opacity: .5;
+    }
+
+    25%  { margin-left: -10px; }
+    50%  { margin-left: 10px; }
+    75%  { margin-left: -6px; }
+
+    to {
+        transform: translateY(calc(-100vh - 600px));
+        opacity: .25
+    }
+}
+
+
+.water-bubble {
+    right: 1280px;
+    bottom: 160px;
+
+    position: absolute;
+    z-index: 9;
+    width: 7em;
+    height: 7em;
+
+    border-radius: 50%;
+    border: .2em #cef solid;
+    box-shadow: #eff 1em 0 0 inset;
+    background-color: #cef;
+    margin: auto;
+
+    animation-name: water-bubble-rise;
+    animation-timing-function: linear;
+    animation-iteration-count: 1;
+}

--- a/modules/web/static/stream-overlay/overlay.css
+++ b/modules/web/static/stream-overlay/overlay.css
@@ -13,6 +13,7 @@
 @import "layout/safari-rates.css";
 @import "layout/section-checklist.css";
 @import "layout/shiny-and-encounter-log.css";
+@import "layout/water-bubbles.css";
 
 :root {
     --headline-background-colour: #66778833;

--- a/modules/web/static/stream-overlay/overlay.js
+++ b/modules/web/static/stream-overlay/overlay.js
@@ -24,7 +24,7 @@ import {updateInputs} from "./content/inputs.js";
 import {updateClock} from "./content/clock.js";
 import {getLastEncounterSpecies, sleep} from "./helper.js";
 import {updateDaycareBox} from "./content/daycare.js";
-import {fireConfetti} from "./content/effects.js";
+import {fireConfetti, fireWaterBubbleBurst} from "./content/effects.js";
 import {showSafariRates} from "./content/safari-rates.js";
 
 const BATTLE_STATES = ["BATTLE_STARTING", "BATTLE", "BATTLE_ENDING"];
@@ -467,6 +467,10 @@ export default async function runOverlay() {
                     .catch(error => console.error(error));
             }
         }
+
+        if (state.map.map.type === "Underwater" && Math.random() * 600 < 1) {
+            fireWaterBubbleBurst();
+        }
     }, 1000);
     updateClock(config.startDate, config.timeZone, config.overrideDisplayTimezone);
 
@@ -535,4 +539,17 @@ export default async function runOverlay() {
     setUpEventSource();
 
     window.handleCustomEvent = handleCustomEvent;
+
+    // Debug shortcuts
+    window.addEventListener("keydown", event => {
+        // Alt+Shift+W for Water Bubbles
+        if (event.altKey && event.shiftKey && event.code === "KeyW") {
+            fireWaterBubbleBurst();
+        }
+
+        // Alt+Shift+C for Confetti
+        if (event.altKey && event.shiftKey && event.code === "KeyC") {
+            fireConfetti(50, 10);
+        }
+    });
 }


### PR DESCRIPTION
### Description

As a little easter egg, this adds an effect that shows a burst of water bubbles every now and then while the bot is hunting underwater.

It has a 1/600 chance each seconds, so should only occur once every 10 minutes on average.

https://github.com/user-attachments/assets/b08332be-14b3-4711-82fd-761ca1921f10


### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
