### PR TITLE
Support tossing items from PC storage, optimise slot usage

### DIFF
--- a/modules/items.py
+++ b/modules/items.py
@@ -408,8 +408,9 @@ class ItemBag:
         space += (pocket_size - len(pocket)) * stack_size
         return quantity <= space
 
-    def pocket_for(self, item: Item) -> list[ItemSlot]:
-        match item.pocket:
+    def pocket_for(self, item: Item | ItemPocket) -> list[ItemSlot]:
+        pocket = item.pocket if isinstance(item, Item) else item
+        match pocket:
             case ItemPocket.Items:
                 return self.items
             case ItemPocket.KeyItems:
@@ -421,7 +422,7 @@ class ItemBag:
             case ItemPocket.Berries:
                 return self.berries
             case _:
-                raise RuntimeError(f"Invalid bag pocket: {str(item.pocket)}")
+                raise RuntimeError(f"Invalid bag pocket: {str(pocket)}")
 
     def quantity_of(self, item: Item) -> int:
         return sum(slot.quantity for slot in self.pocket_for(item) if slot.item == item)
@@ -432,6 +433,11 @@ class ItemBag:
             (slot_index for slot_index in range(len(pocket)) if pocket[slot_index].item == item),
             None,
         )
+
+    def lowest_quantity_slot_index_for(self, item: Item) -> int | None:
+        pocket = self.pocket_for(item)
+        slots = [(index, slot.quantity) for index, slot in enumerate(pocket) if slot.item is item]
+        return min(slots, key=lambda s: s[1])[0] if len(slots) > 0 else None
 
     @property
     def number_of_repels(self) -> int:
@@ -490,6 +496,10 @@ class ItemStorage:
             if slot.item.index == item.index:
                 return index
         return None
+
+    def lowest_quantity_slot_index_for(self, item: Item) -> int | None:
+        slots = [(index, slot.quantity) for index, slot in enumerate(self.items) if slot.item is item]
+        return min(slots, key=lambda s: s[1])[0] if len(slots) > 0 else None
 
     def quantity_of(self, item: Item) -> int:
         return sum(slot.quantity for slot in self.items if slot.item == item)

--- a/modules/menuing.py
+++ b/modules/menuing.py
@@ -3,7 +3,7 @@ from typing import Generator, Iterable
 
 from modules.context import context
 from modules.game_stats import get_game_stat, GameStat
