### PR TITLE
Automatically collect items obtained through Thief/Covet

### DIFF
--- a/modules/battle_handler.py
+++ b/modules/battle_handler.py
@@ -9,34 +9,62 @@ from modules.battle_state import (
     get_current_battle_script_instruction,
     BattlePokemon,
     get_battle_state,
+    get_encounter_type,
+    get_last_battle_outcome,
+    HandledBattleResult,
 )
 from modules.battle_strategies import BattleStrategy
 from modules.context import context
 from modules.debug import debug
+from modules.items import Item, get_item_by_index
 from modules.keyboard import handle_naming_screen
-from modules.memory import get_game_state, GameState
+from modules.memory import get_game_state, GameState, read_symbol, unpack_uint16
 from modules.menuing import scroll_to_party_menu_index
+from modules.player import get_player
 from modules.plugins import plugin_should_nickname_pokemon
-from modules.pokemon_party import get_party, get_party_size
+from modules.pokemon import StatusCondition
+from modules.pokemon_party import get_party, get_party_size, PartyPokemon
 from modules.tasks import task_is_active
 
 if TYPE_CHECKING:
     from modules.encounter import EncounterInfo
 
 
+_last_handled_battle_result: HandledBattleResult | None = None
+
+
 @debug.track
-def handle_battle(strategy: BattleStrategy) -> Generator:
+def handle_battle(strategy: BattleStrategy) -> Generator[None, None, HandledBattleResult]:
     """
     This is the main battle-handling function that will attempt to finish the
     battle, calling the battle strategy's callbacks whenever a decision is
     needed.
     :param strategy: The battle strategy that should be queried each time there
                      is a decision to make.
+    :return: A data class structure listing some things that have changed
+             during the battle.
     """
+    before_cash = get_player().money
+    before_party = get_party()
+    encounter_type = get_encounter_type()
+
+    stolen_items: list[tuple[int, Item]] = []
+    items_before_pickup: list[Item] | None = None
+
     while battle_is_active() and context.bot_mode != "Manual":
         instruction = get_current_battle_script_instruction()
         if get_main_battle_callback() in ("HandleTurnActionSelectionState", "sub_8012324"):
             yield from handle_battle_action_selection(strategy)
+        elif get_current_battle_script_instruction() == "BattleScript_ItemSteal":
+            result = yield from handle_item_stealing()
+            if result is not None:
+                stolen_items.append(result)
+        elif (
+            get_current_battle_script_instruction() == "BattleScript_PayDayMoneyAndPickUpItems"
+            and items_before_pickup is None
+        ):
+            items_before_pickup = [pokemon.held_item for pokemon in get_party()]
+            yield
         elif instruction == "BattleScript_AskToLearnMove":
             yield from handle_move_replacement_dialogue(strategy)
         elif task_is_active("Task_EvolutionScene"):
@@ -52,6 +80,75 @@ def handle_battle(strategy: BattleStrategy) -> Generator:
         else:
             context.emulator.press_button("B")
             yield
+
+    outcome = get_last_battle_outcome()
+    party_indices_with_picked_up_items = []
+    party_indices_that_took_damage_or_changed_status = []
+    party_indices_that_gained_exp = []
+    party_indices_that_evolved = []
+
+    after_party = get_party()
+    for index in range(len(after_party)):
+        if len(before_party) <= index:
+            break
+
+        before: PartyPokemon = before_party[index]
+        after: PartyPokemon = after_party[index]
+
+        if before.current_hp > after.current_hp or (
+            before.status_condition is StatusCondition.Healthy and after.status_condition is not StatusCondition.Healthy
+        ):
+            party_indices_that_took_damage_or_changed_status.append(index)
+
+        if before.total_exp < after.total_exp:
+            party_indices_that_gained_exp.append(index)
+
+            if before.species.name != after.species.name:
+                party_indices_that_evolved.append(index)
+
+        if items_before_pickup is not None and index < len(items_before_pickup):
+            if after.held_item is not items_before_pickup[index]:
+                party_indices_with_picked_up_items.append(index)
+
+    party_indices_with_stolen_items = set()
+    for party_index, item in stolen_items:
+        after: PartyPokemon = after_party[party_index]
+        if after.held_item is item:
+            party_indices_with_stolen_items.add(party_index)
+
+    result = HandledBattleResult(
+        outcome,
+        encounter_type,
+        get_player().money - before_cash,
+        list(party_indices_with_stolen_items),
+        party_indices_with_picked_up_items,
+        party_indices_that_took_damage_or_changed_status,
+        party_indices_that_gained_exp,
+        party_indices_that_evolved,
+    )
+
+    global _last_handled_battle_result
+    _last_handled_battle_result = result
+
+    return result
+
+
+@debug.track
+def handle_item_stealing() -> Generator[None, None, tuple[int, Item] | None]:
+    item_index = unpack_uint16(read_symbol("gLastUsedItem"))
+    if read_symbol("gBattlerAttacker")[0] == 0:
+        stolen_by = get_battle_state().own_side.left_battler.party_index
+    elif read_symbol("gBattlerAttacker")[0] == 2:
+        stolen_by = get_battle_state().own_side.right_battler.party_index
+    else:
+        stolen_by = None
+
+    while get_current_battle_script_instruction() == "BattleScript_ItemSteal":
+        context.emulator.press_button("B")
+        yield
+
+    if stolen_by is not None:
+        return stolen_by, get_item_by_index(item_index)
 
 
 @debug.track
@@ -160,3 +257,7 @@ def handle_nickname_caught_pokemon(encounter: "EncounterInfo"):
     ):
         context.emulator.press_button("B")
         yield
+
+
+def get_last_handled_battle_result() -> HandledBattleResult | None:
+    return _last_handled_battle_result

--- a/modules/battle_state.py
+++ b/modules/battle_state.py
@@ -959,3 +959,15 @@ def get_encounter_type() -> EncounterType:
         return EncounterType.Surfing
     else:
         return EncounterType.Land
+
+
+@dataclass
+class HandledBattleResult:
+    outcome: BattleOutcome
+    encounter_type: EncounterType
+    money_gained: int
+    party_indices_with_stolen_items: list[int]
+    party_indices_with_picked_up_items: list[int]
+    party_indices_that_took_damage_or_changed_status: list[int]
+    party_indices_that_gained_exp: list[int]
+    party_indices_that_evolved: list[int]

