### PR TITLE
Overlay: Fix counter if number gets greater than 1,000

### DIFF
--- a/modules/web/static/stream-overlay/component/info-bubble.js
+++ b/modules/web/static/stream-overlay/component/info-bubble.js
@@ -148,7 +148,7 @@ export default class InfoBubble extends HTMLElement {
             return;
         }
 
-        let currentCounter = Number.parseInt(this.content.innerText);
+        let currentCounter = Number.parseInt(this.content.innerText.replaceAll(/\D/g, ""));
         if (isNaN(currentCounter) || this.content.innerText === "") {
             this.content.innerText = formatInteger(this.quantity);
             return;


### PR DESCRIPTION
### Description

The info bubble counter gets confused when the number reaches 1,000 (because of the thousands separator) and keeps doing the counting-up-from-zero animation in a loop.

This fixes that.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