-from modules.items import Item, get_item_bag
+from modules.items import Item, get_item_bag, ItemPocket
 from modules.memory import GameState, get_event_flag, get_game_state, read_symbol, unpack_uint16
 from modules.menu_parsers import (
     CursorOptionEmerald,
@@ -68,6 +68,20 @@ def scroll_to_item_in_bag(item: Item) -> Generator:
 
     :param item: Item to scroll to
     """
+    slot_index = get_item_bag().first_slot_index_for(item)
+    if slot_index is None:
+        raise RuntimeError(f"Could not find any {item.name}")
+    yield from scroll_to_item_slot(item.pocket, slot_index)
+
+
+def scroll_to_item_slot(pocket: ItemPocket, slot_index: int) -> Generator:
+    """
+    This will scroll inside the item bag menu to reach a certain slot in a certain
+    item bag pocket.
+
+    :param pocket: The pocket to open.
+    :param slot_index: The index number to scroll to in that pocket.
+    """
 
     def open_pocket_index() -> int:
         if context.rom.is_emerald:
@@ -89,6 +103,11 @@ def scroll_to_item_in_bag(item: Item) -> Generator:
             scroll_position = unpack_uint16(read_symbol("gBagMenuState", offset=14 + (bag_index * 2), size=2))
         return cursor_position + scroll_position
 
+    if len(get_item_bag().pocket_for(pocket)) <= slot_index:
+        raise RuntimeError(
+            f"There is no slot index {slot_index} in the '{pocket.name}' pocket. It only has {len(get_item_bag().pocket_for(pocket))} slots."
+        )
+
     # Wait for fade-in to finish (happens when the bag is opened, during which time inputs
     # are not yet active.)
     while (
@@ -98,7 +117,7 @@ def scroll_to_item_in_bag(item: Item) -> Generator:
         yield
 
     # Select the correct pocket
-    target_pocket_index = item.pocket.index
+    target_pocket_index = pocket.index
     while open_pocket_index() != target_pocket_index:
         if open_pocket_index() < target_pocket_index:
             context.emulator.press_button("Right")
@@ -108,9 +127,6 @@ def scroll_to_item_in_bag(item: Item) -> Generator:
             yield
 
     # Scroll to the item
-    slot_index = get_item_bag().first_slot_index_for(item)
-    if slot_index is None:
-        raise RuntimeError(f"Could not find any {item.name}")
     while currently_selected_slot() != slot_index:
         if currently_selected_slot() < slot_index:
             context.emulator.press_button("Down")

--- a/modules/modes/util/pc_interaction.py
+++ b/modules/modes/util/pc_interaction.py
@@ -7,7 +7,7 @@ from modules.debug import debug
 from modules.game import decode_string
 from modules.items import Item, get_item_storage, get_item_bag
 from modules.memory import get_game_state, get_game_state_symbol, read_symbol, GameState, unpack_uint32, unpack_uint16
-from modules.menuing import get_scroll_direction, is_fade_active, scroll_to_item_in_bag
+from modules.menuing import get_scroll_direction, is_fade_active, scroll_to_item_slot
 from modules.modes import BotModeError
 from modules.modes.util import (
     wait_until_task_is_active,
@@ -31,11 +31,13 @@ class PCStorageSection(Enum):
     MoveItems = auto()
     WithdrawItem = auto()
     DepositItem = auto()
+    TossItem = auto()
 
 
 class PCStorageActionType(Enum):
     Withdraw = auto()
     Deposit = auto()
+    Toss = auto()
     ReleaseFromParty = auto()
     ReleaseFromBox = auto()
 
@@ -80,6 +82,10 @@ class PCAction:
     @classmethod
     def deposit_item(cls, item: Item, quantity: int) -> "PCAction":
         return cls(PCStorageSection.DepositItem, PCStorageActionType.Deposit, item=item, quantity=quantity)
+
+    @classmethod
+    def toss_item(cls, item: Item, quantity: int) -> "PCAction":
+        return cls(PCStorageSection.TossItem, PCStorageActionType.Toss, item=item, quantity=quantity)
 
 
 @dataclass
@@ -575,7 +581,7 @@ def _do_withdraw_items_actions(actions: list[PCAction]) -> Generator:
 
         quantity_left = action.quantity
         while quantity_left > 0:
-            target_slot = get_item_storage().first_slot_index_for(action.item)
+            target_slot = get_item_storage().lowest_quantity_slot_index_for(action.item)
             while (current_slot := _get_item_storage_menu_cursor_position()) != target_slot:
                 context.emulator.press_button("Down" if current_slot < target_slot else "Up")
                 yield
@@ -628,10 +634,11 @@ def _do_deposit_items_actions(actions: list[PCAction]) -> Generator:
 
         quantity_left = action.quantity
         while quantity_left > 0:
-            yield from scroll_to_item_in_bag(action.item)
-            max_quantity = (
-                get_item_bag().pocket_for(action.item)[get_item_bag().first_slot_index_for(action.item)].quantity
-            )
+            # Deposit the stack with the smallest quantity first. That will not be the fastest
+            # way to do it, but it will optimise inventory slot usage.
+            smallest_stack_slot_index = get_item_bag().lowest_quantity_slot_index_for(action.item)
+            yield from scroll_to_item_slot(action.item.pocket, smallest_stack_slot_index)
+            max_quantity = get_item_bag().pocket_for(action.item)[smallest_stack_slot_index].quantity
             if max_quantity == 1:
                 yield
                 context.emulator.press_button("A")
@@ -667,6 +674,58 @@ def _do_deposit_items_actions(actions: list[PCAction]) -> Generator:
     yield from _back_to_item_storage_menu()
 
 
+def _do_toss_items_actions(actions: list[PCAction]) -> Generator:
+    yield from _open_item_storage_menu(2)
+    for action in actions:
+        if get_item_storage().quantity_of(action.item) < action.quantity:
+            raise BotModeError(
+                f"Cannot toss {action.quantity}× {action.item.name} because there are not enough in the PC ({get_item_storage().quantity_of(action.item)})."
+            )
+
+        quantity_left = action.quantity
+        while quantity_left > 0:
+            # Toss the stack with the smallest quantity first. That will not be the fastest
+            # way to do it, but it will optimise inventory slot usage.
+            target_slot = get_item_storage().lowest_quantity_slot_index_for(action.item)
+            while (current_slot := _get_item_storage_menu_cursor_position()) != target_slot:
+                context.emulator.press_button("Down" if current_slot < target_slot else "Up")
+                yield
+                yield
+                yield
+            max_quantity = get_item_storage().items[target_slot].quantity
+
+            if max_quantity == 1:
+                yield
+                context.emulator.press_button("A")
+                yield
+                yield
+                yield from wait_until_task_is_active(_get_item_withdraw_menu_task_name(), "A")
+                quantity_left -= 1
+            else:
+                quantity_to_select = min(max_quantity, quantity_left)
+                yield from wait_until_task_is_active(_get_select_item_withdraw_quantity_task_name(), "A")
+                reverse_scroll = quantity_to_select > max_quantity // 2
+                if reverse_scroll:
+                    context.emulator.press_button("Down")
+                    yield
+                    yield
+                while (current_quantity := _get_item_withdraw_quantity_cursor_position()) != quantity_to_select:
+                    if current_quantity <= quantity_to_select - 7:
+                        context.emulator.press_button("Right")
+                    elif current_quantity >= quantity_to_select + 7:
+                        context.emulator.press_button("Left")
+                    elif current_quantity < quantity_to_select:
+                        context.emulator.press_button("Up")
+                    elif current_quantity > quantity_to_select:
+                        context.emulator.press_button("Down")
+                    yield
+                    yield
+                yield from wait_until_task_is_active(_get_item_withdraw_menu_task_name(), "A")
+                quantity_left -= quantity_to_select
+
+    yield from _back_to_item_storage_menu()
+
+
 @debug.track
 def interact_with_pc(actions: list[PCAction]) -> Generator:
     targeted_tile = get_player_avatar().map_location_in_front
@@ -675,6 +734,9 @@ def interact_with_pc(actions: list[PCAction]) -> Generator:
 
     if not player_avatar_is_controllable():
         raise BotModeError("Player is not controllable. Cannot interact with PC.")
+
+    if context.rom.is_frlg and any([action.section is PCStorageSection.TossItem for action in actions]):
+        raise BotModeError("Tossing items from the PC is not supported in FR/LG.")
 
     yield from _open_pc_menu()
 
@@ -690,6 +752,10 @@ def interact_with_pc(actions: list[PCAction]) -> Generator:
     actions_for_withdraw_menu = [action for action in actions if action.section is PCStorageSection.WithdrawPokemon]
     if len(actions_for_withdraw_menu) > 0:
         yield from _do_withdraw_actions(actions_for_withdraw_menu)
+
+    actions_for_toss_items_menu = [action for action in actions if action.section is PCStorageSection.TossItem]
+    if len(actions_for_toss_items_menu) > 0:
+        yield from _do_toss_items_actions(actions_for_toss_items_menu)
 
     actions_for_deposit_items_menu = [action for action in actions if action.section is PCStorageSection.DepositItem]
     if len(actions_for_deposit_items_menu) > 0:


### PR DESCRIPTION
### Description

This updates the `interact_with_pc()` utility function to also support throwing away items in PC storage.

Tossing items from the item bag is not supported (yet?) because, well, I currently don't need it.

Also, this changes which slot gets selected for depositing/withdrawing/tossing items.

Until now, it would always just scroll to the first slot with a given item.

That's time-efficient, but it means there's a good chance that we end up with several incomplete item stacks and thus waste inventory space.

Now, it will always act on the slot with the lowest quantity first.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