--- a/modules/data/extract.py
+++ b/modules/data/extract.py
@@ -921,7 +921,8 @@ def extract_species(
                     "hoenn_dex_number": hoenn_dex_number,
                     "types": list(sorted({type_list[info[6]]["name"], type_list[info[7]]["name"]})),
                     "abilities": abilities,
-                    "held_items": held_items,
+                    "held_items_rse": held_items,
+                    "held_items_frlg": None,
                     "base_stats": {
                         "hp": info[0],
                         "attack": info[1],
@@ -958,6 +959,27 @@ def extract_species(
                     "family": set(),
                 }
             )
+
+    with open(other_editions_roms["FIRE"].file, "rb") as firered_file:
+        set_rom(other_editions_roms["FIRE"])
+        for i in range(412):
+            firered_file.seek(get_address("gSpeciesInfo") + (i * 28))
+            info = firered_file.read(28)
+
+            item1 = int.from_bytes(info[12:14], byteorder="little")
+            item2 = int.from_bytes(info[14:16], byteorder="little")
+            if item1 == 0 and item2 == 0:
+                held_items = []
+            elif item1 == item2:
+                held_items = [(item_list[item1]["name"], 1)]
+            elif item2 == 0:
+                held_items = [(item_list[item1]["name"], 0.5)]
+            elif item1 == 0:
+                held_items = [(item_list[item2]["name"], 0.05)]
+            else:
+                held_items = [(item_list[item1]["name"], 0.5), (item_list[item2]["name"], 0.05)]
+
+            species_list[i]["held_items_frlg"] = held_items
 
     def update_family(species_index: int, species_index_to_add: int) -> None:
         species_list[species_index]["family"].add(species_index_to_add)

--- a/modules/data/species.json
+++ b/modules/data/species.json
@@ -9,7 +9,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 0,
             "attack": 0,
@@ -79,7 +80,8 @@
         "abilities": [
             "Overgrow"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 49,
@@ -200,7 +202,8 @@
         "abilities": [
             "Overgrow"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 62,
@@ -312,7 +315,8 @@
         "abilities": [
             "Overgrow"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 82,
@@ -420,7 +424,8 @@
         "abilities": [
             "Blaze"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 39,
             "attack": 52,
@@ -551,7 +556,8 @@
         "abilities": [
             "Blaze"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 58,
             "attack": 64,
@@ -674,7 +680,8 @@
         "abilities": [
             "Blaze"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 78,
             "attack": 84,
@@ -796,7 +803,8 @@
         "abilities": [
             "Torrent"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 44,
             "attack": 48,
@@ -927,7 +935,8 @@
         "abilities": [
             "Torrent"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 59,
             "attack": 63,
@@ -1049,7 +1058,8 @@
         "abilities": [
             "Torrent"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 79,
             "attack": 83,
@@ -1168,7 +1178,8 @@
         "abilities": [
             "Shield Dust"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 30,
@@ -1236,7 +1247,8 @@
         "abilities": [
             "Shed Skin"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 20,
@@ -1304,7 +1316,13 @@
         "abilities": [
             "Compoundeyes"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Silverpowder",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Silverpowder",
                 0.05
@@ -1413,7 +1431,8 @@
         "abilities": [
             "Shield Dust"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 35,
@@ -1482,7 +1501,8 @@
         "abilities": [
             "Shed Skin"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 25,
@@ -1550,7 +1570,13 @@
         "abilities": [
             "Swarm"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Poison Barb",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Poison Barb",
                 0.05
@@ -1656,7 +1682,8 @@
         "abilities": [
             "Keen Eye"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 45,
@@ -1765,7 +1792,8 @@
         "abilities": [
             "Keen Eye"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 63,
             "attack": 60,
@@ -1868,7 +1896,8 @@
         "abilities": [
             "Keen Eye"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 83,
             "attack": 80,
@@ -1966,7 +1995,8 @@
             "Run Away",
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 30,
             "attack": 56,
@@ -2089,7 +2119,17 @@
             "Run Away",
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Oran Berry",
+                0.5
+            ],
+            [
+                "Sitrus Berry",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 55,
             "attack": 81,
@@ -2200,7 +2240,8 @@
         "abilities": [
             "Keen Eye"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 60,
@@ -2310,7 +2351,13 @@
         "abilities": [
             "Keen Eye"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Sharp Beak",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Sharp Beak",
                 0.05
@@ -2411,7 +2458,8 @@
             "Intimidate",
             "Shed Skin"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 35,
             "attack": 60,
@@ -2527,7 +2575,13 @@
             "Intimidate",
             "Shed Skin"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Poison Barb",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 60,
             "attack": 85,
@@ -2631,7 +2685,7 @@
         "abilities": [
             "Static"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Oran Berry",
                 0.5
@@ -2641,6 +2695,7 @@
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 35,
             "attack": 55,
@@ -2761,12 +2816,13 @@
         "abilities": [
             "Static"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Oran Berry",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 90,
@@ -2876,12 +2932,13 @@
         "abilities": [
             "Sand Veil"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Quick Claw",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 75,
@@ -3007,9 +3064,15 @@
         "abilities": [
             "Sand Veil"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Quick Claw",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Soft Sand",
                 0.05
             ]
         ],
@@ -3124,7 +3187,8 @@
         "abilities": [
             "Poison Point"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 47,
@@ -3248,7 +3312,8 @@
         "abilities": [
             "Poison Point"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 62,
@@ -3364,7 +3429,8 @@
         "abilities": [
             "Poison Point"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 82,
@@ -3491,7 +3557,8 @@
         "abilities": [
             "Poison Point"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 46,
             "attack": 57,
@@ -3614,7 +3681,8 @@
         "abilities": [
             "Poison Point"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 61,
             "attack": 72,
@@ -3730,7 +3798,8 @@
         "abilities": [
             "Poison Point"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 81,
             "attack": 92,
@@ -3857,11 +3926,17 @@
         "abilities": [
             "Cute Charm"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Leppa Berry",
                 0.5
             ],
+            [
+                "Moon Stone",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Moon Stone",
                 0.05
@@ -4005,11 +4080,17 @@
         "abilities": [
             "Cute Charm"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Leppa Berry",
                 0.5
             ],
+            [
+                "Moon Stone",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Moon Stone",
                 0.05
@@ -4139,10 +4220,16 @@
         "abilities": [
             "Flash Fire"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Rawst Berry",
                 1
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Rawst Berry",
+                0.5
             ]
         ],
         "base_stats": {
@@ -4258,10 +4345,16 @@
         "abilities": [
             "Flash Fire"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Rawst Berry",
                 1
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Rawst Berry",
+                0.5
             ]
         ],
         "base_stats": {
@@ -4357,7 +4450,13 @@
         "abilities": [
             "Cute Charm"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Oran Berry",
+                0.5
+            ]
+        ],
         "base_stats": {
             "hp": 115,
             "attack": 45,
@@ -4490,7 +4589,13 @@
         "abilities": [
             "Cute Charm"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Oran Berry",
+                0.5
+            ]
+        ],
         "base_stats": {
             "hp": 140,
             "attack": 70,
@@ -4612,7 +4717,8 @@
         "abilities": [
             "Inner Focus"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 45,
@@ -4727,7 +4833,8 @@
         "abilities": [
             "Inner Focus"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 75,
             "attack": 80,
@@ -4837,7 +4944,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 50,
@@ -4947,7 +5055,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 65,
@@ -5055,7 +5164,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 75,
             "attack": 80,
@@ -5150,7 +5260,17 @@
         "abilities": [
             "Effect Spore"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Tinymushroom",
+                0.5
+            ],
+            [
+                "Big Mushroom",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Tinymushroom",
                 0.5
@@ -5278,7 +5398,17 @@
         "abilities": [
             "Effect Spore"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Tinymushroom",
+                0.5
+            ],
+            [
+                "Big Mushroom",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Tinymushroom",
                 0.5
@@ -5392,7 +5522,8 @@
         "abilities": [
             "Compoundeyes"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 55,
@@ -5502,7 +5633,13 @@
         "abilities": [
             "Shield Dust"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Silverpowder",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 70,
             "attack": 65,
@@ -5605,7 +5742,8 @@
             "Sand Veil",
             "Arena Trap"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 10,
             "attack": 55,
@@ -5719,7 +5857,8 @@
             "Sand Veil",
             "Arena Trap"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 35,
             "attack": 80,
@@ -5821,7 +5960,13 @@
         "abilities": [
             "Pickup"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Nugget",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 40,
             "attack": 45,
@@ -5944,7 +6089,8 @@
         "abilities": [
             "Limber"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 70,
@@ -6057,7 +6203,8 @@
             "Damp",
             "Cloud Nine"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 52,
@@ -6189,7 +6336,8 @@
             "Damp",
             "Cloud Nine"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 82,
@@ -6307,7 +6455,8 @@
         "abilities": [
             "Vital Spirit"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 80,
@@ -6442,7 +6591,8 @@
         "abilities": [
             "Vital Spirit"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 105,
@@ -6565,10 +6715,16 @@
             "Intimidate",
             "Flash Fire"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Rawst Berry",
                 1
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Rawst Berry",
+                0.5
             ]
         ],
         "base_stats": {
@@ -6686,10 +6842,16 @@
             "Intimidate",
             "Flash Fire"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Rawst Berry",
                 1
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Rawst Berry",
+                0.5
             ]
         ],
         "base_stats": {
@@ -6789,7 +6951,8 @@
             "Water Absorb",
             "Damp"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 50,
@@ -6906,12 +7069,13 @@
             "Water Absorb",
             "Damp"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "King\u2019s Rock",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 65,
@@ -7038,12 +7202,13 @@
             "Water Absorb",
             "Damp"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "King\u2019s Rock",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 85,
@@ -7158,7 +7323,13 @@
             "Synchronize",
             "Inner Focus"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Twistedspoon",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Twistedspoon",
                 0.05
@@ -7287,7 +7458,13 @@
             "Synchronize",
             "Inner Focus"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Twistedspoon",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Twistedspoon",
                 0.05
@@ -7419,7 +7596,13 @@
             "Synchronize",
             "Inner Focus"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Twistedspoon",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Twistedspoon",
                 0.05
@@ -7545,7 +7728,8 @@
         "abilities": [
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 80,
@@ -7675,7 +7859,13 @@
         "abilities": [
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Focus Band",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 80,
             "attack": 100,
@@ -7797,7 +7987,13 @@
         "abilities": [
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Focus Band",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 90,
             "attack": 130,
@@ -7915,7 +8111,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 75,
@@ -8028,7 +8225,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 90,
@@ -8133,7 +8331,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 105,
@@ -8229,7 +8428,8 @@
             "Clear Body",
             "Liquid Ooze"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 40,
@@ -8345,7 +8545,8 @@
             "Clear Body",
             "Liquid Ooze"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 70,
@@ -8449,12 +8650,13 @@
             "Rock Head",
             "Sturdy"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Everstone",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 80,
@@ -8579,9 +8781,15 @@
             "Rock Head",
             "Sturdy"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Everstone",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Hard Stone",
                 0.05
             ]
         ],
@@ -8705,9 +8913,15 @@
             "Rock Head",
             "Sturdy"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Everstone",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Hard Stone",
                 0.05
             ]
         ],
@@ -8828,7 +9042,8 @@
             "Run Away",
             "Flash Fire"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 85,
@@ -8939,7 +9154,8 @@
             "Run Away",
             "Flash Fire"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 100,
@@ -9040,12 +9256,13 @@
             "Oblivious",
             "Own Tempo"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "King\u2019s Rock",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 65,
@@ -9183,12 +9400,13 @@
             "Oblivious",
             "Own Tempo"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "King\u2019s Rock",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 95,
             "attack": 75,
@@ -9318,12 +9536,13 @@
             "Magnet Pull",
             "Sturdy"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Metal Coat",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 25,
             "attack": 35,
@@ -9429,9 +9648,15 @@
             "Magnet Pull",
             "Sturdy"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Metal Coat",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Magnet",
                 0.05
             ]
         ],
@@ -9535,7 +9760,13 @@
             "Keen Eye",
             "Inner Focus"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Stick",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Stick",
                 0.05
@@ -9651,12 +9882,13 @@
             "Run Away",
             "Early Bird"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Sharp Beak",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 35,
             "attack": 85,
@@ -9766,7 +9998,13 @@
             "Run Away",
             "Early Bird"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Sharp Beak",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Sharp Beak",
                 0.05
@@ -9869,7 +10107,13 @@
         "abilities": [
             "Thick Fat"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Aspear Berry",
+                0.5
+            ]
+        ],
         "base_stats": {
             "hp": 65,
             "attack": 45,
@@ -9984,7 +10228,17 @@
         "abilities": [
             "Thick Fat"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Aspear Berry",
+                0.5
+            ],
+            [
+                "Nevermeltice",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 90,
             "attack": 70,
@@ -10086,12 +10340,13 @@
             "Stench",
             "Sticky Hold"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Nugget",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 80,
@@ -10214,12 +10469,13 @@
             "Stench",
             "Sticky Hold"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Nugget",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 105,
             "attack": 105,
@@ -10332,7 +10588,17 @@
         "abilities": [
             "Shell Armor"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Pearl",
+                0.5
+            ],
+            [
+                "Big Pearl",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Pearl",
                 0.5
@@ -10451,7 +10717,17 @@
         "abilities": [
             "Shell Armor"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Pearl",
+                0.5
+            ],
+            [
+                "Big Pearl",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Pearl",
                 0.5
@@ -10557,7 +10833,8 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 30,
             "attack": 35,
@@ -10674,7 +10951,13 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Spell Tag",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 45,
             "attack": 50,
@@ -10784,7 +11067,13 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Spell Tag",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 60,
             "attack": 65,
@@ -10906,7 +11195,13 @@
             "Rock Head",
             "Sturdy"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Hard Stone",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 35,
             "attack": 45,
@@ -11022,7 +11317,8 @@
         "abilities": [
             "Insomnia"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 48,
@@ -11152,7 +11448,8 @@
         "abilities": [
             "Insomnia"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 85,
             "attack": 73,
@@ -11271,7 +11568,8 @@
             "Hyper Cutter",
             "Shell Armor"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 30,
             "attack": 105,
@@ -11391,7 +11689,8 @@
             "Hyper Cutter",
             "Shell Armor"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 130,
@@ -11498,7 +11797,8 @@
             "Soundproof",
             "Static"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 30,
@@ -11605,7 +11905,8 @@
             "Soundproof",
             "Static"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 50,
@@ -11707,7 +12008,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 40,
@@ -11826,7 +12128,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 95,
             "attack": 95,
@@ -11927,7 +12230,13 @@
             "Rock Head",
             "Lightningrod"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Thick Club",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Thick Club",
                 0.05
@@ -12065,7 +12374,13 @@
             "Rock Head",
             "Lightningrod"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Thick Club",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Thick Club",
                 0.05
@@ -12189,7 +12504,8 @@
         "abilities": [
             "Limber"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 120,
@@ -12300,7 +12616,8 @@
         "abilities": [
             "Keen Eye"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 105,
@@ -12414,7 +12731,8 @@
             "Own Tempo",
             "Oblivious"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 55,
@@ -12552,12 +12870,13 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Smoke Ball",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 65,
@@ -12672,12 +12991,13 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Smoke Ball",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 90,
@@ -12782,7 +13102,8 @@
             "Lightningrod",
             "Rock Head"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 85,
@@ -12913,7 +13234,8 @@
             "Lightningrod",
             "Rock Head"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 105,
             "attack": 130,
@@ -13040,7 +13362,13 @@
             "Natural Cure",
             "Serene Grace"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Lucky Egg",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Lucky Egg",
                 0.05
@@ -13191,7 +13519,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 55,
@@ -13301,7 +13630,8 @@
         "abilities": [
             "Early Bird"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 105,
             "attack": 95,
@@ -13438,12 +13768,13 @@
         "abilities": [
             "Swift Swim"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Dragon Scale",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 30,
             "attack": 40,
@@ -13555,12 +13886,13 @@
         "abilities": [
             "Poison Point"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Dragon Scale",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 65,
@@ -13666,7 +13998,8 @@
             "Swift Swim",
             "Water Veil"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 67,
@@ -13777,7 +14110,8 @@
             "Swift Swim",
             "Water Veil"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 92,
@@ -13877,7 +14211,17 @@
             "Illuminate",
             "Natural Cure"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Stardust",
+                0.5
+            ],
+            [
+                "Star Piece",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Stardust",
                 0.5
@@ -14001,7 +14345,17 @@
             "Illuminate",
             "Natural Cure"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Stardust",
+                0.5
+            ],
+            [
+                "Star Piece",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Stardust",
                 0.5
@@ -14113,12 +14467,13 @@
         "abilities": [
             "Soundproof"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Leppa Berry",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 45,
@@ -14252,7 +14607,8 @@
         "abilities": [
             "Swarm"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 110,
@@ -14369,12 +14725,13 @@
         "abilities": [
             "Oblivious"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Aspear Berry",
                 1
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 50,
@@ -14493,7 +14850,8 @@
         "abilities": [
             "Static"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 83,
@@ -14605,12 +14963,13 @@
         "abilities": [
             "Flame Body"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Rawst Berry",
                 1
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 95,
@@ -14717,7 +15076,8 @@
         "abilities": [
             "Hyper Cutter"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 125,
@@ -14827,7 +15187,8 @@
         "abilities": [
             "Intimidate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 75,
             "attack": 100,
@@ -14934,7 +15295,8 @@
         "abilities": [
             "Swift Swim"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 20,
             "attack": 10,
@@ -15004,7 +15366,8 @@
         "abilities": [
             "Intimidate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 95,
             "attack": 125,
@@ -15117,7 +15480,8 @@
             "Water Absorb",
             "Shell Armor"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 130,
             "attack": 85,
@@ -15237,7 +15601,13 @@
         "abilities": [
             "Limber"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Metal Powder",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Metal Powder",
                 0.05
@@ -15301,7 +15671,8 @@
         "abilities": [
             "Run Away"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 55,
@@ -15433,7 +15804,8 @@
         "abilities": [
             "Water Absorb"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 130,
             "attack": 65,
@@ -15540,7 +15912,8 @@
         "abilities": [
             "Volt Absorb"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 65,
@@ -15644,7 +16017,8 @@
         "abilities": [
             "Flash Fire"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 130,
@@ -15746,7 +16120,8 @@
         "abilities": [
             "Trace"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 60,
@@ -15862,7 +16237,8 @@
             "Swift Swim",
             "Shell Armor"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 35,
             "attack": 40,
@@ -15983,7 +16359,8 @@
             "Swift Swim",
             "Shell Armor"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 60,
@@ -16093,7 +16470,8 @@
             "Swift Swim",
             "Battle Armor"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 30,
             "attack": 80,
@@ -16216,7 +16594,8 @@
             "Swift Swim",
             "Battle Armor"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 115,
@@ -16334,7 +16713,8 @@
             "Rock Head",
             "Pressure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 105,
@@ -16448,9 +16828,15 @@
             "Immunity",
             "Thick Fat"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Leftovers",
+                1
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Chesto Berry",
                 1
             ]
         ],
@@ -16588,7 +16974,8 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 85,
@@ -16691,7 +17078,8 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 90,
@@ -16794,7 +17182,8 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 100,
@@ -16894,12 +17283,13 @@
         "abilities": [
             "Shed Skin"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Dragon Scale",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 41,
             "attack": 64,
@@ -17022,9 +17412,15 @@
         "abilities": [
             "Shed Skin"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Dragon Scale",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Dragon Fang",
                 0.05
             ]
         ],
@@ -17144,9 +17540,15 @@
         "abilities": [
             "Inner Focus"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Dragon Scale",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Dragon Fang",
                 0.05
             ]
         ],
@@ -17280,7 +17682,8 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 106,
             "attack": 110,
@@ -17417,12 +17820,13 @@
         "abilities": [
             "Synchronize"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Lum Berry",
                 1
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 100,
             "attack": 100,
@@ -17576,7 +17980,13 @@
         "abilities": [
             "Overgrow"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Lum Berry",
+                1
+            ]
+        ],
         "base_stats": {
             "hp": 45,
             "attack": 49,
@@ -17695,7 +18105,8 @@
         "abilities": [
             "Overgrow"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 62,
@@ -17808,7 +18219,8 @@
         "abilities": [
             "Overgrow"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 82,
@@ -17917,7 +18329,8 @@
         "abilities": [
             "Blaze"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 39,
             "attack": 52,
@@ -18031,7 +18444,8 @@
         "abilities": [
             "Blaze"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 58,
             "attack": 64,
@@ -18142,7 +18556,8 @@
         "abilities": [
             "Blaze"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 78,
             "attack": 84,
@@ -18257,7 +18672,8 @@
         "abilities": [
             "Torrent"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 65,
@@ -18386,7 +18802,8 @@
         "abilities": [
             "Torrent"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 80,
@@ -18510,7 +18927,8 @@
         "abilities": [
             "Torrent"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 85,
             "attack": 105,
@@ -18632,7 +19050,13 @@
             "Run Away",
             "Keen Eye"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Oran Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Oran Berry",
                 0.05
@@ -18766,7 +19190,17 @@
             "Run Away",
             "Keen Eye"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Oran Berry",
+                0.5
+            ],
+            [
+                "Sitrus Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Oran Berry",
                 0.5
@@ -18895,7 +19329,8 @@
             "Insomnia",
             "Keen Eye"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 30,
@@ -19011,7 +19446,8 @@
             "Insomnia",
             "Keen Eye"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 100,
             "attack": 50,
@@ -19114,7 +19550,8 @@
             "Swarm",
             "Early Bird"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 20,
@@ -19233,7 +19670,8 @@
             "Swarm",
             "Early Bird"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 35,
@@ -19343,7 +19781,8 @@
             "Swarm",
             "Insomnia"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 60,
@@ -19455,7 +19894,8 @@
             "Swarm",
             "Insomnia"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 90,
@@ -19554,7 +19994,8 @@
         "abilities": [
             "Inner Focus"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 85,
             "attack": 90,
@@ -19660,7 +20101,13 @@
             "Volt Absorb",
             "Illuminate"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Yellow Shard",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Yellow Shard",
                 0.05
@@ -19778,7 +20225,13 @@
             "Volt Absorb",
             "Illuminate"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Yellow Shard",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Yellow Shard",
                 0.05
@@ -19885,12 +20338,13 @@
         "abilities": [
             "Static"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Oran Berry",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 20,
             "attack": 40,
@@ -20005,11 +20459,17 @@
         "abilities": [
             "Cute Charm"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Leppa Berry",
                 0.5
             ],
+            [
+                "Moon Stone",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Moon Stone",
                 0.05
@@ -20142,7 +20602,13 @@
         "abilities": [
             "Cute Charm"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Oran Berry",
+                0.5
+            ]
+        ],
         "base_stats": {
             "hp": 90,
             "attack": 30,
@@ -20265,7 +20731,8 @@
             "Hustle",
             "Serene Grace"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 35,
             "attack": 20,
@@ -20397,7 +20864,8 @@
             "Hustle",
             "Serene Grace"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 40,
@@ -20522,7 +20990,8 @@
             "Synchronize",
             "Early Bird"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 50,
@@ -20643,7 +21112,8 @@
             "Synchronize",
             "Early Bird"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 75,
@@ -20749,7 +21219,8 @@
         "abilities": [
             "Static"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 40,
@@ -20861,7 +21332,8 @@
         "abilities": [
             "Static"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 55,
@@ -20976,7 +21448,8 @@
         "abilities": [
             "Static"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 75,
@@ -21087,7 +21560,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 75,
             "attack": 80,
@@ -21183,7 +21657,8 @@
             "Thick Fat",
             "Huge Power"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 20,
@@ -21313,7 +21788,8 @@
             "Thick Fat",
             "Huge Power"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 100,
             "attack": 50,
@@ -21429,7 +21905,8 @@
             "Sturdy",
             "Rock Head"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 100,
@@ -21545,7 +22022,13 @@
             "Water Absorb",
             "Damp"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "King\u2019s Rock",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "King\u2019s Rock",
                 0.05
@@ -21662,7 +22145,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 35,
             "attack": 35,
@@ -21775,7 +22259,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 45,
@@ -21880,7 +22365,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 75,
             "attack": 55,
@@ -21980,7 +22466,8 @@
             "Run Away",
             "Pickup"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 70,
@@ -22111,7 +22598,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 30,
             "attack": 30,
@@ -22220,7 +22708,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 75,
             "attack": 75,
@@ -22320,7 +22809,8 @@
             "Speed Boost",
             "Compoundeyes"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 65,
@@ -22426,7 +22916,8 @@
             "Damp",
             "Water Absorb"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 45,
@@ -22553,7 +23044,8 @@
             "Damp",
             "Water Absorb"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 95,
             "attack": 85,
@@ -22672,7 +23164,8 @@
         "abilities": [
             "Synchronize"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 65,
@@ -22779,7 +23272,8 @@
         "abilities": [
             "Synchronize"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 95,
             "attack": 65,
@@ -22886,7 +23380,8 @@
         "abilities": [
             "Insomnia"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 85,
@@ -22999,7 +23494,13 @@
             "Oblivious",
             "Own Tempo"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "King\u2019s Rock",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "King\u2019s Rock",
                 0.05
@@ -23131,7 +23632,13 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Spell Tag",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Spell Tag",
                 0.05
@@ -23248,7 +23755,8 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 48,
             "attack": 72,
@@ -23307,7 +23815,8 @@
         "abilities": [
             "Shadow Tag"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 190,
             "attack": 33,
@@ -23372,7 +23881,13 @@
             "Inner Focus",
             "Early Bird"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Persim Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Persim Berry",
                 0.05
@@ -23496,7 +24011,8 @@
         "abilities": [
             "Sturdy"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 65,
@@ -23613,7 +24129,8 @@
         "abilities": [
             "Sturdy"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 75,
             "attack": 90,
@@ -23718,7 +24235,8 @@
             "Serene Grace",
             "Run Away"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 100,
             "attack": 70,
@@ -23843,7 +24361,8 @@
             "Hyper Cutter",
             "Sand Veil"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 75,
@@ -23956,7 +24475,13 @@
             "Rock Head",
             "Sturdy"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Metal Coat",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Metal Coat",
                 0.05
@@ -24070,7 +24595,8 @@
             "Intimidate",
             "Run Away"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 80,
@@ -24211,7 +24737,8 @@
             "Intimidate",
             "Intimidate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 120,
@@ -24342,7 +24869,8 @@
             "Poison Point",
             "Swift Swim"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 95,
@@ -24452,7 +24980,8 @@
         "abilities": [
             "Swarm"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 130,
@@ -24556,9 +25085,15 @@
         "abilities": [
             "Sturdy"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Oran Berry",
+                1
+            ]
+        ],
+        "held_items_frlg": [
+            [
+                "Berry Juice",
                 1
             ]
         ],
@@ -24664,7 +25199,8 @@
             "Swarm",
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 125,
@@ -24777,12 +25313,13 @@
             "Inner Focus",
             "Keen Eye"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Quick Claw",
                 0.05
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 95,
@@ -24910,7 +25447,17 @@
         "abilities": [
             "Pickup"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Oran Berry",
+                0.5
+            ],
+            [
+                "Sitrus Berry",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 60,
             "attack": 80,
@@ -25044,7 +25591,17 @@
         "abilities": [
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Oran Berry",
+                0.5
+            ],
+            [
+                "Sitrus Berry",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 90,
             "attack": 130,
@@ -25167,7 +25724,8 @@
             "Magma Armor",
             "Flame Body"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 40,
@@ -25277,7 +25835,8 @@
             "Magma Armor",
             "Flame Body"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 50,
@@ -25382,7 +25941,13 @@
         "abilities": [
             "Oblivious"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Aspear Berry",
+                0.5
+            ]
+        ],
         "base_stats": {
             "hp": 50,
             "attack": 50,
@@ -25502,7 +26067,17 @@
         "abilities": [
             "Oblivious"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Aspear Berry",
+                0.5
+            ],
+            [
+                "Nevermeltice",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 100,
             "attack": 100,
@@ -25610,7 +26185,13 @@
             "Hustle",
             "Natural Cure"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Red Shard",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Red Shard",
                 0.05
@@ -25737,7 +26318,8 @@
         "abilities": [
             "Hustle"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 35,
             "attack": 65,
@@ -25855,7 +26437,8 @@
         "abilities": [
             "Suction Cups"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 75,
             "attack": 105,
@@ -25965,7 +26548,8 @@
             "Vital Spirit",
             "Hustle"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 55,
@@ -26070,7 +26654,8 @@
             "Swift Swim",
             "Water Absorb"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 40,
@@ -26179,7 +26764,13 @@
             "Keen Eye",
             "Sturdy"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Sharp Beak",
+                0.05
+            ]
+        ],
         "base_stats": {
             "hp": 65,
             "attack": 80,
@@ -26289,7 +26880,8 @@
             "Early Bird",
             "Flash Fire"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 60,
@@ -26413,7 +27005,8 @@
             "Early Bird",
             "Flash Fire"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 75,
             "attack": 90,
@@ -26523,7 +27116,13 @@
         "abilities": [
             "Swift Swim"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Dragon Scale",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Dragon Scale",
                 0.05
@@ -26628,7 +27227,8 @@
         "abilities": [
             "Pickup"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 60,
@@ -26741,7 +27341,8 @@
         "abilities": [
             "Sturdy"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 120,
@@ -26843,7 +27444,13 @@
         "abilities": [
             "Trace"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [
+            [
+                "Up-grade",
+                1
+            ]
+        ],
         "base_stats": {
             "hp": 85,
             "attack": 80,
@@ -26952,7 +27559,8 @@
         "abilities": [
             "Intimidate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 73,
             "attack": 95,
@@ -27068,7 +27676,8 @@
         "abilities": [
             "Own Tempo"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 20,
@@ -27127,7 +27736,8 @@
         "abilities": [
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 35,
             "attack": 35,
@@ -27245,7 +27855,8 @@
         "abilities": [
             "Intimidate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 95,
@@ -27352,12 +27963,13 @@
         "abilities": [
             "Oblivious"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Aspear Berry",
                 1
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 30,
@@ -27483,7 +28095,8 @@
         "abilities": [
             "Static"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 63,
@@ -27606,12 +28219,13 @@
         "abilities": [
             "Flame Body"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Rawst Berry",
                 1
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 75,
@@ -27729,7 +28343,13 @@
         "abilities": [
             "Thick Fat"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Moomoo Milk",
+                1
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Moomoo Milk",
                 1
@@ -27867,7 +28487,13 @@
             "Natural Cure",
             "Serene Grace"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Lucky Egg",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Lucky Egg",
                 0.05
@@ -28005,7 +28631,8 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 85,
@@ -28112,7 +28739,8 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 115,
             "attack": 115,
@@ -28218,7 +28846,8 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 100,
             "attack": 75,
@@ -28328,7 +28957,8 @@
         "abilities": [
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 64,
@@ -28445,7 +29075,8 @@
         "abilities": [
             "Shed Skin"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 84,
@@ -28554,7 +29185,8 @@
         "abilities": [
             "Sand Stream"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 100,
             "attack": 134,
@@ -28682,7 +29314,8 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 106,
             "attack": 90,
@@ -28806,12 +29439,13 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [
+        "held_items_rse": [
             [
                 "Sacred Ash",
                 1
             ]
         ],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 106,
             "attack": 130,
@@ -28929,7 +29563,13 @@
         "abilities": [
             "Natural Cure"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Lum Berry",
+                1
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Lum Berry",
                 1
@@ -29044,7 +29684,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29103,7 +29744,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29162,7 +29804,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29221,7 +29864,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29280,7 +29924,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29339,7 +29984,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29398,7 +30044,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29457,7 +30104,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29516,7 +30164,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29575,7 +30224,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29634,7 +30284,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29693,7 +30344,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29752,7 +30404,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29811,7 +30464,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29870,7 +30524,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29929,7 +30584,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -29988,7 +30644,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -30047,7 +30704,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -30106,7 +30764,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -30165,7 +30824,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -30224,7 +30884,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -30283,7 +30944,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -30342,7 +31004,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -30401,7 +31064,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -30460,7 +31124,8 @@
         "abilities": [
             "-------"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -30519,7 +31184,8 @@
         "abilities": [
             "Overgrow"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 45,
@@ -30649,7 +31315,8 @@
         "abilities": [
             "Overgrow"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 65,
@@ -30773,7 +31440,8 @@
         "abilities": [
             "Overgrow"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 85,
@@ -30895,7 +31563,8 @@
         "abilities": [
             "Blaze"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 60,
@@ -31018,7 +31687,8 @@
         "abilities": [
             "Blaze"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 85,
@@ -31142,7 +31812,8 @@
         "abilities": [
             "Blaze"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 120,
@@ -31264,7 +31935,8 @@
         "abilities": [
             "Torrent"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 70,
@@ -31388,7 +32060,8 @@
         "abilities": [
             "Torrent"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 85,
@@ -31514,7 +32187,8 @@
         "abilities": [
             "Torrent"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 100,
             "attack": 110,
@@ -31637,7 +32311,13 @@
         "abilities": [
             "Run Away"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Pecha Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Pecha Berry",
                 0.05
@@ -31759,7 +32439,13 @@
         "abilities": [
             "Intimidate"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Pecha Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Pecha Berry",
                 0.05
@@ -31871,7 +32557,13 @@
         "abilities": [
             "Pickup"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Oran Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Oran Berry",
                 0.05
@@ -32001,7 +32693,17 @@
         "abilities": [
             "Pickup"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Oran Berry",
+                0.5
+            ],
+            [
+                "Sitrus Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Oran Berry",
                 0.5
@@ -32126,7 +32828,8 @@
         "abilities": [
             "Shield Dust"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 45,
@@ -32202,7 +32905,8 @@
         "abilities": [
             "Shed Skin"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 35,
@@ -32270,7 +32974,13 @@
         "abilities": [
             "Swarm"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Silverpowder",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Silverpowder",
                 0.05
@@ -32374,7 +33084,8 @@
         "abilities": [
             "Shed Skin"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 35,
@@ -32442,7 +33153,13 @@
         "abilities": [
             "Shield Dust"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Silverpowder",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Silverpowder",
                 0.05
@@ -32549,7 +33266,8 @@
             "Swift Swim",
             "Rain Dish"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 30,
@@ -32666,7 +33384,8 @@
             "Swift Swim",
             "Rain Dish"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 50,
@@ -32789,7 +33508,8 @@
             "Swift Swim",
             "Rain Dish"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 70,
@@ -32906,7 +33626,8 @@
             "Chlorophyll",
             "Early Bird"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 40,
@@ -33021,7 +33742,8 @@
             "Chlorophyll",
             "Early Bird"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 70,
@@ -33144,7 +33866,8 @@
             "Chlorophyll",
             "Early Bird"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 100,
@@ -33255,7 +33978,8 @@
         "abilities": [
             "Compoundeyes"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 31,
             "attack": 45,
@@ -33371,7 +34095,8 @@
         "abilities": [
             "Speed Boost"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 61,
             "attack": 90,
@@ -33478,7 +34203,8 @@
         "abilities": [
             "Wonder Guard"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 1,
             "attack": 90,
@@ -33580,7 +34306,8 @@
         "abilities": [
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 55,
@@ -33690,7 +34417,8 @@
         "abilities": [
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 85,
@@ -33787,7 +34515,8 @@
         "abilities": [
             "Effect Spore"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 40,
@@ -33899,7 +34628,8 @@
         "abilities": [
             "Effect Spore"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 130,
@@ -34015,7 +34745,13 @@
         "abilities": [
             "Own Tempo"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Chesto Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Chesto Berry",
                 0.05
@@ -34155,7 +34891,8 @@
         "abilities": [
             "Keen Eye"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 30,
@@ -34268,7 +35005,8 @@
         "abilities": [
             "Keen Eye"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 50,
@@ -34374,7 +35112,8 @@
         "abilities": [
             "Swift Swim"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 30,
@@ -34487,7 +35226,13 @@
         "abilities": [
             "Intimidate"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Silverpowder",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Silverpowder",
                 0.05
@@ -34596,7 +35341,8 @@
             "Water Veil",
             "Oblivious"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 130,
             "attack": 70,
@@ -34720,7 +35466,8 @@
             "Water Veil",
             "Oblivious"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 170,
             "attack": 90,
@@ -34829,7 +35576,13 @@
         "abilities": [
             "Cute Charm"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Leppa Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Leppa Berry",
                 0.05
@@ -34964,7 +35717,13 @@
         "abilities": [
             "Cute Charm"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Leppa Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Leppa Berry",
                 0.05
@@ -35079,7 +35838,13 @@
         "abilities": [
             "Color Change"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Persim Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Persim Berry",
                 0.05
@@ -35223,7 +35988,8 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 40,
@@ -35337,7 +36103,8 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 70,
@@ -35450,7 +36217,8 @@
             "Sturdy",
             "Magnet Pull"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 30,
             "attack": 45,
@@ -35563,7 +36331,8 @@
         "abilities": [
             "White Smoke"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 85,
@@ -35670,7 +36439,8 @@
         "abilities": [
             "Keen Eye"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 75,
@@ -35798,7 +36568,8 @@
         "abilities": [
             "Oblivious"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 48,
@@ -35911,7 +36682,8 @@
         "abilities": [
             "Oblivious"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 110,
             "attack": 78,
@@ -36018,7 +36790,13 @@
         "abilities": [
             "Swift Swim"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Heart Scale",
+                0.5
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Heart Scale",
                 0.5
@@ -36127,7 +36905,8 @@
             "Hyper Cutter",
             "Shell Armor"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 43,
             "attack": 80,
@@ -36252,7 +37031,8 @@
             "Hyper Cutter",
             "Shell Armor"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 63,
             "attack": 120,
@@ -36367,7 +37147,8 @@
         "abilities": [
             "Swift Swim"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 20,
             "attack": 15,
@@ -36472,7 +37253,8 @@
         "abilities": [
             "Marvel Scale"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 95,
             "attack": 60,
@@ -36579,7 +37361,8 @@
         "abilities": [
             "Rough Skin"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 90,
@@ -36693,7 +37476,8 @@
         "abilities": [
             "Rough Skin"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 120,
@@ -36805,7 +37589,13 @@
             "Hyper Cutter",
             "Arena Trap"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Soft Sand",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Soft Sand",
                 0.05
@@ -36922,7 +37712,8 @@
             "Levitate",
             "Levitate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 70,
@@ -37034,7 +37825,8 @@
             "Levitate",
             "Levitate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 100,
@@ -37145,7 +37937,8 @@
             "Thick Fat",
             "Guts"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 72,
             "attack": 60,
@@ -37275,7 +38068,13 @@
             "Thick Fat",
             "Guts"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "King\u2019s Rock",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "King\u2019s Rock",
                 0.05
@@ -37396,7 +38195,8 @@
             "Static",
             "Lightningrod"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 40,
             "attack": 45,
@@ -37511,7 +38311,8 @@
             "Static",
             "Lightningrod"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 75,
@@ -37615,7 +38416,13 @@
         "abilities": [
             "Oblivious"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Rawst Berry",
+                1
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Rawst Berry",
                 1
@@ -37737,7 +38544,13 @@
         "abilities": [
             "Magma Armor"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Rawst Berry",
+                1
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Rawst Berry",
                 1
@@ -37850,7 +38663,8 @@
         "abilities": [
             "Thick Fat"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 70,
             "attack": 40,
@@ -37977,7 +38791,8 @@
         "abilities": [
             "Thick Fat"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 90,
             "attack": 60,
@@ -38096,7 +38911,8 @@
         "abilities": [
             "Thick Fat"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 110,
             "attack": 80,
@@ -38209,7 +39025,13 @@
         "abilities": [
             "Sand Veil"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Poison Barb",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Poison Barb",
                 0.05
@@ -38336,7 +39158,13 @@
         "abilities": [
             "Sand Veil"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Poison Barb",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Poison Barb",
                 0.05
@@ -38453,7 +39281,8 @@
         "abilities": [
             "Inner Focus"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 50,
@@ -38563,7 +39392,13 @@
         "abilities": [
             "Inner Focus"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Nevermeltice",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Nevermeltice",
                 0.05
@@ -38678,7 +39513,13 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Moon Stone",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Moon Stone",
                 0.05
@@ -38792,7 +39633,13 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Sun Stone",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Sun Stone",
                 0.05
@@ -38909,7 +39756,8 @@
             "Thick Fat",
             "Huge Power"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 20,
@@ -39021,7 +39869,8 @@
             "Thick Fat",
             "Own Tempo"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 25,
@@ -39142,7 +39991,8 @@
             "Thick Fat",
             "Own Tempo"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 45,
@@ -39262,7 +40112,8 @@
         "abilities": [
             "Plus"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 50,
@@ -39373,7 +40224,8 @@
         "abilities": [
             "Minus"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 40,
@@ -39485,7 +40337,8 @@
             "Hyper Cutter",
             "Intimidate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 85,
@@ -39612,7 +40465,8 @@
         "abilities": [
             "Pure Power"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 30,
             "attack": 40,
@@ -39744,7 +40598,8 @@
         "abilities": [
             "Pure Power"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 60,
@@ -39867,7 +40722,8 @@
         "abilities": [
             "Natural Cure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 40,
@@ -39983,7 +40839,8 @@
         "abilities": [
             "Natural Cure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 75,
             "attack": 70,
@@ -40097,7 +40954,8 @@
         "abilities": [
             "Shadow Tag"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 95,
             "attack": 23,
@@ -40169,7 +41027,13 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Spell Tag",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Spell Tag",
                 0.05
@@ -40293,7 +41157,13 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Spell Tag",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Spell Tag",
                 0.05
@@ -40425,7 +41295,13 @@
             "Natural Cure",
             "Poison Point"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Poison Barb",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Poison Barb",
                 0.05
@@ -40542,7 +41418,8 @@
         "abilities": [
             "Truant"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 60,
             "attack": 60,
@@ -40676,7 +41553,8 @@
         "abilities": [
             "Vital Spirit"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 80,
@@ -40806,7 +41684,8 @@
         "abilities": [
             "Truant"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 150,
             "attack": 160,
@@ -40932,7 +41811,13 @@
             "Liquid Ooze",
             "Sticky Hold"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Big Pearl",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Big Pearl",
                 0.05
@@ -41062,7 +41947,13 @@
             "Liquid Ooze",
             "Sticky Hold"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Big Pearl",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Big Pearl",
                 0.05
@@ -41183,7 +42074,8 @@
         "abilities": [
             "Chlorophyll"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 99,
             "attack": 68,
@@ -41297,7 +42189,13 @@
         "abilities": [
             "Soundproof"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Chesto Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Chesto Berry",
                 0.05
@@ -41430,7 +42328,13 @@
         "abilities": [
             "Soundproof"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Chesto Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Chesto Berry",
                 0.05
@@ -41565,7 +42469,13 @@
         "abilities": [
             "Soundproof"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Chesto Berry",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Chesto Berry",
                 0.05
@@ -41696,7 +42606,13 @@
         "abilities": [
             "Shell Armor"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Blue Shard",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Blue Shard",
                 0.05
@@ -41812,7 +42728,8 @@
         "abilities": [
             "Swift Swim"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 104,
@@ -41913,7 +42830,8 @@
         "abilities": [
             "Swift Swim"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 55,
             "attack": 84,
@@ -42015,7 +42933,8 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 130,
@@ -42146,7 +43065,13 @@
         "abilities": [
             "Insomnia"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Spell Tag",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Spell Tag",
                 0.05
@@ -42270,7 +43195,13 @@
         "abilities": [
             "Insomnia"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Spell Tag",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Spell Tag",
                 0.05
@@ -42385,7 +43316,8 @@
         "abilities": [
             "Shed Skin"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 73,
             "attack": 100,
@@ -42495,7 +43427,8 @@
         "abilities": [
             "Immunity"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 73,
             "attack": 115,
@@ -42633,7 +43566,13 @@
             "Swift Swim",
             "Rock Head"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Green Shard",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Green Shard",
                 0.05
@@ -42756,7 +43695,13 @@
             "Sturdy",
             "Rock Head"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Hard Stone",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Hard Stone",
                 0.05
@@ -42885,7 +43830,13 @@
             "Sturdy",
             "Rock Head"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Hard Stone",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Hard Stone",
                 0.05
@@ -43009,7 +43960,13 @@
             "Sturdy",
             "Rock Head"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Hard Stone",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Hard Stone",
                 0.05
@@ -43148,7 +44105,13 @@
         "abilities": [
             "Forecast"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Mystic Water",
+                1
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Mystic Water",
                 1
@@ -43265,7 +44228,8 @@
             "Illuminate",
             "Swarm"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 73,
@@ -43385,7 +44349,8 @@
         "abilities": [
             "Oblivious"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 47,
@@ -43506,7 +44471,8 @@
         "abilities": [
             "Suction Cups"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 66,
             "attack": 41,
@@ -43616,7 +44582,8 @@
         "abilities": [
             "Suction Cups"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 86,
             "attack": 81,
@@ -43720,7 +44687,8 @@
         "abilities": [
             "Battle Armor"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 45,
             "attack": 95,
@@ -43834,7 +44802,8 @@
         "abilities": [
             "Battle Armor"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 75,
             "attack": 125,
@@ -43942,7 +44911,8 @@
             "Synchronize",
             "Trace"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 28,
             "attack": 25,
@@ -44070,7 +45040,8 @@
             "Synchronize",
             "Trace"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 38,
             "attack": 35,
@@ -44192,7 +45163,8 @@
             "Synchronize",
             "Trace"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 68,
             "attack": 65,
@@ -44308,7 +45280,13 @@
         "abilities": [
             "Rock Head"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Dragon Scale",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Dragon Scale",
                 0.05
@@ -44431,7 +45409,13 @@
         "abilities": [
             "Rock Head"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Dragon Scale",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Dragon Scale",
                 0.05
@@ -44552,7 +45536,13 @@
         "abilities": [
             "Intimidate"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Dragon Scale",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Dragon Scale",
                 0.05
@@ -44674,7 +45664,13 @@
         "abilities": [
             "Clear Body"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Metal Coat",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Metal Coat",
                 0.05
@@ -44747,7 +45743,13 @@
         "abilities": [
             "Clear Body"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Metal Coat",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Metal Coat",
                 0.05
@@ -44877,7 +45879,13 @@
         "abilities": [
             "Clear Body"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Metal Coat",
+                0.05
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Metal Coat",
                 0.05
@@ -45000,7 +46008,8 @@
         "abilities": [
             "Clear Body"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 100,
@@ -45115,7 +46124,8 @@
         "abilities": [
             "Clear Body"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 50,
@@ -45230,7 +46240,8 @@
         "abilities": [
             "Clear Body"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 75,
@@ -45346,7 +46357,8 @@
         "abilities": [
             "Drizzle"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 100,
             "attack": 100,
@@ -45461,7 +46473,8 @@
         "abilities": [
             "Drought"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 100,
             "attack": 150,
@@ -45589,7 +46602,8 @@
         "abilities": [
             "Air Lock"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 105,
             "attack": 150,
@@ -45712,7 +46726,8 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 80,
@@ -45836,7 +46851,8 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 80,
             "attack": 90,
@@ -45960,7 +46976,13 @@
         "abilities": [
             "Serene Grace"
         ],
-        "held_items": [
+        "held_items_rse": [
+            [
+                "Star Piece",
+                1
+            ]
+        ],
+        "held_items_frlg": [
             [
                 "Star Piece",
                 1
@@ -46082,7 +47104,8 @@
         "abilities": [
             "Pressure"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 50,
             "attack": 150,
@@ -46213,7 +47236,8 @@
         "abilities": [
             "Levitate"
         ],
-        "held_items": [],
+        "held_items_rse": [],
+        "held_items_frlg": [],
         "base_stats": {
             "hp": 65,
             "attack": 50,

--- a/modules/debug.py
+++ b/modules/debug.py
@@ -32,7 +32,8 @@ class DebugUtil:
                 self.action_stack.append(f"{name}({', '.join(formatted_args)})")
 
             try:
-                yield from generator_function(*args, **kwargs)
+                return_value = yield from generator_function(*args, **kwargs)
+                return return_value
             finally:
                 if self.enabled:
                     self.action_stack.pop()

--- a/modules/items.py
+++ b/modules/items.py
@@ -404,7 +404,9 @@ class ItemBag:
         else:
             stack_size = 99
 
-        return any(slot.item == item and slot.quantity + quantity <= stack_size for slot in pocket)
+        space = sum([stack_size - slot.quantity for slot in pocket if slot.item is item])
+        space += (pocket_size - len(pocket)) * stack_size
+        return quantity <= space
 
     def pocket_for(self, item: Item) -> list[ItemSlot]:
         match item.pocket:
@@ -478,11 +480,10 @@ class ItemStorage:
                 result.append(ItemSlot(item, quantity))
         return result
 
-    def has_space_for(self, item: Item) -> bool:
-        if len(self.items) < self.number_of_slots:
-            return True
-
-        return any(slot.item == item and slot.quantity < 999 for slot in self.items)
+    def has_space_for(self, item: Item, quantity: int = 1) -> bool:
+        space = sum([999 - slot.quantity for slot in self.items if slot.item is item])
+        space += (self.number_of_slots - len(self.items)) * 999
+        return quantity <= space
 
     def first_slot_index_for(self, item: Item) -> int | None:
         for index, slot in enumerate(self.items):

--- a/modules/menuing.py
+++ b/modules/menuing.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import Generator
+from typing import Generator, Iterable
 
 from modules.context import context
 from modules.game_stats import get_game_stat, GameStat
@@ -18,7 +18,7 @@ from modules.menu_parsers import (
 from modules.modes._asserts import assert_has_pokemon_with_any_move
 from modules.modes._interface import BotModeError
 from modules.pokemon import get_move_by_name
-from modules.pokemon_party import get_party, get_party_size
+from modules.pokemon_party import get_party, get_party_size, PartyPokemon
 from modules.tasks import get_task, task_is_active
 
 
@@ -648,150 +648,49 @@ def get_items_available_for_pickup() -> list[str]:
         ]
 
 
-class CheckForPickup(BaseMenuNavigator):
-    """
-    class that handles pickup farming.
-    """
+def take_held_items_from_multiple_party_pokemon(
+    list_of_party_indices: Iterable[int], force_checking: bool = False
+) -> Generator[None, None, list[Item]]:
+    # Check whether these Pokémon actually have a held item, and whether
+    # there is space for it in the item bag.
+    verified_list_of_party_indices = set()
+    for party_index in list_of_party_indices:
+        if len(get_party()) <= party_index:
+            continue
 
-    def __init__(self):
-        super().__init__()
-
-        self.possible_pickup_items = get_items_available_for_pickup()
-        self.party = get_party()
-        self.pokemon_with_pickup = 0
-        self.pokemon_with_pickup_and_item = []
-        self.picked_up_items = []
-        self.current_mon = -1
-        self.pickup_threshold_met = None
-        self.check_threshold_met = False
-        self.check_pickup_threshold()
-        self.checked = False
-        self.game = context.rom.game_title
-        self.party_menu_opener = None
-        self.party_menu_navigator = None
-
-    def get_pokemon_with_pickup_and_item(self):
-        for i, mon in enumerate(self.party):
-            if mon.ability.name == "Pickup":
-                self.pokemon_with_pickup += 1
-                if mon.held_item is not None and mon.held_item.name in self.possible_pickup_items:
-                    self.pokemon_with_pickup_and_item.append(i)
-                    self.picked_up_items.append(mon.held_item)
-
-    def check_pickup_threshold(self):
-        if context.config.cheats.faster_pickup:
-            self.check_threshold_met = True
-            self.checked = True
-        else:
-            self.check_threshold_met = (
-                get_game_stat(GameStat.TOTAL_BATTLES) % context.config.battle.pickup_check_frequency == 0
-            )
-        self.get_pokemon_with_pickup_and_item()
-        if context.config.battle.pickup_threshold > self.pokemon_with_pickup > 0:
-            threshold = self.pokemon_with_pickup
-            context.message = (
-                f"Number of pickup pokemon is {threshold}, which is lower than config. "
-                f"Using party value of {threshold} instead."
-            )
-        else:
-            threshold = context.config.battle.pickup_threshold
-        self.pickup_threshold_met = self.check_threshold_met and len(self.pokemon_with_pickup_and_item) >= threshold
-        if self.pickup_threshold_met:
-            context.stats.log_pickup_items(self.picked_up_items)
-            context.message = "Pickup threshold is met! Gathering items..."
-
-    def open_party_menu(self):
-        while not party_menu_is_open():
-            if self.party_menu_opener is None:
-                self.party_menu_opener = StartMenuNavigator("POKEMON")
-            if self.party_menu_opener.current_step != "exit":
-                yield from self.party_menu_opener.step()
-            else:
-                context.emulator.press_button("A")
-                yield
-
-    def return_to_party_menu(self):
-        if self.game in ["POKEMON EMER", "POKEMON FIRE", "POKEMON LEAF"]:
-            while task_is_active("Task_PrintAndWaitForText"):
-                context.emulator.press_button("B")
-                yield
-        else:
-            while (
-                task_is_active("HANDLEDEFAULTPARTYMENU")
-                and task_is_active("HANDLEPARTYMENUSWITCHPOKEMONINPUT")
-                and task_is_active("HANDLEBATTLEPARTYMENU")
-            ):
-                context.emulator.press_button("B")
-                yield
-
-    def should_open_party_menu(self):
+        pokemon: PartyPokemon = get_party()[party_index]
         if (
-            not context.config.cheats.faster_pickup
-            and self.check_threshold_met
-            and not self.checked
-            and self.pokemon_with_pickup > 0
+            pokemon.is_valid
+            and not pokemon.is_egg
+            and (held_item := pokemon.held_item) is not None
+            and get_item_bag().has_space_for(held_item)
         ):
-            return True
-        elif self.pickup_threshold_met:
-            return True
-        else:
-            return False
+            verified_list_of_party_indices.add(party_index)
 
-    def check_space_in_bag(self):
-        if self.current_mon is not None:
-            pokemon = self.party[self.current_mon]
-            if not get_item_bag().has_space_for(pokemon.held_item):
-                context.message = (
-                    f"Item bag is full! {pokemon.species.name} (party slot #{self.current_mon + 1}) is holding a "
-                    f"{pokemon.held_item.name} but there is no space left for it in the bag."
-                )
-                context.set_manual_mode()
+    # Do nothing if none of the Pokémon qualify.
+    if len(verified_list_of_party_indices) == 0 and not force_checking:
+        return []
 
-    def get_next_func(self):
-        match self.current_step:
-            case "None":
-                if self.should_open_party_menu():
-                    self.current_step = "open_party_menu"
-                else:
-                    self.current_step = "exit"
-            case "open_party_menu":
-                self.checked = True
-                if self.pickup_threshold_met and len(self.pokemon_with_pickup_and_item) > 0:
-                    self.current_mon = self.pokemon_with_pickup_and_item[0]
-                    self.check_space_in_bag()
-                    self.current_step = "take_mon_item"
-                else:
-                    self.current_step = "exit_to_overworld"
-            case "take_mon_item":
-                self.current_step = "return_to_party_menu"
-            case "return_to_party_menu":
-                if self.current_mon == self.pokemon_with_pickup_and_item[-1]:
-                    self.current_step = "exit_to_overworld"
-                else:
-                    self.get_next_mon()
-                    self.current_step = "take_mon_item"
-            case "exit_to_overworld":
-                self.current_step = "exit"
+    # Open Party Menu
+    yield from StartMenuNavigator("POKEMON").step()
 
-    def get_next_mon(self):
-        next_idx = self.pokemon_with_pickup_and_item.index(self.current_mon) + 1
-        if next_idx > len(self.pokemon_with_pickup_and_item) - 1:
-            context.message = "I forgot how to count, switching to manual mode..."
-            context.set_manual_mode()
-        else:
-            self.current_mon = self.pokemon_with_pickup_and_item[next_idx]
-            self.check_space_in_bag()
+    list_of_retrieved_items = []
+    for party_index in sorted(verified_list_of_party_indices):
+        # We already checked whether there was space in the item bag before, but
+        # if we fetch items from multiple Pokémon it's possible that the last
+        # remaining spot got used up by the Pokémon before. That's why we're
+        # checking again. If there is no space left, we just skip silently.
+        if not get_item_bag().has_space_for(get_party()[party_index].held_item):
+            continue
 
-    def update_navigator(self):
-        match self.current_step:
-            case "open_party_menu":
-                self.navigator = self.open_party_menu()
-            case "take_mon_item":
-                self.navigator = PokemonPartyMenuNavigator(idx=self.current_mon, mode="take_item").step()
-            case "return_to_party_menu":
-                self.navigator = self.return_to_party_menu()
-            case "exit_to_overworld":
-                self.navigator = PartyMenuExit().step()
+        list_of_retrieved_items.append(get_party()[party_index].held_item)
+        yield from PokemonPartyMenuNavigator(idx=party_index, mode="take_item").step()
+
+    # Exit party menu
+    yield from PartyMenuExit().step()
+    yield
+
+    return list_of_retrieved_items
 
 
 class PartyMenuExit(BaseMenuNavigator):
@@ -846,9 +745,19 @@ def should_check_for_pickup():
     if not context.config.battle.pickup:
         return False
 
+    items_available_for_pickup = get_items_available_for_pickup()
+    if not any(
+        [
+            pokemon.ability.name == "Pickup"
+            and not pokemon.is_egg
+            and ((held_item := pokemon.held_item) is None or held_item.name in items_available_for_pickup)
+            for pokemon in get_party()
+        ]
+    ):
+        return False
+
     if context.config.cheats.faster_pickup:
         pokemon_with_items_to_pick_up = 0
-        items_available_for_pickup = get_items_available_for_pickup()
         for pokemon in get_party():
             if (
                 pokemon.ability.name == "Pickup"

--- a/modules/modes/_listeners.py
+++ b/modules/modes/_listeners.py
@@ -7,7 +7,13 @@ from modules.encounter import handle_encounter, EncounterInfo, log_encounter
 from modules.map import get_map_objects, get_map_data_for_current_position
 from modules.map_data import MapFRLG, MapRSE, is_safari_map
 from modules.memory import GameState, get_game_state, get_game_state_symbol, read_symbol, unpack_uint32, unpack_uint16
-from modules.menuing import CheckForPickup, MenuWrapper, should_check_for_pickup, RotatePokemon
+from modules.menuing import (
+    MenuWrapper,
+    should_check_for_pickup,
+    RotatePokemon,
+    take_held_items_from_multiple_party_pokemon,
+    get_items_available_for_pickup,
+)
 from modules.player import TileTransitionState, get_player_avatar, player_avatar_is_standing_still
 from modules.pokemon import StatusCondition, clear_opponent, get_opponent
 from modules.pokemon_party import get_party
@@ -23,6 +29,7 @@ from ..battle_state import (
     get_battle_state,
     BattleType,
     get_main_battle_callback,
+    HandledBattleResult,
 )
 from ..battle_strategies import DefaultBattleStrategy, BattleStrategy
 from ..battle_strategies.catch import CatchStrategy
@@ -37,6 +44,7 @@ from ..plugins import (
     plugin_wild_encounter_visible,
     plugin_egg_starting_to_hatch,
     plugin_should_nickname_pokemon,
+    plugin_picked_up_items,
 )
 from ..text_printer import get_text_printer, TextPrinterState
 
@@ -198,20 +206,24 @@ class BattleListener(BotListener):
     def fight(self, strategy: BattleStrategy):
         first_non_fainted_lead_before_battle = get_party().first_non_fainted.index
         yield from plugin_battle_started(self._active_wild_encounter)
-        yield from handle_battle(strategy)
+        result = yield from handle_battle(strategy)
         yield from self._wait_until_battle_is_over()
+
+        if len(result.party_indices_with_picked_up_items) > 0:
+            context.stats.log_pickup_items(
+                [get_party()[index].held_item for index in result.party_indices_with_picked_up_items]
+            )
 
         if (
             get_game_state() != GameState.BATTLE
             and not get_global_script_context().is_active
             and player_avatar_is_standing_still()
         ):
-            if (
-                should_check_for_pickup()
-                and context.bot_mode_instance is not None
-                and context.bot_mode_instance.on_pickup_threshold_reached()
+            if context.bot_mode_instance is not None and (
+                len(result.party_indices_with_stolen_items) > 0
+                or (should_check_for_pickup() and context.bot_mode_instance.on_pickup_threshold_reached())
             ):
-                yield from self.check_for_pickup()
+                yield from self.retrieve_held_items(result)
             if strategy.choose_new_lead_after_battle() is not None:
                 if context.bot_mode != "Manual":
                     yield from self.rotate_lead_pokemon(
@@ -219,8 +231,26 @@ class BattleListener(BotListener):
                     )
 
     @debug.track
-    def check_for_pickup(self):
-        yield from MenuWrapper(CheckForPickup()).step()
+    def retrieve_held_items(self, result: HandledBattleResult):
+        pickup_item_names = get_items_available_for_pickup()
+        pokemon_with_picked_up_item = []
+        for pokemon in get_party():
+            if (
+                not pokemon.is_egg
+                and pokemon.ability.name == "Pickup"
+                and (held_item := pokemon.held_item) is not None
+                and held_item.name in pickup_item_names
+            ):
+                pokemon_with_picked_up_item.append(pokemon.index)
+
+        retrieved_items = yield from take_held_items_from_multiple_party_pokemon(
+            [
+                *result.party_indices_with_stolen_items,
+                *pokemon_with_picked_up_item,
+            ],
+            force_checking=len(result.party_indices_with_stolen_items) == 0,
+        )
+        plugin_picked_up_items(retrieved_items)
 
     @debug.track
     def rotate_lead_pokemon(self, new_lead_index: int, old_lead_index: int):

--- a/modules/modes/item_steal.py
+++ b/modules/modes/item_steal.py
@@ -34,6 +34,8 @@ class ItemStealMode(BotMode):
         self._controller.battle_strategy = ItemStealingBattleStrategy
 
     def on_battle_started(self, encounter: EncounterInfo | None) -> BattleAction | BattleStrategy | None:
+        if encounter and len(encounter.pokemon.species.held_items) == 0:
+            return BattleAction.RunAway
         return self._controller.on_battle_started(encounter)
 
     def on_battle_ended(self, outcome: BattleOutcome) -> None:

--- a/modules/modes/util/pokecenter_loop.py
+++ b/modules/modes/util/pokecenter_loop.py
@@ -4,7 +4,7 @@ from typing import Optional, Literal
 from modules.battle_strategies import BattleStrategy, DefaultBattleStrategy
 from modules.context import context
 from modules.debug import debug
-from modules.encounter import handle_encounter
+from modules.encounter import EncounterInfo, handle_encounter
 from modules.map import get_map_data_for_current_position, get_effective_encounter_rates_for_current_map
 from modules.map_data import MapFRLG, get_map_enum
 from modules.modes import BotModeError, BattleAction
@@ -27,7 +27,10 @@ class PokecenterLoopController:
         self._needs_healing = False
         self._leave_pokemon_center = False
 
-    def on_battle_started(self, encounter: "EncounterInfo | None") -> BattleAction | BattleStrategy:
+    def on_battle_started(self, encounter: "EncounterInfo | None") -> BattleAction | BattleStrategy | None:
+        if encounter is None:
+            return None
+
         action = handle_encounter(encounter, enable_auto_battle=True)
         return self.battle_strategy() if action is BattleAction.Fight else action
 

--- a/modules/plugin_interface.py
+++ b/modules/plugin_interface.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Iterable, Generator
 if TYPE_CHECKING:
     from modules.battle_state import BattleOutcome
     from modules.encounter import EncounterInfo
+    from modules.items import Item
     from modules.modes import BotMode, BotListener
     from modules.pokemon import Pokemon
     from modules.profiles import Profile
@@ -145,6 +146,22 @@ class BotPlugin:
                  And/or it can return a boolean, which if True indicates that the bot
                  should not switch to manual mode in any case (which is the default for
                  gift Pokémon and hatched eggs once a shiny/CCF match is found.)
+        """
+        pass
+
+    def on_picked_up_items(self, list_of_items: list["Item"]) -> Generator | None:
+        """
+        This is called after retrieving items from Pokémon with the ability Pickup
+        OR that have been stolen in a previous battle using Thief or Covet.
+
+        :param list_of_items: List of items that have been retrieved. The same item
+                              can appear multiple times in this list if there is
+                              more than one Pokémon with Pickup in the party, and
+                              they happened to have picked up the same item at the
+                              same time.
+        :return: This _may_ return a Generator (so you can use `yield` inside here), in
+                 which case the current bot mode is suspended and this generator function
+                 takes control.
         """
         pass
 

--- a/modules/plugins.py
+++ b/modules/plugins.py
@@ -10,6 +10,7 @@ from modules.runtime import get_base_path
 
 if TYPE_CHECKING:
     from modules.encounter import EncounterInfo
+    from modules.items import Item
     from modules.modes import BotMode, BotListener
     from modules.profiles import Profile
 
@@ -145,6 +146,13 @@ def plugin_egg_hatched(hatched_pokemon: "EncounterInfo") -> Generator[None, None
         elif result is True:
             do_not_switch_to_manual = True
     return do_not_switch_to_manual
+
+
+def plugin_picked_up_items(list_of_items: list["Item"]) -> Generator:
+    for plugin in plugins:
+        result = plugin.on_picked_up_items(list_of_items)
+        if isinstance(result, GeneratorType):
+            yield from result
 
 
 def plugin_whiteout() -> Generator:

--- a/modules/pokemon.py
+++ b/modules/pokemon.py
@@ -717,7 +717,8 @@ class Species:
     name: str
     types: list[Type]
     abilities: list[Ability]
-    held_items: list[HeldItem]
+    _held_items_rse: list[HeldItem]
+    _held_items_frlg: list[HeldItem]
     base_stats: StatsValues
     gender_ratio: int
     egg_cycles: int
@@ -733,6 +734,10 @@ class Species:
     evolutions: list[SpeciesEvolution]
     evolves_from: int | None
     family: list[int]
+
+    @property
+    def held_items(self) -> list[HeldItem]:
+        return self._held_items_rse if context.rom is not None and context.rom.is_rse else self._held_items_frlg
 
     def has_type(self, type_to_find: Type) -> bool:
         return any(t.index == type_to_find.index for t in self.types)
@@ -762,7 +767,8 @@ class Species:
             name=data["name"],
             types=list(map(get_type_by_name, data["types"])),
             abilities=list(map(get_ability_by_name, data["abilities"])),
-            held_items=list(map(lambda e: HeldItem(e[0], e[1]), data["held_items"])),
+            _held_items_rse=list(map(lambda e: HeldItem(e[0], e[1]), data["held_items_rse"])),
+            _held_items_frlg=list(map(lambda e: HeldItem(e[0], e[1]), data["held_items_frlg"])),
             base_stats=StatsValues.from_dict(data["base_stats"]),
             gender_ratio=data["gender_ratio"],
             egg_cycles=data["egg_cycles"],


### PR DESCRIPTION
### Description

This  introduces a result dataclass for `handle_battle()` that reports things that have changed in that battle, such as Pokémon having taking damage -- or Pokémon having obtained new items through Pickup, Thief, or Covet.

It then uses this result to automatically take any items that Pokémon have obtained using Thief or Covet.

Fixes #664

Also, I noticed that there is actually a difference in the game data between RSE and FRLG with regards to held item tables for different species. For example, Meowth may hold a Nugget on FRLG but not on RSE.

I've updated the species data file (and extract script) to reflect that.

Fixes #781

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
