### PR TITLE
Overlay: Fix issues with encounter list and pre-load sprites

### DIFF
--- a/modules/web/static/stream-overlay/content/route-encounters.js
+++ b/modules/web/static/stream-overlay/content/route-encounters.js
@@ -9,7 +9,7 @@ import {
     overlaySprite,
     renderTableRow,
     small,
-    speciesSprite
+    speciesSprite, speciesSpritePath
 } from "../helper.js";
 
 const mapNameSpan = document.querySelector("#map-name");
@@ -17,6 +17,7 @@ const antiShinyCounter = document.querySelector("#anti-shiny-counter");
 const tbody = document.querySelector("#route-encounters tbody");
 const table = document.querySelector("#route-encounters table");
 const noEncountersMessage = document.querySelector("#no-encounters-on-this-route-message");
+const bufferedSpriteSpecies = new Set();
 
 const ALTERNATIVE_SPECIES = {
     "Ivysaur": ["Bulbasaur"],
@@ -214,7 +215,7 @@ const updateMapName = map => {
 
 const animateRouteEncounterSprite = (speciesName) => {
     for (const entry of cachedRouteEncountersList) {
-        if (entry.speciesName === speciesName && entry.spriteElement) {
+        if (entry.spriteElement?.species === speciesName) {
             entry.spriteElement.animate();
         }
     }
@@ -237,6 +238,12 @@ const getEncounterList = (state) => {
     ) {
         encounterList = [];
         regularEncounterList = [];
+    } else if (state.lastEncounter?.pokemon?.species?.name === "Rayquaza") {
+        // When hunting Rayquaza, we need to move between the top floor and 5F of Sky Pillar,
+        // but on 5F there are some more encounters. That leads to constant flickering of the
+        // encounter list. So instead, we only show Rayquaza in that case.
+        encounterList = state.mapEncounters.effective.land_encounters.filter(e => e.species_name === "Rayquaza");
+        regularEncounterList = encounterList;
     } else if (state.lastEncounterType === "surfing" || state.map.map.name.toLowerCase().includes("underwater")) {
         encounterList = [...state.mapEncounters.effective.surf_encounters];
         regularEncounterList = [...state.mapEncounters.regular.surf_encounters];
@@ -348,9 +355,33 @@ let cachedRouteEncountersList = [];
 let cachedAntiShinyCount = 0;
 
 /**
+ * @param {string} speciesName
+ */
+const bufferSprites = (speciesName) => {
+    const bufferSingleSprite = (path) => {
+        const link = document.createElement("link");
+        link.rel = "preload";
+        link.href = path;
+        link.as = "image";
+        document.head.append(link);
+    };
+
+    bufferSingleSprite(speciesSpritePath(speciesName, "normal"));
+    bufferSingleSprite(speciesSpritePath(speciesName, "anti-shiny"));
+    bufferSingleSprite(speciesSpritePath(speciesName, "shiny"));
+    bufferSingleSprite(speciesSpritePath(speciesName, "normal", true));
+    bufferSingleSprite(speciesSpritePath(speciesName, "anti-shiny", true));
+    bufferSingleSprite(speciesSpritePath(speciesName, "shiny", true));
+    bufferSingleSprite(speciesSpritePath(speciesName, "normal-cropped"));
+    bufferSingleSprite(speciesSpritePath(speciesName, "shiny-cropped"));
+};
+
+/**
  * @param {RouteEncounterEntry[]} encountersList
  */
 const renderRouteEncountersList = (encountersList) => {
+    encountersList.forEach(encounter => bufferSprites(encounter.speciesName));
+
     const renderEncounterRate = (rate) => {
         if (rate === 0) {
             return [""];
@@ -454,8 +485,8 @@ const renderRouteEncountersList = (encountersList) => {
         const cached = cachedRouteEncountersList[index];
         const row = cached.element;
 
-        if (entry.speciesName !== cached.speciesName || entry.isAnti !== cached.isAnti) {
-            cached.spriteElement.remove();
+        if (entry.speciesName !== cached.spriteElement?.species || entry.isAnti !== cached.spriteElement?.antiShiny) {
+            cached.spriteElement?.remove();
             cached.spriteElement = speciesSprite(entry.speciesName, entry.isAnti ? "anti-shiny" : "normal");
             row.children[0].textContent = "";
             row.children[0].append(cached.spriteElement);

--- a/modules/web/static/stream-overlay/layout/section-checklist.css
+++ b/modules/web/static/stream-overlay/layout/section-checklist.css
@@ -49,6 +49,10 @@
                 transform: scale(.9);
             }
 
+            > pokemon-sprite[species="Chinchou"] img {
+                margin-left: -.9vh;
+            }
+
             > span {
                 display: block;
                 font-size: .75rem;

--- a/modules/web/static/stream-overlay/overlay.js
+++ b/modules/web/static/stream-overlay/overlay.js
@@ -90,7 +90,6 @@ async function doFullUpdate(state, retryOnError = true) {
 
             updateMapName(state.map);
             updateRouteEncountersList(state, config.sectionChecklist);
-            animateRouteEncounterSprite(getLastEncounterSpecies(state.encounterLog));
             updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
             updateShinyLog(state.shinyLog);
             updateEncounterLog(state.encounterLog);
@@ -128,7 +127,6 @@ async function doUpdateAfterEncounter(state) {
         updateShinyLog(state.shinyLog);
         updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
         updateRouteEncountersList(state, config.sectionChecklist);
-        animateRouteEncounterSprite(getLastEncounterSpecies(state.encounterLog));
         updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
         updatePhaseStats(state.stats);
         updateTotalStats(state.stats, state.encounterRate);
@@ -215,7 +213,6 @@ function handleBotMode(event, state) {
     if (previousModeWasDaycare !== newModeIsDaycare) {
         updateDaycareBox(event, state);
         updateRouteEncountersList(state, config.sectionChecklist);
-        animateRouteEncounterSprite(getLastEncounterSpecies(state.encounterLog));
         updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
     }
 }
@@ -290,7 +287,6 @@ function handleMapChange(event, state) {
 function handleMapEncounters(event, state) {
     state.mapEncounters = event;
     updateRouteEncountersList(state, config.sectionChecklist);
-    animateRouteEncounterSprite(getLastEncounterSpecies(state.encounterLog));
     updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
 }
 
@@ -301,7 +297,6 @@ function handleMapEncounters(event, state) {
 function handlePlayerAvatar(event, state) {
     if (state.logPlayerAvatarChange(event)) {
         updateRouteEncountersList(state, config.sectionChecklist);
-        animateRouteEncounterSprite(getLastEncounterSpecies(state.encounterLog));
         updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
     }
 }
@@ -382,12 +377,10 @@ function handleCustomEvent(event, state) {
                     state.daycare = data;
                     updateDaycareBox(state.emulator.bot_mode, state);
                     updateRouteEncountersList(state, config.sectionChecklist);
-                    animateRouteEncounterSprite(getLastEncounterSpecies(state.encounterLog));
                 });
             } else {
                 updateDaycareBox(state.emulator.bot_mode, state);
                 updateRouteEncountersList(state, config.sectionChecklist);
-                animateRouteEncounterSprite(getLastEncounterSpecies(state.encounterLog));
                 updateSectionChecklist(config.sectionChecklist, state.stats, state.mapEncounters, state.additionalRouteSpecies, state.lastEncounterType);
             }
             break;

--- a/modules/web/static/stream-overlay/state.js
+++ b/modules/web/static/stream-overlay/state.js
@@ -371,7 +371,7 @@ export default class OverlayState {
 
     /** @param {StreamEvents.MapChange} map */
     logNewMap(map) {
-        this.map = map.map;
+        this.map = map;
         this.additionalRouteSpecies.clear();
         if (this.lastEncounter && ["hatched", "gift", "static"].includes(this.lastEncounter.type) && !this.additionalRouteSpecies.has(this.lastEncounter.pokemon.species_name_for_stats)) {
             this.additionalRouteSpecies.add(this.lastEncounter.pokemon.species_name_for_stats);


### PR DESCRIPTION
### Description

This fixes a few display bugs.

It also adds code that will pre-load all sprite variants of encounters on any given route. This should fix the issue where the sprite in the recent encounters list did not yet load when the Discord screenshot is taken.

### Checklist

<!-- Pre-merge checks that should be completed -->

- [x] [Black Linter](https://github.com/psf/black) has been ran, using `--line-length 120` argument
- [x] Wiki has been updated (if relevant)

<!-- Any further information can be added below here such as images/videos -->
